### PR TITLE
refactor : BattleReadyScreen padding값 변경

### DIFF
--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/ready/BattleReadyScreen.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/ready/BattleReadyScreen.kt
@@ -56,15 +56,10 @@ fun ReadyInfo() {
     Box(
         modifier = Modifier.fillMaxSize()
     ) {
-        LottieImage(
-            modifier = Modifier.padding(top = 200.dp),
-            rawAnimation = R.raw.ready
-        )
-
         HeadLine(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(top = 80.dp)
+                .padding(top = 50.dp)
                 .align(Alignment.TopCenter)
         ) {
             Text(
@@ -79,5 +74,9 @@ fun ReadyInfo() {
                 color = MaterialTheme.colorScheme.onPrimary
             )
         }
+        LottieImage(
+            modifier = Modifier.padding(top = 150.dp),
+            rawAnimation = R.raw.ready
+        )
     }
 }


### PR DESCRIPTION
## Description
BattleReadyScreen에서 각 ui component들의 위치를 상단으로 조금씩 이동 시킨다.

## Implementation
<img width="373" alt="image" src="https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/91bd5e85-e1d3-4a14-a39e-0d58646ed73c">
