### PR TITLE
#PAR-84 : Authentication 프로세스 변경

### DIFF
--- a/app/src/main/java/online/partyrun/partyrunapplication/AuthActivity.kt
+++ b/app/src/main/java/online/partyrun/partyrunapplication/AuthActivity.kt
@@ -18,7 +18,6 @@ import online.partyrun.partyrunapplication.core.navigation.auth.AuthNavRoutes
 import online.partyrun.partyrunapplication.core.navigation.auth.signInRoute
 import online.partyrun.partyrunapplication.core.navigation.auth.splashRoute
 import online.partyrun.partyrunapplication.core.network.GoogleAuthUiClient
-import timber.log.Timber
 import javax.inject.Inject
 
 @AndroidEntryPoint

--- a/app/src/main/java/online/partyrun/partyrunapplication/MainActivity.kt
+++ b/app/src/main/java/online/partyrun/partyrunapplication/MainActivity.kt
@@ -5,23 +5,19 @@ import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.lifecycle.lifecycleScope
-import com.google.android.gms.auth.api.identity.Identity
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import online.partyrun.partyrunapplication.ui.PartyRunMain
 import online.partyrun.partyrunapplication.core.common.extension.setIntentActivity
 import online.partyrun.partyrunapplication.core.designsystem.theme.PartyRunApplicationTheme
 import online.partyrun.partyrunapplication.core.network.GoogleAuthUiClient
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
-    private val googleAuthUiClient by lazy {
-        GoogleAuthUiClient(
-            context = applicationContext,
-            oneTapClient = Identity.getSignInClient(applicationContext)
-        )
-    }
+    @Inject
+    lateinit var googleAuthUiClient: GoogleAuthUiClient
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/online/partyrun/partyrunapplication/di/DefaultTokenExpirationNotifier.kt
+++ b/app/src/main/java/online/partyrun/partyrunapplication/di/DefaultTokenExpirationNotifier.kt
@@ -1,0 +1,23 @@
+package online.partyrun.partyrunapplication.di
+
+import android.content.Context
+import android.content.Intent
+import online.partyrun.partyrunapplication.AuthActivity
+import online.partyrun.partyrunapplication.core.common.extension.setIntentActivity
+import online.partyrun.partyrunapplication.core.common.network.TokenExpirationNotifier
+import timber.log.Timber
+
+class DefaultTokenExpirationNotifier(
+    private val context: Context
+): TokenExpirationNotifier {
+    override fun onTokenExpired() {
+        Timber.tag("TokenExpirationNotifier").e("refresh token Expired")
+        /* 로그아웃 한 경우 Splash 생략을 위한 Intent Extension Bundle String 제공*/
+        context.setIntentActivity(
+            AuthActivity::class.java,
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        ) {
+            putString("fromMain", "sign_in")
+        }
+    }
+}

--- a/app/src/main/java/online/partyrun/partyrunapplication/di/TokenExpirationModule.kt
+++ b/app/src/main/java/online/partyrun/partyrunapplication/di/TokenExpirationModule.kt
@@ -1,0 +1,22 @@
+package online.partyrun.partyrunapplication.di
+
+import android.content.Context
+import androidx.appcompat.app.AppCompatActivity
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import online.partyrun.partyrunapplication.core.common.network.TokenExpirationNotifier
+
+@Module
+@InstallIn(SingletonComponent::class)
+object TokenExpirationModule {
+
+    @Provides
+    fun provideTokenExpirationNotifier(
+        @ApplicationContext context: Context
+    ): TokenExpirationNotifier =
+        DefaultTokenExpirationNotifier(context)
+}

--- a/core/common/src/main/java/online/partyrun/partyrunapplication/core/common/network/TokenExpirationNotifier.kt
+++ b/core/common/src/main/java/online/partyrun/partyrunapplication/core/common/network/TokenExpirationNotifier.kt
@@ -1,0 +1,5 @@
+package online.partyrun.partyrunapplication.core.common.network
+
+interface TokenExpirationNotifier{
+    fun onTokenExpired()
+}

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/AuthAuthenticator.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/AuthAuthenticator.kt
@@ -1,7 +1,6 @@
 package online.partyrun.partyrunapplication.core.network
 
 import android.content.Context
-import android.content.Intent
 import com.google.android.gms.auth.api.identity.Identity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
@@ -9,9 +8,8 @@ import kotlinx.coroutines.runBlocking
 import okhttp3.*
 import okhttp3.logging.HttpLoggingInterceptor
 import online.partyrun.partyrunapplication.core.model.SignInTokenResponse
-//import online.partyrun.partyrunapplication.app.AuthActivity
 import online.partyrun.partyrunapplication.core.common.Constants.BASE_URL
