### PR TITLE
fix : SSE Failure 이벤트 발생 시 수행할 메소드 정의

### DIFF
--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/MatchRepository.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/MatchRepository.kt
@@ -16,7 +16,7 @@ interface MatchRepository {
     suspend fun declineMatch(matchDecision: MatchDecision): Flow<ApiResponse<MatchStatus>>
 
     /* SSE */
-    fun createMatchEventSourceListener(onEvent: (data: String) -> Unit, onClosed: () -> Unit): EventSourceListener
+    fun createMatchEventSourceListener(onEvent: (data: String) -> Unit, onClosed: () -> Unit, onFailure: () -> Unit): EventSourceListener
     fun createWaitingEventSource(listener: EventSourceListener): EventSource
     fun createMatchResultEventSource(listener: EventSourceListener): EventSource
 

--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/MatchRepositoryImpl.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/MatchRepositoryImpl.kt
@@ -15,7 +15,6 @@ import online.partyrun.partyrunapplication.core.network.model.request.toRequestM
 import online.partyrun.partyrunapplication.core.network.model.response.toDomainModel
 import javax.inject.Inject
 
-
 class MatchRepositoryImpl @Inject constructor(
     private val dataSource: MatchDataSource
 ) : MatchRepository {
@@ -52,8 +51,8 @@ class MatchRepositoryImpl @Inject constructor(
             }
     }
 
-    override fun createMatchEventSourceListener(onEvent: (data: String) -> Unit, onClosed: () -> Unit): EventSourceListener {
-        return dataSource.createMatchEventSourceListener(onEvent, onClosed)
+    override fun createMatchEventSourceListener(onEvent: (data: String) -> Unit, onClosed: () -> Unit, onFailure: () -> Unit): EventSourceListener {
+        return dataSource.createMatchEventSourceListener(onEvent, onClosed, onFailure)
     }
 
     /* SSE */

--- a/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/match/CreateMatchEventSourceListenerUseCase.kt
+++ b/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/match/CreateMatchEventSourceListenerUseCase.kt
@@ -7,7 +7,7 @@ import javax.inject.Inject
 class CreateMatchEventSourceListenerUseCase @Inject constructor(
     private val matchRepository: MatchRepository
 ) {
-    operator fun invoke(onEvent: (data: String) -> Unit, onClosed: () -> Unit): EventSourceListener {
-        return matchRepository.createMatchEventSourceListener(onEvent, onClosed)
+    operator fun invoke(onEvent: (data: String) -> Unit, onClosed: () -> Unit, onFailure: () -> Unit): EventSourceListener {
+        return matchRepository.createMatchEventSourceListener(onEvent, onClosed, onFailure)
     }
 }

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/MatchDataSource.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/MatchDataSource.kt
@@ -13,7 +13,7 @@ interface MatchDataSource {
     suspend fun acceptMatch(matchDecisionRequest: MatchDecisionRequest): ApiResult<MatchStatusResponse>
     suspend fun declineMatch(matchDecisionRequest: MatchDecisionRequest): ApiResult<MatchStatusResponse>
 
-    fun createMatchEventSourceListener(onEvent: (data: String) -> Unit, onClosed: () -> Unit): EventSourceListener
+    fun createMatchEventSourceListener(onEvent: (data: String) -> Unit, onClosed: () -> Unit, onFailure: () -> Unit): EventSourceListener
     fun createEventSource(url: String, listener: EventSourceListener): EventSource
     fun connectWaitingEventSource(eventSource: EventSource)
     fun connectMatchResultEventSource(eventSource: EventSource)

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/MatchDataSourceImpl.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/MatchDataSourceImpl.kt
@@ -37,9 +37,10 @@ class MatchDataSourceImpl @Inject constructor(
 
     override fun createMatchEventSourceListener(
         onEvent: (data: String) -> Unit,
-        onClosed: () -> Unit
+        onClosed: () -> Unit,
+        onFailure: () -> Unit
     ) : EventSourceListener {
-        return createEventListener(onEvent, onClosed)
+        return createEventListener(onEvent, onClosed, onFailure)
     }
 
     override fun createEventSource(url: String, listener: EventSourceListener): EventSource {
@@ -69,7 +70,8 @@ class MatchDataSourceImpl @Inject constructor(
 
     private fun createEventListener(
         onEvent: (data: String) -> Unit,
-        onClosed: () -> Unit
+        onClosed: () -> Unit,
+        onFailure: () -> Unit
     ): EventSourceListener {
         return object : EventSourceListener() {
             override fun onOpen(eventSource: EventSource, response: Response) {
@@ -97,6 +99,7 @@ class MatchDataSourceImpl @Inject constructor(
             ) {
                 Timber.tag("Event").d("On Failure -: $response")
                 Timber.tag("Event").d("On Failure -: ${response?.body?.string()}")
+                onFailure()
             }
         }
     }

--- a/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/MatchViewModel.kt
+++ b/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/MatchViewModel.kt
@@ -267,6 +267,9 @@ class MatchViewModel @Inject constructor(
             onEvent = ::handleWaitingEvent,
             onClosed = {
                 waitingEventSSEstate.complete(Unit)
+            },
+            onFailure = {
+                waitingEventSSEstate.complete(Unit)
             }
         )
         connectWaitingEventSourceUseCase(createWaitingEventSourceUseCase(listener))
@@ -277,6 +280,9 @@ class MatchViewModel @Inject constructor(
         val listener = createMatchEventSourceListenerUseCase(
             onEvent = ::handleMatchResultEvent,
             onClosed = {
+                matchResultEventSSEstate.complete(Unit)
+            },
+            onFailure = {
                 matchResultEventSSEstate.complete(Unit)
             }
         )


### PR DESCRIPTION
## Description
SSE 프로세스 진행 중 서버와의 연결 또는 통신 중에 오류가 발생할 때 onFailure 메서드가 호출된다.
타임아웃이 발생했거나, 동일 유저가 또 다시 접속을 시도한다거나 할 경우, onFailure가 발생하고 이에 대응하기 위해 onFailure 호출 시 수행할 메소드를 파라미터를 통해 전달

onFailure 발생 시, SSE 상태를 끝냄으로써 예외를 발생시켜 프로세스를 끝낸다.
