### PR TITLE
#PAR-221 : 로그아웃 시 스플래시->약관동의 과정부터 시작하도록 변경

### DIFF
--- a/app/src/main/java/online/partyrun/partyrunapplication/AuthActivity.kt
+++ b/app/src/main/java/online/partyrun/partyrunapplication/AuthActivity.kt
@@ -7,7 +7,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.navigation.compose.rememberNavController
 import dagger.hilt.android.AndroidEntryPoint
-import online.partyrun.partyrunapplication.core.common.ExtraConstants.EXTRA_FROM_MAIN
 import online.partyrun.partyrunapplication.core.common.ExtraConstants.SPLASH
 import online.partyrun.partyrunapplication.core.common.extension.setIntentActivity
 import online.partyrun.partyrunapplication.core.designsystem.component.PartyRunBackground
@@ -26,13 +25,11 @@ class AuthActivity : ComponentActivity() {
                 disableDynamicTheming = true,
             ) {
                 val navController = rememberNavController()
-                /* 프로세스 절차 중 유저가 로그아웃 한 경우 혹은 refresh가 만료된 경우 Splash 생략하고 바로 sign_in으로 */
-                val fromMain = intent.getStringExtra(EXTRA_FROM_MAIN)?: SPLASH
 
                 PartyRunBackground {
                     PartyRunAuth(
                         navController = navController,
-                        startDestination = fromMain,
+                        startDestination = SPLASH,
                         intentToMainActivity = {
                             intentToMainActivity(toastText = resources.getString(R.string.sign_in_message))
                         }

--- a/app/src/main/java/online/partyrun/partyrunapplication/MainActivity.kt
+++ b/app/src/main/java/online/partyrun/partyrunapplication/MainActivity.kt
@@ -11,8 +11,6 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
-import online.partyrun.partyrunapplication.core.common.ExtraConstants.EXTRA_FROM_MAIN
-import online.partyrun.partyrunapplication.core.common.ExtraConstants.SIGN_IN
 import online.partyrun.partyrunapplication.ui.PartyRunMain
 import online.partyrun.partyrunapplication.core.common.extension.setIntentActivity
 import online.partyrun.partyrunapplication.core.designsystem.component.PartyRunBackground
@@ -69,10 +67,7 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun performSignOutProcess() {
-        /* 로그아웃 한 경우 Splash 생략을 위한 Intent Extension Bundle String 제공*/
-        setIntentActivity(AuthActivity::class.java) {
-            putString(EXTRA_FROM_MAIN, SIGN_IN)
-        }
+        setIntentActivity(AuthActivity::class.java)
         overridePendingTransition(0, 0) // 전환 애니메이션 생략
         finish()
     }

--- a/app/src/main/java/online/partyrun/partyrunapplication/di/RefreshTokenExpirationNotifier.kt
+++ b/app/src/main/java/online/partyrun/partyrunapplication/di/RefreshTokenExpirationNotifier.kt
@@ -15,7 +15,6 @@ class RefreshTokenExpirationNotifier(
 
     override fun notifyRefreshTokenExpired() {
         Timber.tag("RefreshTokenExpirationNotifier").d("Refresh token expired")
-        /* 로그아웃 한 경우 Splash 생략을 위한 Intent Extension Bundle String 제공*/
         context.setIntentActivity(
             AuthActivity::class.java,
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK

--- a/app/src/main/java/online/partyrun/partyrunapplication/ui/PartyRunAuth.kt
+++ b/app/src/main/java/online/partyrun/partyrunapplication/ui/PartyRunAuth.kt
@@ -50,7 +50,9 @@ fun SetUpAuthNavGraph(
 
         agreementRoute(
             navController = navController,
-            setIntentMainActivity = intentToMainActivity,
+            navigationToSignIn = {
+                 navController.navigate(AuthNavRoutes.SignIn.route)
+            },
             navigationToTermsOfService = {
                 navController.navigate(AuthNavRoutes.TermsOfService.route)
             },

--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/GoogleAuthRepository.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/GoogleAuthRepository.kt
@@ -2,6 +2,7 @@ package online.partyrun.partyrunapplication.core.data.repository
 
 import android.content.Intent
 import android.content.IntentSender
+import kotlinx.coroutines.flow.Flow
 import online.partyrun.partyrunapplication.core.model.auth.GoogleUserData
 import online.partyrun.partyrunapplication.core.model.auth.GoogleUserInfo
 
@@ -12,5 +13,5 @@ interface GoogleAuthRepository {
     suspend fun signInGoogle(): IntentSender?
     suspend fun signInGoogleWithIntent(intent: Intent): GoogleUserInfo?
     suspend fun signOutGoogleAuth()
-    fun getGoogleAuthUser(): GoogleUserData?
+    fun getGoogleAuthUser(): Flow<GoogleUserData?>
 }

--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/GoogleAuthRepositoryImpl.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/GoogleAuthRepositoryImpl.kt
@@ -2,6 +2,8 @@ package online.partyrun.partyrunapplication.core.data.repository
 
 import android.content.Intent
 import android.content.IntentSender
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import online.partyrun.partyrunapplication.core.model.auth.GoogleUserData
 import online.partyrun.partyrunapplication.core.model.auth.GoogleUserInfo
 import online.partyrun.partyrunapplication.core.network.GoogleAuthClient
@@ -26,7 +28,7 @@ class GoogleAuthRepositoryImpl @Inject constructor(
         googleAuthClient.signOutGoogleAuth()
     }
 
-    override fun getGoogleAuthUser(): GoogleUserData? {
-        return googleAuthClient.getGoogleAuthUser()?.toDomainModel()
+    override fun getGoogleAuthUser(): Flow<GoogleUserData?> {
+        return googleAuthClient.getGoogleAuthUser().map { it?.toDomainModel() }
     }
 }

--- a/core/datastore/src/main/java/online/partyrun/partyrunapplication/core/datastore/datasource/AgreementDataSource.kt
+++ b/core/datastore/src/main/java/online/partyrun/partyrunapplication/core/datastore/datasource/AgreementDataSource.kt
@@ -3,6 +3,6 @@ package online.partyrun.partyrunapplication.core.datastore.datasource
 import kotlinx.coroutines.flow.Flow
 
 interface AgreementDataSource {
-    suspend fun saveAgreementState(checked: Boolean)
+    suspend fun saveAgreementState(isChecked: Boolean)
     fun getAgreementState(): Flow<Boolean>
 }

--- a/core/datastore/src/main/java/online/partyrun/partyrunapplication/core/datastore/datasource/AgreementDataSourceImpl.kt
+++ b/core/datastore/src/main/java/online/partyrun/partyrunapplication/core/datastore/datasource/AgreementDataSourceImpl.kt
@@ -18,9 +18,9 @@ class AgreementDataSourceImpl @Inject constructor(
         private val AGREEMENT_KEY = booleanPreferencesKey("agree")
     }
 
-    override suspend fun saveAgreementState(checked: Boolean) {
+    override suspend fun saveAgreementState(isChecked: Boolean) {
         agreementDataStore.edit { preferences ->
-            preferences[AGREEMENT_KEY] = checked
+            preferences[AGREEMENT_KEY] = isChecked
         }
     }
 

--- a/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/agreement/AgreementUseCase.kt
+++ b/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/agreement/AgreementUseCase.kt
@@ -14,6 +14,6 @@ class GetAgreementStateUseCase @Inject constructor(
 class SaveAgreementStateUseCase @Inject constructor(
     private val agreementRepository: AgreementRepository
 ) {
-    suspend operator fun invoke(checked: Boolean) =
-        agreementRepository.saveAgreementState(checked)
+    suspend operator fun invoke(isChecked: Boolean) =
+        agreementRepository.saveAgreementState(isChecked)
 }

--- a/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/auth/GetGoogleAuthUserUseCase.kt
+++ b/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/auth/GetGoogleAuthUserUseCase.kt
@@ -1,5 +1,6 @@
 package online.partyrun.partyrunapplication.core.domain.auth
 
+import kotlinx.coroutines.flow.Flow
 import online.partyrun.partyrunapplication.core.data.repository.GoogleAuthRepository
 import online.partyrun.partyrunapplication.core.model.auth.GoogleUserData
 import javax.inject.Inject
@@ -7,7 +8,7 @@ import javax.inject.Inject
 class GetGoogleAuthUserUseCase @Inject constructor(
     private val googleAuthRepository: GoogleAuthRepository
 ) {
-    operator fun invoke(): GoogleUserData? {
+    operator fun invoke(): Flow<GoogleUserData?> {
         return googleAuthRepository.getGoogleAuthUser()
     }
 }

--- a/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/auth/AuthNavGraph.kt
+++ b/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/auth/AuthNavGraph.kt
@@ -23,13 +23,13 @@ fun NavGraphBuilder.splashRoute(
 
 fun NavGraphBuilder.agreementRoute(
     navController: NavHostController,
-    setIntentMainActivity: () -> Unit,
+    navigationToSignIn: () -> Unit,
     navigationToTermsOfService: () -> Unit,
     navigationToPrivacyPolicy: () -> Unit
 ) {
     composable(AuthNavRoutes.Agreement.route) {
         AgreementScreen(
-            setIntentMainActivity = setIntentMainActivity,
+            navigationToSignIn = navigationToSignIn,
             navigationToTermsOfService = navigationToTermsOfService,
             navigationToPrivacyPolicy = navigationToPrivacyPolicy
         )

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/GoogleAuthClient.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/GoogleAuthClient.kt
@@ -11,6 +11,8 @@ import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.tasks.await
 import online.partyrun.partyrunapplication.core.common.Constants.FIREBASE_GOOGLE_CLIENT_ID
 import online.partyrun.partyrunapplication.core.network.model.response.GoogleUserInfoResponse
@@ -119,11 +121,13 @@ class GoogleAuthClient @Inject constructor(
      * getGoogleAuthUser(): 현재 구글에 로그인된 사용자 정보를 UserData 객체로 반환
      * 현재 사용자가 로그인되어 있지 않으면 null 반환
      */
-    fun getGoogleAuthUser(): GoogleUserDataResponse? = auth.currentUser?.run {
-        GoogleUserDataResponse(
-            userId = uid,
-            username = displayName,
-            profilePictureUrl = photoUrl?.toString()
-        )
+    fun getGoogleAuthUser(): Flow<GoogleUserDataResponse?> = flow {
+        emit(auth.currentUser?.run {
+            GoogleUserDataResponse(
+                userId = uid,
+                username = displayName,
+                profilePictureUrl = photoUrl?.toString()
+            )
+        })
     }
 }

--- a/core/testing/src/main/java/online/partyrun/partyrunapplication/core/testing/repository/TestGoogleAuthRepository.kt
+++ b/core/testing/src/main/java/online/partyrun/partyrunapplication/core/testing/repository/TestGoogleAuthRepository.kt
@@ -2,6 +2,7 @@ package online.partyrun.partyrunapplication.core.testing.repository
 
 import android.content.Intent
 import android.content.IntentSender
+import kotlinx.coroutines.flow.Flow
 import online.partyrun.partyrunapplication.core.data.repository.GoogleAuthRepository
 import online.partyrun.partyrunapplication.core.model.auth.GoogleUserData
 import online.partyrun.partyrunapplication.core.model.auth.GoogleUserInfo
@@ -19,7 +20,8 @@ class TestGoogleAuthRepository : GoogleAuthRepository{
         TODO("Not yet implemented")
     }
 
-    override fun getGoogleAuthUser(): GoogleUserData? {
+    override fun getGoogleAuthUser(): Flow<GoogleUserData?> {
         TODO("Not yet implemented")
     }
+
 }

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageScreen.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageScreen.kt
@@ -26,6 +26,7 @@ fun MyPageScreen(
         Button(
             onClick = {
                 viewModel.signOutFromGoogle()
+                viewModel.saveAgreementState(isChecked = false)
                 onSignOut()
             }
         ) {

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageViewModel.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageViewModel.kt
@@ -4,15 +4,22 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
+import online.partyrun.partyrunapplication.core.domain.agreement.SaveAgreementStateUseCase
 import online.partyrun.partyrunapplication.core.domain.auth.GoogleSignOutUseCase
 import javax.inject.Inject
 
 @HiltViewModel
 class MyPageViewModel @Inject constructor(
-    private val googleSignOutUseCase: GoogleSignOutUseCase
+    private val googleSignOutUseCase: GoogleSignOutUseCase,
+    private val saveAgreementUseCase: SaveAgreementStateUseCase
 ): ViewModel() {
     fun signOutFromGoogle() = viewModelScope.launch {
         googleSignOutUseCase()
     }
+
+    fun saveAgreementState(isChecked: Boolean) = viewModelScope.launch {
+        saveAgreementUseCase(isChecked)
+    }
+
 
 }

--- a/feature/splash/src/main/java/online/partyrun/partyrunapplication/feature/splash/agreement/AgreementScreen.kt
+++ b/feature/splash/src/main/java/online/partyrun/partyrunapplication/feature/splash/agreement/AgreementScreen.kt
@@ -32,7 +32,7 @@ import online.partyrun.partyrunapplication.feature.splash.R
 fun AgreementScreen(
     navigationToTermsOfService: () -> Unit,
     navigationToPrivacyPolicy: () -> Unit,
-    setIntentMainActivity: () -> Unit,
+    navigationToSignIn: () -> Unit,
     agreementViewModel: AgreementViewModel = hiltViewModel()
 ) {
     val state by agreementViewModel.agreementUiState.collectAsStateWithLifecycle()
@@ -105,8 +105,8 @@ fun AgreementScreen(
             PartyRunAnimatedButton(
                 modifier = Modifier.padding(horizontal = 40.dp),
                 onClick = {
-                    agreementViewModel.saveAgreementState()
-                    setIntentMainActivity()
+                    agreementViewModel.saveAgreementState(isChecked = true)
+                    navigationToSignIn()
                 },
                 visible = state.isAllChecked
             ) {

--- a/feature/splash/src/main/java/online/partyrun/partyrunapplication/feature/splash/agreement/AgreementViewModel.kt
+++ b/feature/splash/src/main/java/online/partyrun/partyrunapplication/feature/splash/agreement/AgreementViewModel.kt
@@ -18,8 +18,8 @@ class AgreementViewModel @Inject constructor(
     private val _agreementUiState = MutableStateFlow(AgreementUiState())
     val agreementUiState: StateFlow<AgreementUiState> = _agreementUiState.asStateFlow()
 
-    fun saveAgreementState() = viewModelScope.launch {
-        saveAgreementUseCase(true)
+    fun saveAgreementState(isChecked: Boolean) = viewModelScope.launch {
+        saveAgreementUseCase(isChecked)
     }
 
     fun onCheckedChangeAllAgreement(isChecked: Boolean) {

--- a/feature/splash/src/main/java/online/partyrun/partyrunapplication/feature/splash/splash/SplashScreen.kt
+++ b/feature/splash/src/main/java/online/partyrun/partyrunapplication/feature/splash/splash/SplashScreen.kt
@@ -25,12 +25,11 @@ fun SplashScreen(
     setIntentMainActivity: () -> Unit,
     navigationToAgreement: () -> Unit
 ) {
-    val agreementState by splashViewModel.isAgreement.collectAsStateWithLifecycle()
     val googleUserState by splashViewModel.googleUser.collectAsStateWithLifecycle()
 
     LaunchedEffect(key1 = googleUserState) {
         delay(1500L)
-        if (googleUserState != null) {
+        if (googleUserState != null) { // Google 로그인이 되어있는 상태라면
             setIntentMainActivity()
         } else {
             navigationToAgreement()

--- a/feature/splash/src/main/java/online/partyrun/partyrunapplication/feature/splash/splash/SplashViewModel.kt
+++ b/feature/splash/src/main/java/online/partyrun/partyrunapplication/feature/splash/splash/SplashViewModel.kt
@@ -29,7 +29,9 @@ class SplashViewModel @Inject constructor(
         getGoogleAuthUser()
     }
     private fun getGoogleAuthUser() = viewModelScope.launch {
-        _googleUser.value = getGoogleAuthUserUseCase()
+        getGoogleAuthUserUseCase().collect {
+            _googleUser.value = it
+        }
     }
 
     private fun getAgreementState() = viewModelScope.launch {


### PR DESCRIPTION
## Description
기존에는 로그아웃 시, 스플래시와 약관동의를 생략하고 로그인부터 수행하도록 프로세스가 수행되었다.
그러나, 파티런은 로그인 하기 전에 약관동의를 먼저 받기 때문에 이에 맞춰 프로세스 과정이 수정되어야 한다.
최초 로그인 완료 후 로그아웃 시, 스플래시와 약관동의를 생략하지 않고 스플래시 과정부터 다시 시작해 약관동의를 받을 수 있도록 수정한다.

## Implementation
로그인 스크린은 디자인 작업 전. 임시 lottie파일로 대체

https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/f6453fce-2162-43bf-b595-d7da09f90b91