-import online.partyrun.partyrunapplication.core.common.extension.setIntentActivity
+import online.partyrun.partyrunapplication.core.common.network.TokenExpirationNotifier
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import timber.log.Timber
@@ -25,7 +23,8 @@ import javax.inject.Singleton
 @Singleton
 class AuthAuthenticator @Inject constructor(
     private val tokenManager: TokenManager,
-    private val context: Context
+    private val context: Context,
+    private val tokenExpirationNotifier: TokenExpirationNotifier
 ): Authenticator {
 
     private val googleAuthUiClient by lazy {
@@ -47,21 +46,17 @@ class AuthAuthenticator @Inject constructor(
             if (!newAccessToken.isSuccessful || newAccessToken.body() == null) {
                 googleAuthUiClient.signOutGoogleAuth() // Google 로그아웃
                 tokenManager.deleteAccessToken()
-                /*
-                context.setIntentActivity(
-                    AuthActivity::class.java,
-                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-                ) {
-                    putString("fromMain", "sign_in")
+                // Token 만료 알림 -> 이벤트 브로드캐스팅
+                tokenExpirationNotifier.onTokenExpired()
+                return@runBlocking null
+            }else {
+                /* 정상적으로 Access Token을 받아온 경우 */
+                newAccessToken.body()?.let {
+                    tokenManager.saveAccessToken(it.accessToken)
+                    response.request.newBuilder()
+                        .header("Authorization", "Bearer ${it.accessToken}")
+                        .build()
                 }
-                */
-            }
-            /* 정상적으로 Access Token을 받아온 경우 */
-            newAccessToken.body()?.let {
-                tokenManager.saveAccessToken(it.accessToken)
-                response.request.newBuilder()
-                    .header("Authorization", "Bearer ${it.accessToken}")
-                    .build()
             }
         }
     }

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/AuthAuthenticator.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/AuthAuthenticator.kt
@@ -56,7 +56,7 @@ class AuthAuthenticator @Inject constructor(
                     tokenManager.saveAccessToken(it.accessToken)
                     tokenManager.saveRefreshToken(it.refreshToken)
                     response.request.newBuilder()
-                        .header("Authorization", "Bearer ${it.accessToken}")
+                        .header("Authorization", it.accessToken)
                         .build()
                 }
             }
@@ -79,6 +79,6 @@ class AuthAuthenticator @Inject constructor(
             .build()
 
         val service = retrofit.create(SignInApiService::class.java)
-        return service.replaceToken("Bearer $refreshToken")
+        return service.replaceToken("$refreshToken")
     }
 }

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/AuthInterceptor.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/AuthInterceptor.kt
@@ -25,7 +25,7 @@ class AuthInterceptor @Inject constructor(
         Timber.tag("AuthInterceptor").e("$accessToken")
         val originalRequest = chain.request()
         val requestBuilder = originalRequest.newBuilder() //  현재 request에 대한 빌더 생성
-        requestBuilder.addHeader("Authorization", "Bearer $accessToken") // 빌더에 Authorization 헤더 추가해 토큰 포함
+        requestBuilder.addHeader("Authorization", "$accessToken") // 빌더에 Authorization 헤더 추가해 토큰 포함
         val request = requestBuilder.build()
         return chain.proceed(request) // 변경된 request를 다음 인터셉터로 전달, response 반환
     }

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/di/NetworkModule.kt
@@ -14,6 +14,7 @@ import dagger.hilt.components.SingletonComponent
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import online.partyrun.partyrunapplication.core.common.Constants.BASE_URL
+import online.partyrun.partyrunapplication.core.common.network.TokenExpirationNotifier
 import online.partyrun.partyrunapplication.core.network.AuthAuthenticator
 import online.partyrun.partyrunapplication.core.network.AuthInterceptor
 import online.partyrun.partyrunapplication.core.network.GoogleAuthUiClient
@@ -42,9 +43,10 @@ object ConfigModule {
     @Provides
     fun provideAuthAuthenticator(
         tokenManager: TokenManager,
-        @ApplicationContext context: Context
+        @ApplicationContext context: Context,
+        tokenExpirationNotifier: TokenExpirationNotifier
     ): AuthAuthenticator =
-        AuthAuthenticator(tokenManager, context)
+        AuthAuthenticator(tokenManager, context, tokenExpirationNotifier)
 
     /* SignInClient 인스턴스 생성 */
     @Provides


### PR DESCRIPTION
### 설명

자주 서비스를 이용하는 유저에게는 지속적으로 로그인 상태를 유지시켜줘야 한다.

오랜만에 로그인한 유저는 Token이 만료됐으므로 재로그인하는 과정을 거쳐야 한다.



### 구현
![image](https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/89e1d306-da59-4990-b967-874d97cc29be)

Access Token 만료 → 새로운 Access Token을 발급 받을 경우, Refresh Token이 유효하다면

Access Token과 Refresh Token을 둘 다 Update


![image](https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/f5a8602a-29e8-40eb-b377-bc618f719a4f)

만약, Refresh Token이 유효하지 않다면,

구글 로그아웃을 진행한 후

tokenExpireationNofier를 통해 재로그인을 하도록 로그인 창으로 전환 진행



### 완료
백엔드에서 Refresh Token 재발급. 현재 14일

테스트 케이스: 로그인 후 14일 두었을 때 로그인 화면으로 가지 않아야 함.