### PR TITLE
#PAR-134 : SSE 프로세스가 끝난 뒤 다음 REST를 수행하도록 보장

### DIFF
--- a/core/common/src/main/java/online/partyrun/partyrunapplication/core/common/network/MatchSourceManager.kt
+++ b/core/common/src/main/java/online/partyrun/partyrunapplication/core/common/network/MatchSourceManager.kt
@@ -4,7 +4,7 @@ import okhttp3.sse.EventSource
 import okhttp3.sse.EventSourceListener
 
 interface MatchSourceManager {
-    fun getMatchEventSourceListener(onEvent: (data: String) -> Unit): EventSourceListener
+    fun getMatchEventSourceListener(onEvent: (data: String) -> Unit, onClosed: () -> Unit): EventSourceListener
     fun connectMatchEventSource(eventSource: EventSource)
     fun connectMatchResultEventSource(eventSource: EventSource)
     fun closeMatchEventSource()

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/match/WaitingEventResult.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/match/WaitingEventResult.kt
@@ -2,9 +2,14 @@ package online.partyrun.partyrunapplication.core.model.match
 
 import com.google.gson.annotations.SerializedName
 
+enum class WaitingMatchStatus {
+    CONNECT,
+    MATCHED,
+    TIMEOUT
+}
 data class WaitingEventResult(
-    @SerializedName("isSuccess")
-    val isSuccess: Boolean = false,
+    @SerializedName("status")
+    val status: WaitingMatchStatus = WaitingMatchStatus.CONNECT,
     @SerializedName("message")
     val message: String = ""
 )

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/MatchSourceManagerImpl.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/MatchSourceManagerImpl.kt
@@ -12,9 +12,10 @@ class MatchSourceManagerImpl: MatchSourceManager {
     private lateinit var connectMatchResultSource: EventSource
 
     override fun getMatchEventSourceListener(
-        onEvent: (data: String) -> Unit
+        onEvent: (data: String) -> Unit,
+        onClosed: () -> Unit
     ): EventSourceListener {
-        return createEventListener(onEvent)
+        return createEventListener(onEvent, onClosed)
     }
 
     override fun connectMatchEventSource(eventSource: EventSource) {
@@ -34,7 +35,8 @@ class MatchSourceManagerImpl: MatchSourceManager {
     }
 
     private fun createEventListener(
-        onEvent: (data: String) -> Unit
+        onEvent: (data: String) -> Unit,
+        onClosed: () -> Unit
     ): EventSourceListener {
         return object : EventSourceListener() {
             override fun onOpen(eventSource: EventSource, response: Response) {
@@ -43,6 +45,7 @@ class MatchSourceManagerImpl: MatchSourceManager {
 
             override fun onClosed(eventSource: EventSource) {
                 Timber.tag("Event").d("Connection closed")
+                onClosed()
             }
 
             override fun onEvent(

--- a/feature/battle/src/main/java/online/partyrun/partyrunapplication/feature/battle/BattleMainScreen.kt
+++ b/feature/battle/src/main/java/online/partyrun/partyrunapplication/feature/battle/BattleMainScreen.kt
@@ -110,7 +110,7 @@ fun Content(
             }
         )
         Text(
-            text = "연결 여부: ${matchUiState.waitingEventState.isSuccess}"
+            text = "연결 여부: ${matchUiState.waitingEventState.status}"
         )
         Text(
             text = "메세지: ${matchUiState.waitingEventState.message}"
@@ -179,7 +179,7 @@ fun MatchContent(
 
 
 private fun getVideoUri(): Uri {
-    val videoUri = "https://cdn.pixabay.com/vimeo/462182247/trning-50884.mp4?width=3840&hash=b62785592f7d9ca46a0af26e9883996278ac2483"
+    val videoUri = "https://storage.googleapis.com/gtv-videos-bucket/sample/ForBiggerBlazes.mp4"
     return Uri.parse(videoUri)
 }
 

--- a/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/MatchDialogScreen.kt
+++ b/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/MatchDialogScreen.kt
@@ -43,13 +43,6 @@ fun MatchDialog(
 ) {
     val matchState by matchViewModel.matchUiState.collectAsStateWithLifecycle()
 
-    LaunchedEffect(Unit) {
-        while (true) {
-            delay(6000L)
-            matchViewModel.cycleMatchProgressType() // ViewModel에 정의된 상태 업데이트 함수
-        }
-    }
-
     when (matchState.matchProgress.name) {
         MatchProgress.WAITING.name ->
             MatchWaitingDialog(
@@ -128,4 +121,3 @@ fun Context.buildPlayerView(exoPlayer: ExoPlayer) =
         resizeMode = RESIZE_MODE_ZOOM
         setBackgroundColor(Color.Transparent.hashCode()) // 배경을 투명하게 설정
     }
-

--- a/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/MatchUiState.kt
+++ b/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/MatchUiState.kt
@@ -1,11 +1,12 @@
 package online.partyrun.partyrunapplication.feature.match
 
+import online.partyrun.partyrunapplication.core.model.match.WaitingMatchStatus
+
 enum class MatchProgress {
     WAITING,
     DECISION,
     RESULT,
 }
-
 enum class MatchResultStatus {
     WAIT,
     SUCCESS,
@@ -31,7 +32,7 @@ data class WaitingRestState(
     val message: String = ""
 )
 data class WaitingEventState(
-    val isSuccess: Boolean = false,
+    val status: WaitingMatchStatus = WaitingMatchStatus.CONNECT,
     val message: String = "",
 )
 

--- a/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/ui/MatchWaitingDialog.kt
+++ b/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/ui/MatchWaitingDialog.kt
@@ -118,7 +118,7 @@ fun MatchWaitingDialog(
                     }
                 }
                 Column(modifier = Modifier.fillMaxWidth()) {
-                    Text(text = "연결 여부: ${matchUiState.waitingEventState.isSuccess}")
+                    Text(text = "연결 여부: ${matchUiState.waitingEventState.status}")
                     Text(text = "메세지: ${matchUiState.waitingEventState.message}")
                 }
                 Column(


### PR DESCRIPTION
## Description
매칭 과정 프로세스는 다음과 같다.
REST -> SSE -> REST -> SSE -> REST
이 중 SSE 프로세스가 끝나고 난 뒤 REST 메소드를 수행해야 하는데, SSE 프로세스가 진행 중임에도 다음 REST로 넘어가는 이슈 발생

![image](https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/ca5fd6ea-48f7-40a3-aec3-4cd8c9aaed9f)

## Implement
CompletableDeferred를 통해 SSE 프로세스 동작 과정 추적

![image](https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/b5591bd2-be42-4939-ac50-451b248c02a4)

