### PR TITLE
#PAR-161 : MatchListener 관련 메소드명 페어 통일

### DIFF
--- a/core/common/src/main/java/online/partyrun/partyrunapplication/core/common/network/MatchSourceManager.kt
+++ b/core/common/src/main/java/online/partyrun/partyrunapplication/core/common/network/MatchSourceManager.kt
@@ -4,9 +4,9 @@ import okhttp3.sse.EventSource
 import okhttp3.sse.EventSourceListener
 
 interface MatchSourceManager {
-    fun getMatchEventSourceListener(onEvent: (data: String) -> Unit, onClosed: () -> Unit): EventSourceListener
+    fun createMatchEventSourceListener(onEvent: (data: String) -> Unit, onClosed: () -> Unit): EventSourceListener
     fun connectMatchEventSource(eventSource: EventSource)
     fun connectMatchResultEventSource(eventSource: EventSource)
-    fun closeMatchEventSource()
-    fun closeMatchResultEventSource()
+    fun disconnectMatchEventSource()
+    fun disconnectMatchResultEventSource()
 }

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/MatchSourceManagerImpl.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/MatchSourceManagerImpl.kt
@@ -1,17 +1,16 @@
 package online.partyrun.partyrunapplication.core.network
 
-import com.google.gson.Gson
 import okhttp3.Response
 import okhttp3.sse.EventSource
 import okhttp3.sse.EventSourceListener
 import online.partyrun.partyrunapplication.core.common.network.MatchSourceManager
 import timber.log.Timber
 
-class MatchSourceManagerImpl: MatchSourceManager {
+class MatchSourceManagerImpl : MatchSourceManager {
     private lateinit var connectMatchEventSource: EventSource
     private lateinit var connectMatchResultSource: EventSource
 
-    override fun getMatchEventSourceListener(
+    override fun createMatchEventSourceListener(
         onEvent: (data: String) -> Unit,
         onClosed: () -> Unit
     ): EventSourceListener {
@@ -26,11 +25,11 @@ class MatchSourceManagerImpl: MatchSourceManager {
         connectMatchResultSource = eventSource
     }
 
-    override fun closeMatchEventSource() {
+    override fun disconnectMatchEventSource() {
         connectMatchEventSource.cancel()
     }
 
-    override fun closeMatchResultEventSource() {
+    override fun disconnectMatchResultEventSource() {
         connectMatchResultSource.cancel()
     }
 

--- a/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/MatchDialogScreen.kt
+++ b/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/MatchDialogScreen.kt
@@ -48,7 +48,7 @@ fun MatchDialog(
             MatchWaitingDialog(
                 setShowDialog = setShowDialog,
                 disconnectSSE = {
-                    matchViewModel.closeMatchEventSource()
+                    matchViewModel.disconnectMatchEventSource()
                 },
                 matchUiState = matchState,
                 exoPlayer = exoPlayer,

--- a/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/MatchViewModel.kt
+++ b/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/MatchViewModel.kt
@@ -235,7 +235,7 @@ class MatchViewModel @Inject constructor(
      * sseState.await(): 현재 스트림의 상태(sseState)가 완료 상태가 될 때까지 대기
      */
     private suspend fun connectMatchEventSource() {
-        val listener = matchSourceManager.getMatchEventSourceListener(
+        val listener = matchSourceManager.createMatchEventSourceListener(
             onEvent = ::handleMatchEvent,
             onClosed = {
                 matchEventSSEstate.complete(Unit)
@@ -246,7 +246,7 @@ class MatchViewModel @Inject constructor(
     }
 
     private suspend fun connectMatchResultEventSource() {
-        val listener = matchSourceManager.getMatchEventSourceListener(
+        val listener = matchSourceManager.createMatchEventSourceListener(
             onEvent = ::handleMatchResultEvent,
             onClosed = {
                 matchResultEventSSEstate.complete(Unit)
@@ -256,16 +256,16 @@ class MatchViewModel @Inject constructor(
         matchResultEventSSEstate.await()
     }
 
-    fun closeMatchEventSource() {
+    fun disconnectMatchEventSource() {
         viewModelScope.launch {
-            matchSourceManager.closeMatchEventSource()
+            matchSourceManager.disconnectMatchEventSource()
             cancelBattleMatchingProcess()
         }
     }
 
-    fun closeMatchResultEventSource() {
+    fun disconnectMatchResultEventSource() {
         viewModelScope.launch {
-            matchSourceManager.closeMatchResultEventSource()
+            matchSourceManager.disconnectMatchResultEventSource()
             cancelBattleMatchingProcess()
         }
     }


### PR DESCRIPTION
## Description
okhttp 내부 메소드명에 따라 메소드명을 일치시키기 위한 작업 수행

okhttp-sse -> EventSources

![image](https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/b9b0d304-6822-4b18-8889-a319f187415e)
![image](https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/9850894c-fe9f-4d3a-87ad-485749cac510)


## Implementation
1. 리스너를 생성하는 과정은 get 대신 create로 통일
2. connect으로 event를 연결하므로 취소하는 과정은 disconnect로 통일

