### PR TITLE
#PAR-163 : 배틀 프로세스 단계에 따른 유동적인 UI 변경과 onEach 블록 활용

### DIFF
--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentScreen.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentScreen.kt
@@ -21,7 +21,6 @@ fun BattleContentScreen(
     runnerIds: RunnerIds,
     viewModel: BattleContentViewModel = hiltViewModel()
 ) {
-    val battleScreenState by viewModel.battleScreenState.collectAsState()
     val battleUiState by viewModel.battleUiState.collectAsState()
 
     LaunchedEffect(battleId) {
@@ -35,19 +34,18 @@ fun BattleContentScreen(
 
     CheckStartTime(battleUiState, battleId, viewModel, runnerIds)
 
-    Content(battleScreenState, battleUiState)
+    Content(battleUiState)
 }
 
 @Composable
 fun Content(
-    battleScreenState: BattleScreenState,
     battleUiState: BattleUiState
 ) {
     Column(
         modifier = Modifier
             .fillMaxSize()
     ) {
-        when (battleScreenState) {
+        when (battleUiState.screenState) {
             is BattleScreenState.Ready -> BattleReadyScreen(isConnecting = battleUiState.isConnecting)
             is BattleScreenState.Running -> BattleRunningScreen(battleState = battleUiState.battleState)
         }
@@ -62,7 +60,7 @@ private fun CheckStartTime(
     runnerIds: RunnerIds
 ) {
     when (battleUiState.timeRemaining) {
-        in 1..Int.MAX_VALUE -> CountdownDialog(battleUiState.timeRemaining)
+        in 1..5 -> CountdownDialog(battleUiState.timeRemaining)
         0 -> battleId?.let {
             // 위치 업데이트 시작 및 정지 로직
             StartBattleRunning(battleId, viewModel, runnerIds)
@@ -77,8 +75,8 @@ private fun StartBattleRunning(
     runnerIds: RunnerIds
 ) {
     DisposableEffect(Unit) {
+        viewModel.initBattleState(runnerIds) // 러너 데이터를 기반으로 BattleState를 초기화하고 시작
         battleId?.let {
-            viewModel.initBattleState(runnerIds) // 러너 데이터를 기반으로 BattleState를 초기화하고 시작
             viewModel.startLocationUpdates(battleId = it)
         }
 

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleUiState.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleUiState.kt
@@ -4,6 +4,7 @@ import online.partyrun.partyrunapplication.core.model.battle.BattleState
 
 data class BattleUiState(
     val isConnecting: Boolean = true,
+    val screenState: BattleScreenState = BattleScreenState.Ready,
     val showConnectionError: Boolean = false,
     val battleState: BattleState = BattleState(),
     val timeRemaining: Int = -1,


### PR DESCRIPTION
## Description
배틀을 위한 웹소켓 커넥션 과정부터 카운트다운 그리고 Running 상태를 보여줄 스크린의 전환이 유동적으로 이루어져야 한다.
또한, onEach{ ..} 블록을 활용해 복잡한 코드를 제거하고 간결하게 처리할 수 있도록 수정한다.

## Implementation
1. BattleScreenState의 Flow를 별도로 관리하지 않고 BattleUiState 안에서 처리함으로써 보다 유동적인 UI 변경의 이점을 취함

2. 기존에 추가적인 resultResult.collect { ... } 을 통해 Result 이벤트값들을 처리했다면, onEach{..}을 최대한 활용해 더 간결하게 처리하게끔 수정