### PR TITLE
 #PAR-157 : 매칭 과정을 총괄하는 코루틴 메소드를 종료시키기 위한 커스텀 예외 클래스 생성

### DIFF
--- a/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/MatchViewModel.kt
+++ b/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/MatchViewModel.kt
@@ -24,6 +24,7 @@ import online.partyrun.partyrunapplication.core.model.match.MatchResultEventResu
 import online.partyrun.partyrunapplication.core.model.match.UserSelectedMatchDistance
 import online.partyrun.partyrunapplication.core.model.match.WaitingEventResult
 import online.partyrun.partyrunapplication.core.model.match.WaitingMatchStatus
+import online.partyrun.partyrunapplication.feature.match.exception.MatchingProcessException
 import timber.log.Timber
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -76,7 +77,7 @@ class MatchViewModel @Inject constructor(
             handleUserMatchDecision()
             connectMatchResultEventSource()
             verifyMatchSuccess()
-        } catch(e: Exception) {
+        } catch(e: MatchingProcessException) {
             /* 예외 발생 시 배틀 매칭 과정을 종료하고 상태 초기화 과정 수행 */
             Timber.tag("MatchViewModel").e(e, "매칭 거절")
             closeMatchDialog()
@@ -109,7 +110,7 @@ class MatchViewModel @Inject constructor(
     }
 
     private fun cancelBattleMatchingProcess(): Nothing {
-        throw RuntimeException("Closing match dialog and End of the matching coroutine process")
+        throw MatchingProcessException("Closing match dialog and End of the matching coroutine process")
     }
 
     /* REST */

--- a/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/exception/MatchingProcessException.kt
+++ b/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/exception/MatchingProcessException.kt
@@ -1,0 +1,3 @@
+package online.partyrun.partyrunapplication.feature.match.exception
+
+class MatchingProcessException(message: String) : RuntimeException(message)


### PR DESCRIPTION
## Description
매칭 과정은 하나의 코루틴 메소드안에서 여러 세부적인 메소드들이 순차적으로 수행되어야 한다.
그러나 매칭 과정 중 예외가 발생하거나 혹은 사용자가 중간에 매칭을 취소하는 등의 상황이 발생할 경우,
이 매칭 프로세스를 총괄하는 코루틴 메소드 자체에 대한 판단을 설정할 수 있어야 한다.
메소드를 종료시킬 것이라면 예외를 던져 처리하는 것이 가장 쉽게 처리할 수 있을 것이라 판단.

## Implementation
MatchingProcessException 커스텀 예외 클래스 생성
예외를 던지면 코루틴의 실행이 즉시 중단되고, 해당 예외를 catch하는 부분으로 제어가 이동하기에 이를 통해 코루틴 메소드를 종료하거나 예외 처리를 수행하도록 변경