### PR TITLE
#PAR-219 : 배틀 시작부터 BottomNavigationBar 제외

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -80,6 +80,7 @@ dependencies {
     implementation(project(":core:model"))
     implementation(project(":core:navigation"))
     implementation(project(":core:network"))
+    implementation(project(":core:ui"))
 
     // feature modules
     implementation(project(":feature:sign_in"))

--- a/app/src/main/java/online/partyrun/partyrunapplication/ui/PartyRunMain.kt
+++ b/app/src/main/java/online/partyrun/partyrunapplication/ui/PartyRunMain.kt
@@ -10,12 +10,14 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import online.partyrun.partyrunapplication.core.navigation.main.BottomNavigationBar
 import online.partyrun.partyrunapplication.core.navigation.main.MainNavRoutes
@@ -47,9 +49,17 @@ fun SetUpMainGraph(
     navController: NavHostController,
     onSignOut: () -> Unit
 ) {
+    /**
+     * 현재 destination 가져와 arguments는 고려하지 않고 route만 비교 -> currentRoute
+     */
+    val currentDestination by navController.currentBackStackEntryAsState()
+    val currentRoute = currentDestination?.destination?.route?.substringBefore("?")
+
     Scaffold(
         bottomBar = {
-            BottomNavigationBar(navController = navController)
+            if (currentRoute != MainNavRoutes.BattleRunning.route) {
+                BottomNavigationBar(navController = navController)
+            }
         },
     ) { paddingValues ->
         Box(
@@ -66,13 +76,15 @@ fun SetUpMainGraph(
                 onSignOut = onSignOut
             )
 
-            Divider( // 네비게이션바 border 상단 표현
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(1.dp)
-                    .align(Alignment.BottomCenter), // 스크린 바닥에 경계 표현
-                color = Color(0xFFBD55F2)
-            )
+            if (currentRoute != MainNavRoutes.BattleRunning.route) {
+                Divider( // 네비게이션바 border 상단 표현
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(1.dp)
+                        .align(Alignment.BottomCenter), // 스크린 바닥에 경계 표현
+                    color = Color(0xFFBD55F2)
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Description
배틀이 시작되는 순간부터는 메인과는 달리 BottomNavigationBar 없이 배틀 화면이 스크린의 전체를 차지해야 한다.
Route에 따라 BottomNavigationBar Composable의 렌더링 여부를 결정한다.

## Implementation
<img width="376" alt="스크린샷 2023-07-30 오후 12 31 09" src="https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/2008d8ec-661d-4152-b4f0-00f123aeeb01">
