### PR TITLE
#PAR-126 : PreLoad를 위한 Builder 위치 변경

### DIFF
--- a/feature/battle/build.gradle.kts
+++ b/feature/battle/build.gradle.kts
@@ -15,5 +15,7 @@ dependencies {
     implementation(libs.okhttp.sse)
     implementation("com.google.code.gson:gson:2.10.1")
 
+    implementation(libs.exo.player)
+
     implementation(project(":feature:match"))
 }

--- a/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/ui/MatchWaitingDialog.kt
+++ b/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/ui/MatchWaitingDialog.kt
@@ -108,10 +108,10 @@ fun MatchWaitingDialog(
                             factory = { it.buildPlayerView(exoPlayer) },
                             modifier = Modifier
                                 .fillMaxSize()
-                                .alpha(if (visible.value) 1f else 0f)
+                                .alpha(if (visible.value) 1f else 0.2f)
                         ) {
                             scope.launch {
-                                delay(100L)
+                                delay(500L)
                                 visible.value = true
                             }
                         }


### PR DESCRIPTION
## Description

클라이언트에서 매칭잡기를 시작해 다이얼로그를 띄울 때, ExoPlayer와 PlayerView(buildExoPlayer, buildPlayerView)를 빌드하는 과정에서 생기는 검은색 화면을 최소화해야 한다.

미리 빌드해놓고 필요할 때 띄워주는 방식으로 구현하는 로직은 구현해놨지만, 두 build 메소드를 호출하는 위치가 잘못되어 항상 처음부터 ExoPlayer를 build를 진행하는 문제 발생.

## Implementation

buildExoPlayer는 Battle에 관한 메인 Screen Composable이 만들어질 때 호출이 되고,

다이얼로그를 띄울 때 buildPlayerView를 함으로써 별도의 ExoPlayer의 빌드 과정이 없이도 Player를 보여주도록 한다.