### PR TITLE
refactor : Match-related classes 전반적인 네이밍 리팩토링 수행

### DIFF
--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/datasource/MatchDataSource.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/datasource/MatchDataSource.kt
@@ -10,7 +10,7 @@ import online.partyrun.partyrunapplication.core.model.match.UserSelectedMatchDis
 interface MatchDataSource {
     fun connectEvent(url: String, listener: EventSourceListener): EventSource
 
-    suspend fun registerToBattleMatchingQueue(userSelectedMatchDistance: UserSelectedMatchDistance): ApiResult<MatchStatusResult>
-    suspend fun acceptBattleMatchingQueue(matchDecisionRequest: MatchDecisionRequest): ApiResult<MatchStatusResult>
-    suspend fun declineBattleMatchingQueue(matchDecisionRequest: MatchDecisionRequest): ApiResult<MatchStatusResult>
+    suspend fun registerMatch(userSelectedMatchDistance: UserSelectedMatchDistance): ApiResult<MatchStatusResult>
+    suspend fun acceptMatch(matchDecisionRequest: MatchDecisionRequest): ApiResult<MatchStatusResult>
+    suspend fun declineMatch(matchDecisionRequest: MatchDecisionRequest): ApiResult<MatchStatusResult>
 }

--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/datasource/MatchDataSourceImpl.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/datasource/MatchDataSourceImpl.kt
@@ -12,13 +12,13 @@ import online.partyrun.partyrunapplication.core.model.match.UserSelectedMatchDis
 import online.partyrun.partyrunapplication.core.network.di.SSEOkHttpClient
 import online.partyrun.partyrunapplication.core.network.di.SSERequestBuilder
 import online.partyrun.partyrunapplication.core.network.service.MatchDecisionApiService
-import online.partyrun.partyrunapplication.core.network.service.WaitingBattleApiService
+import online.partyrun.partyrunapplication.core.network.service.WaitingMatchApiService
 import javax.inject.Inject
 
 class MatchDataSourceImpl @Inject constructor(
     @SSEOkHttpClient private val okHttpClient: OkHttpClient,
     @SSERequestBuilder private val request: Request.Builder,
-    private val waitingBattleApi: WaitingBattleApiService,
+    private val waitingMatchApi: WaitingMatchApiService,
     private val matchDecisionApiService: MatchDecisionApiService
 ) : MatchDataSource {
 
@@ -27,13 +27,13 @@ class MatchDataSourceImpl @Inject constructor(
         return EventSources.createFactory(okHttpClient).newEventSource(request, listener)
     }
 
-    override suspend fun registerToBattleMatchingQueue(userSelectedMatchDistance: UserSelectedMatchDistance): ApiResult<MatchStatusResult> =
-        waitingBattleApi.registerToBattleMatchingQueue(userSelectedMatchDistance)
+    override suspend fun registerMatch(userSelectedMatchDistance: UserSelectedMatchDistance): ApiResult<MatchStatusResult> =
+        waitingMatchApi.registerMatch(userSelectedMatchDistance)
 
-    override suspend fun acceptBattleMatchingQueue(matchDecisionRequest: MatchDecisionRequest): ApiResult<MatchStatusResult> =
-        matchDecisionApiService.acceptBattleMatchingQueue(matchDecisionRequest)
+    override suspend fun acceptMatch(matchDecisionRequest: MatchDecisionRequest): ApiResult<MatchStatusResult> =
+        matchDecisionApiService.acceptMatch(matchDecisionRequest)
 
-    override suspend fun declineBattleMatchingQueue(matchDecisionRequest: MatchDecisionRequest): ApiResult<MatchStatusResult> =
-        matchDecisionApiService.declineBattleMatchingQueue(matchDecisionRequest)
+    override suspend fun declineMatch(matchDecisionRequest: MatchDecisionRequest): ApiResult<MatchStatusResult> =
+        matchDecisionApiService.declineMatch(matchDecisionRequest)
 
 }

--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/di/DataSourceModule.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/di/DataSourceModule.kt
@@ -8,11 +8,10 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import online.partyrun.partyrunapplication.core.data.datasource.MatchDataSource
 import online.partyrun.partyrunapplication.core.data.datasource.MatchDataSourceImpl
-import online.partyrun.partyrunapplication.core.data.repository.MatchRepositoryImpl
 import online.partyrun.partyrunapplication.core.network.di.SSEOkHttpClient
 import online.partyrun.partyrunapplication.core.network.di.SSERequestBuilder
 import online.partyrun.partyrunapplication.core.network.service.MatchDecisionApiService
-import online.partyrun.partyrunapplication.core.network.service.WaitingBattleApiService
+import online.partyrun.partyrunapplication.core.network.service.WaitingMatchApiService
 import javax.inject.Singleton
 
 @Module
