### PR TITLE
refactor : TokenExpirationNotifier 명명규칙 변경

### DIFF
--- a/app/src/main/java/online/partyrun/partyrunapplication/di/RefreshTokenExpirationNotifier.kt
+++ b/app/src/main/java/online/partyrun/partyrunapplication/di/RefreshTokenExpirationNotifier.kt
@@ -6,14 +6,15 @@ import online.partyrun.partyrunapplication.AuthActivity
 import online.partyrun.partyrunapplication.core.common.ExtraConstants.EXTRA_FROM_MAIN
 import online.partyrun.partyrunapplication.core.common.ExtraConstants.SIGN_IN
 import online.partyrun.partyrunapplication.core.common.extension.setIntentActivity
-import online.partyrun.partyrunapplication.core.common.network.TokenExpirationNotifier
+import online.partyrun.partyrunapplication.core.common.network.RefreshTokenExpirationNotifier
 import timber.log.Timber
 
-class DefaultTokenExpirationNotifier(
+class RefreshTokenExpirationNotifier(
     private val context: Context
-): TokenExpirationNotifier {
-    override fun onTokenExpired() {
-        Timber.tag("DefaultTokenExpirationNotifier").d("refresh token Expired")
+): RefreshTokenExpirationNotifier {
+
+    override fun notifyRefreshTokenExpired() {
+        Timber.tag("RefreshTokenExpirationNotifier").d("refresh token Expired")
         /* 로그아웃 한 경우 Splash 생략을 위한 Intent Extension Bundle String 제공*/
         context.setIntentActivity(
             AuthActivity::class.java,
@@ -22,4 +23,5 @@ class DefaultTokenExpirationNotifier(
             putString(EXTRA_FROM_MAIN, SIGN_IN)
         }
     }
+
 }

--- a/app/src/main/java/online/partyrun/partyrunapplication/di/RefreshTokenExpirationNotifier.kt
+++ b/app/src/main/java/online/partyrun/partyrunapplication/di/RefreshTokenExpirationNotifier.kt
@@ -14,7 +14,7 @@ class RefreshTokenExpirationNotifier(
 ): RefreshTokenExpirationNotifier {
 
     override fun notifyRefreshTokenExpired() {
-        Timber.tag("RefreshTokenExpirationNotifier").d("refresh token Expired")
+        Timber.tag("RefreshTokenExpirationNotifier").d("Refresh token expired")
         /* 로그아웃 한 경우 Splash 생략을 위한 Intent Extension Bundle String 제공*/
         context.setIntentActivity(
             AuthActivity::class.java,

--- a/app/src/main/java/online/partyrun/partyrunapplication/di/TokenExpirationModule.kt
+++ b/app/src/main/java/online/partyrun/partyrunapplication/di/TokenExpirationModule.kt
@@ -6,15 +6,16 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
-import online.partyrun.partyrunapplication.core.common.network.TokenExpirationNotifier
+import online.partyrun.partyrunapplication.core.common.network.RefreshTokenExpirationNotifier
 
 @Module
 @InstallIn(SingletonComponent::class)
 object TokenExpirationModule {
 
     @Provides
-    fun provideTokenExpirationNotifier(
+    fun provideRefreshTokenExpirationNotifier(
         @ApplicationContext context: Context
-    ): TokenExpirationNotifier =
-        DefaultTokenExpirationNotifier(context)
+    ): RefreshTokenExpirationNotifier =
+        RefreshTokenExpirationNotifier(context)
+
 }

--- a/core/common/src/main/java/online/partyrun/partyrunapplication/core/common/network/RefreshTokenExpirationNotifier.kt
+++ b/core/common/src/main/java/online/partyrun/partyrunapplication/core/common/network/RefreshTokenExpirationNotifier.kt
@@ -1,0 +1,5 @@
+package online.partyrun.partyrunapplication.core.common.network
+
+interface RefreshTokenExpirationNotifier {
+    fun notifyRefreshTokenExpired()
+}

--- a/core/common/src/main/java/online/partyrun/partyrunapplication/core/common/network/TokenExpirationNotifier.kt
+++ b/core/common/src/main/java/online/partyrun/partyrunapplication/core/common/network/TokenExpirationNotifier.kt
@@ -1,5 +1,0 @@
-package online.partyrun.partyrunapplication.core.common.network
-
-interface TokenExpirationNotifier{
-    fun onTokenExpired()
-}

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/AuthAuthenticator.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/AuthAuthenticator.kt
@@ -9,7 +9,7 @@ import okhttp3.*
 import okhttp3.logging.HttpLoggingInterceptor
 import online.partyrun.partyrunapplication.core.model.signin.SignInTokenResult
 import online.partyrun.partyrunapplication.core.common.Constants.BASE_URL
-import online.partyrun.partyrunapplication.core.common.network.TokenExpirationNotifier
+import online.partyrun.partyrunapplication.core.common.network.RefreshTokenExpirationNotifier
 import online.partyrun.partyrunapplication.core.network.service.SignInApiService
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
@@ -25,8 +25,8 @@ import javax.inject.Singleton
 class AuthAuthenticator @Inject constructor(
     private val tokenManager: TokenManager,
     private val context: Context,
-    private val tokenExpirationNotifier: TokenExpirationNotifier
-): Authenticator {
+    private val refreshTokenExpirationNotifier: RefreshTokenExpirationNotifier
+) : Authenticator {
 
     private val googleAuthUiClient by lazy {
         GoogleAuthUiClient(
@@ -48,7 +48,7 @@ class AuthAuthenticator @Inject constructor(
                 googleAuthUiClient.signOutGoogleAuth() // Google 로그아웃
                 tokenManager.deleteAccessToken()
                 // Token 만료 알림 -> 이벤트 브로드캐스팅
-                tokenExpirationNotifier.onTokenExpired()
+                refreshTokenExpirationNotifier.notifyRefreshTokenExpired()
                 return@runBlocking null
             }else {
                 /* 정상적으로 새로운 Token Set을 받아온 경우 */

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/di/NetworkModule.kt
@@ -16,7 +16,7 @@ import okhttp3.Request
 import okhttp3.logging.HttpLoggingInterceptor
 import online.partyrun.partyrunapplication.core.common.Constants.BASE_URL
 import online.partyrun.partyrunapplication.core.common.network.MatchSourceManager
-import online.partyrun.partyrunapplication.core.common.network.TokenExpirationNotifier
+import online.partyrun.partyrunapplication.core.common.network.RefreshTokenExpirationNotifier
 import online.partyrun.partyrunapplication.core.network.AuthAuthenticator
 import online.partyrun.partyrunapplication.core.network.AuthInterceptor
 import online.partyrun.partyrunapplication.core.network.GoogleAuthUiClient
@@ -49,9 +49,9 @@ object NetworkModule {
     fun provideAuthAuthenticator(
         tokenManager: TokenManager,
         @ApplicationContext context: Context,
-        tokenExpirationNotifier: TokenExpirationNotifier
+        refreshTokenExpirationNotifier: RefreshTokenExpirationNotifier
     ): AuthAuthenticator =
-        AuthAuthenticator(tokenManager, context, tokenExpirationNotifier)
+        AuthAuthenticator(tokenManager, context, refreshTokenExpirationNotifier)
 
     /* SignInClient 인스턴스 생성 */
     @Provides


### PR DESCRIPTION
## Description
1. Refresh Token이 완료 되었을 때 Intent를 위한 Notifier 이므로 리프레시 토큰이 만료될 때 애플리케이션의 시작 화면으로 돌아가는 작업을 수행한다는 것을 명확하게 나타내기 위해 Notifier 클래스 네이밍 변경

2. "on"으로 시작하는 메소드 이름은 일반적으로 이벤트 리스너(event listener)에서 주로 볼 수 있는데, 특정 이벤트가 발생했을 때 이를 처리하는 메소드임을 나타내는 네이밍 컨벤션이다. 예를 들어, 사용자가 버튼을 클릭했을 때 발생하는 이벤트를 처리하는 메소드는 onClick(), 특정 값이 변경되었을 때 발생하는 이벤트를 처리하는 메소드는 onChange()와 같이 이름을 지을 수 있다. 그러나,  Notifier 클래스는 특정 상황에서 다른 객체나 시스템에 정보를 전달하는 역할을 하는 경우가 많다. 따라서 메소드 이름에는 "notify", "alert", "update", "send" 등의 동사가 자주 사용되며 이는 Notifier 클래스가 다른 객체나 시스템에 정보를 전달하는 역할을 명확하게 보여준다.
위와 같은 이유로 Notifier클래스의 메소드명을 변경한다.

## Implementation
1. DefaultTokenExpirationNotifier.kt -> RefreshTokenExpirationNotifier.kt 클래스명 변경
2. onTokenExpired() -> notifyRefreshTokenExpired() 메소드명 변경