### PR TITLE
#PAR-154 : Navigation 모듈에서 feature별로 NavGraphBuilder 관리

### DIFF
--- a/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/battle/BattleNavigation.kt
+++ b/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/battle/BattleNavigation.kt
@@ -1,0 +1,15 @@
+package online.partyrun.partyrunapplication.core.navigation.battle
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import online.partyrun.partyrunapplication.core.navigation.main.MainNavRoutes
+import online.partyrun.partyrunapplication.feature.battle.BattleMainScreen
+
+fun NavGraphBuilder.battleRoute(
+    navigateToSingle: () -> Unit,
+    navigateToSingleWithArgs: (String) -> Unit
+) {
+    composable(route = MainNavRoutes.Battle.route) {
+        BattleMainScreen()
+    }
+}

--- a/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/challenge/ChallengeNavigation.kt
+++ b/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/challenge/ChallengeNavigation.kt
@@ -1,0 +1,16 @@
+package online.partyrun.partyrunapplication.core.navigation.challenge
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import online.partyrun.partyrunapplication.core.navigation.main.MainNavRoutes
+import online.partyrun.partyrunapplication.feature.challenge.ChallengeScreen
+
+fun NavGraphBuilder.challengeRoute(
+    onSignOut: () -> Unit
+) {
+    composable(route = MainNavRoutes.Challenge.route) {
+        ChallengeScreen(
+            onSignOut = onSignOut
+        )
+    }
+}

--- a/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/main/MainNavGraph.kt
+++ b/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/main/MainNavGraph.kt
@@ -6,17 +6,13 @@ import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
-import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
-import androidx.navigation.navArgument
-import online.partyrun.partyrunapplication.feature.battle.BattleMainScreen
-import online.partyrun.partyrunapplication.feature.single.SingleScreen
-import online.partyrun.partyrunapplication.feature.challenge.ChallengeScreen
-import online.partyrun.partyrunapplication.feature.my_page.MyPageScreen
+import online.partyrun.partyrunapplication.core.navigation.battle.battleRoute
+import online.partyrun.partyrunapplication.core.navigation.challenge.challengeRoute
+import online.partyrun.partyrunapplication.core.navigation.my_page.myPageRoute
+import online.partyrun.partyrunapplication.core.navigation.single.singleRoute
 
 @Composable
 fun SetUpMainNavGraph(
@@ -51,55 +47,6 @@ fun SetUpMainNavGraph(
             onSignOut = onSignOut
         )
         myPageRoute()
-    }
-}
-
-/**
- *그래프의 크기가 커질수록 관리가 필요함 ->
- * 그래프를 여러 메서드로 분할할 수 있도록 Navigation Builder 구축
- */
-fun NavGraphBuilder.battleRoute(
-    navigateToSingle: () -> Unit,
-    navigateToSingleWithArgs: (String) -> Unit
-) {
-    composable(route = MainNavRoutes.Battle.route) {
-        BattleMainScreen()
-    }
-}
-
-fun NavGraphBuilder.singleRoute(
-    navigateToMyPage: () -> Unit,
-) {
-    /**
-     * 선택적 매개변수는 URL이 "/arg1=$value1/arg2=$value2" 형식이 아닌
-     * "?arg1=$value1&arg2=$value2" 형식을 사용하는 경우에만 작동
-     */
-    composable(
-        route = "${MainNavRoutes.Single.route}?userName={userName}",
-        arguments = listOf(navArgument("userName") {
-            type = NavType.StringType
-            defaultValue = ""
-        })
-    ) { backStackEntry ->
-        SingleScreen(
-            userName = backStackEntry.arguments?.getString("userName")
-        )
-    }
-}
-
-fun NavGraphBuilder.challengeRoute(
-    onSignOut: () -> Unit
-) {
-    composable(route = MainNavRoutes.Challenge.route) {
-        ChallengeScreen(
-            onSignOut = onSignOut
-        )
-    }
-}
-
-fun NavGraphBuilder.myPageRoute() {
-    composable(route = MainNavRoutes.MyPage.route) {
-        MyPageScreen()
     }
 }
 

--- a/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/my_page/MyPageNavigation.kt
+++ b/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/my_page/MyPageNavigation.kt
@@ -1,0 +1,12 @@
+package online.partyrun.partyrunapplication.core.navigation.my_page
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import online.partyrun.partyrunapplication.core.navigation.main.MainNavRoutes
+import online.partyrun.partyrunapplication.feature.my_page.MyPageScreen
+
+fun NavGraphBuilder.myPageRoute() {
+    composable(route = MainNavRoutes.MyPage.route) {
+        MyPageScreen()
+    }
+}

--- a/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/single/SingleNavigation.kt
+++ b/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/single/SingleNavigation.kt
@@ -1,0 +1,28 @@
+package online.partyrun.partyrunapplication.core.navigation.single
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavType
+import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+import online.partyrun.partyrunapplication.core.navigation.main.MainNavRoutes
+import online.partyrun.partyrunapplication.feature.single.SingleScreen
+
+fun NavGraphBuilder.singleRoute(
+    navigateToMyPage: () -> Unit,
+) {
+    /**
+     * 선택적 매개변수는 URL이 "/arg1=$value1/arg2=$value2" 형식이 아닌
+     * "?arg1=$value1&arg2=$value2" 형식을 사용하는 경우에만 작동
+     */
+    composable(
+        route = "${MainNavRoutes.Single.route}?userName={userName}",
+        arguments = listOf(navArgument("userName") {
+            type = NavType.StringType
+            defaultValue = ""
+        })
+    ) { backStackEntry ->
+        SingleScreen(
+            userName = backStackEntry.arguments?.getString("userName")
+        )
+    }
+}


### PR DESCRIPTION
## Description
기존 Navigation 모듈에서 MainNavGraph 하나로 모든 feature별 네비게이션을 담당하게 했었음.
코드 수가 증가할 것을 고려해 feature모듈별 Navivation 분리해서 관리하기로 변경 

NavGraphBuilder 사용하는 이유 :
그래프의 크기가 커질수록 관리가 필요함 -> 그래프를 여러 메서드로 분할할 수 있도록 Navigation Builder구축


## Implementation
각 feature 별로 디렉토리를 생성해 Navigation Builder 생성