@@ -24,10 +23,10 @@ object DataSourceModule {
     fun provideMatchDataSource(
         @SSEOkHttpClient okHttpClient: OkHttpClient,
         @SSERequestBuilder request: Request.Builder,
-        waitingBattleApiService: WaitingBattleApiService,
+        waitingMatchApiService: WaitingMatchApiService,
         matchDecisionApiService: MatchDecisionApiService
     ): MatchDataSource {
-        return MatchDataSourceImpl(okHttpClient, request, waitingBattleApiService, matchDecisionApiService)
+        return MatchDataSourceImpl(okHttpClient, request, waitingMatchApiService, matchDecisionApiService)
     }
 
 }

--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/MatchRepository.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/MatchRepository.kt
@@ -11,9 +11,9 @@ import online.partyrun.partyrunapplication.core.model.match.UserSelectedMatchDis
 interface MatchRepository {
 
     /* REST */
-    suspend fun registerToBattleMatchingQueue(userSelectedMatchDistance: UserSelectedMatchDistance): Flow<ApiResponse<MatchStatusResult>>
-    suspend fun sendAcceptBattleMatchingQueue(matchDecisionRequest: MatchDecisionRequest): Flow<ApiResponse<MatchStatusResult>>
-    suspend fun sendDeclineBattleMatchingQueue(matchDecisionRequest: MatchDecisionRequest): Flow<ApiResponse<MatchStatusResult>>
+    suspend fun registerMatch(userSelectedMatchDistance: UserSelectedMatchDistance): Flow<ApiResponse<MatchStatusResult>>
+    suspend fun acceptMatch(matchDecisionRequest: MatchDecisionRequest): Flow<ApiResponse<MatchStatusResult>>
+    suspend fun declineMatch(matchDecisionRequest: MatchDecisionRequest): Flow<ApiResponse<MatchStatusResult>>
 
     /* SSE */
     fun connectWaitingEventSource(listener: EventSourceListener): EventSource

--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/MatchRepositoryImpl.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/MatchRepositoryImpl.kt
@@ -1,14 +1,11 @@
 package online.partyrun.partyrunapplication.core.data.repository
 
-import kotlinx.coroutines.flow.Flow
 import okhttp3.sse.EventSource
 import okhttp3.sse.EventSourceListener
 import online.partyrun.partyrunapplication.core.common.Constants.BASE_URL
-import online.partyrun.partyrunapplication.core.common.network.ApiResponse
 import online.partyrun.partyrunapplication.core.common.network.apiRequestFlow
 import online.partyrun.partyrunapplication.core.data.datasource.MatchDataSource
 import online.partyrun.partyrunapplication.core.model.match.MatchDecisionRequest
-import online.partyrun.partyrunapplication.core.model.match.MatchStatusResult
 import online.partyrun.partyrunapplication.core.model.match.UserSelectedMatchDistance
 import javax.inject.Inject
 
@@ -17,16 +14,16 @@ class MatchRepositoryImpl @Inject constructor(
     private val dataSource: MatchDataSource
 ) : MatchRepository {
     /* REST */
-    override suspend fun registerToBattleMatchingQueue(userSelectedMatchDistance: UserSelectedMatchDistance) = apiRequestFlow {
-        dataSource.registerToBattleMatchingQueue(userSelectedMatchDistance)
+    override suspend fun registerMatch(userSelectedMatchDistance: UserSelectedMatchDistance) = apiRequestFlow {
+        dataSource.registerMatch(userSelectedMatchDistance)
     }
 
-    override suspend fun sendAcceptBattleMatchingQueue(matchDecisionRequest: MatchDecisionRequest) = apiRequestFlow {
-        dataSource.acceptBattleMatchingQueue(matchDecisionRequest)
+    override suspend fun acceptMatch(matchDecisionRequest: MatchDecisionRequest) = apiRequestFlow {
+        dataSource.acceptMatch(matchDecisionRequest)
     }
 
-    override suspend fun sendDeclineBattleMatchingQueue(matchDecisionRequest: MatchDecisionRequest) = apiRequestFlow {
-        dataSource.declineBattleMatchingQueue(matchDecisionRequest)
+    override suspend fun declineMatch(matchDecisionRequest: MatchDecisionRequest) = apiRequestFlow {
+        dataSource.declineMatch(matchDecisionRequest)
     }
 
     /* SSE */

--- a/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/SendAcceptMatchUseCase.kt
+++ b/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/SendAcceptMatchUseCase.kt
@@ -11,5 +11,5 @@ class SendAcceptMatchUseCase @Inject constructor(
     private val matchRepository: MatchRepository
 ) {
     suspend operator fun invoke(matchDecisionRequest: MatchDecisionRequest): Flow<ApiResponse<MatchStatusResult>> =
-        matchRepository.sendAcceptBattleMatchingQueue(matchDecisionRequest)
+        matchRepository.acceptMatch(matchDecisionRequest)
 }

--- a/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/SendDeclineMatchUseCase.kt
+++ b/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/SendDeclineMatchUseCase.kt
@@ -11,5 +11,5 @@ class SendDeclineMatchUseCase @Inject constructor(
     private val matchRepository: MatchRepository
 ) {
     suspend operator fun invoke(matchDecisionRequest: MatchDecisionRequest): Flow<ApiResponse<MatchStatusResult>> =
-        matchRepository.sendDeclineBattleMatchingQueue(matchDecisionRequest)
+        matchRepository.declineMatch(matchDecisionRequest)
 }

--- a/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/SendWaitingMatchUseCase.kt
+++ b/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/SendWaitingMatchUseCase.kt
@@ -7,9 +7,9 @@ import online.partyrun.partyrunapplication.core.model.match.MatchStatusResult
 import online.partyrun.partyrunapplication.core.model.match.UserSelectedMatchDistance
 import javax.inject.Inject
 
-class SendWaitingBattleUseCase @Inject constructor(
+class SendWaitingMatchUseCase @Inject constructor(
     private val matchRepository: MatchRepository
 ) {
     suspend operator fun invoke(userSelectedMatchDistance: UserSelectedMatchDistance): Flow<ApiResponse<MatchStatusResult>> =
-        matchRepository.registerToBattleMatchingQueue(userSelectedMatchDistance)
+        matchRepository.registerMatch(userSelectedMatchDistance)
 }

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/di/ApiServiceModule.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/di/ApiServiceModule.kt
@@ -7,7 +7,7 @@ import dagger.hilt.components.SingletonComponent
 import okhttp3.OkHttpClient
 import online.partyrun.partyrunapplication.core.network.service.MatchDecisionApiService
 import online.partyrun.partyrunapplication.core.network.service.SignInApiService
-import online.partyrun.partyrunapplication.core.network.service.WaitingBattleApiService
+import online.partyrun.partyrunapplication.core.network.service.WaitingMatchApiService
 import retrofit2.Retrofit
 import retrofit2.Retrofit.Builder
 import javax.inject.Singleton
@@ -26,11 +26,11 @@ object ApiServiceModule {
 
     @Singleton
     @Provides
-    fun provideWaitingBattleApiService(@RESTOkHttpClient okHttpClient: OkHttpClient, retrofit: Builder): WaitingBattleApiService =
+    fun provideWaitingMatchApiService(@RESTOkHttpClient okHttpClient: OkHttpClient, retrofit: Builder): WaitingMatchApiService =
         retrofit
             .client(okHttpClient)
             .build()
-            .create(WaitingBattleApiService::class.java)
+            .create(WaitingMatchApiService::class.java)
 
     @Singleton
     @Provides

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/service/MatchDecisionApiService.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/service/MatchDecisionApiService.kt
@@ -8,12 +8,12 @@ import retrofit2.http.POST
 
 interface MatchDecisionApiService {
     @POST("/api/match")
-    suspend fun acceptBattleMatchingQueue(
+    suspend fun acceptMatch(
         @Body body: MatchDecisionRequest
     ): ApiResult<MatchStatusResult>
 
     @POST("/api/match")
-    suspend fun declineBattleMatchingQueue(
+    suspend fun declineMatch(
         @Body body: MatchDecisionRequest
     ): ApiResult<MatchStatusResult>
 }

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/service/WaitingMatchApiService.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/service/WaitingMatchApiService.kt
@@ -6,9 +6,9 @@ import online.partyrun.partyrunapplication.core.model.match.UserSelectedMatchDis
 import retrofit2.http.Body
 import retrofit2.http.POST
 
-interface WaitingBattleApiService {
+interface WaitingMatchApiService {
     @POST("/api/waiting")
-    suspend fun registerToBattleMatchingQueue(
+    suspend fun registerMatch(
         @Body body: UserSelectedMatchDistance
     ): ApiResult<MatchStatusResult>
 }


### PR DESCRIPTION
## Description
매칭과 관련된 부분들의 네이밍 정보를 보다 간결하게 변경함으로써 그 역할과 동작을 명확하게 나타내고자 리팩토링 작업 수행

예를 들어,
registerToBattleMatchingQueue, acceptBattleMatchingQueue, declineBattleMatchingQueue 등은 서버에 '등록', '수락', '거절' 액션을 보내는 역할을 한다. 그러나, Queue는 프론트에서 실제 작업과 관련이 없으므로 이를 제거하고, 더욱 간결하고 명확한 명칭으로 변경한다.