### PR TITLE
#PAR-224 : 바뀐 API 명세에 따른 수정사항 반영 및 flow가 emit한 값을 소비

### DIFF
--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/MatchRepositoryImpl.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/MatchRepositoryImpl.kt
@@ -62,7 +62,7 @@ class MatchRepositoryImpl @Inject constructor(
     }
 
     override fun createMatchResultEventSource(listener: EventSourceListener): EventSource {
-        val url = BASE_URL.plus("/api/match/event")
+        val url = BASE_URL.plus("/api/matching/event")
         return dataSource.createEventSource(url = url, listener = listener)
     }
 

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/match/WaitingEvent.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/match/WaitingEvent.kt
@@ -1,12 +1,12 @@
 package online.partyrun.partyrunapplication.core.model.match
 
 enum class WaitingStatus {
-    CONNECT,
+    CONNECTED,
     MATCHED,
     TIMEOUT
 }
 
 data class WaitingEvent(
-    val status: WaitingStatus = WaitingStatus.CONNECT,
+    val status: WaitingStatus = WaitingStatus.CONNECTED,
     val message: String = ""
 )

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/running/BattleEvent.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/running/BattleEvent.kt
@@ -3,14 +3,18 @@ package online.partyrun.partyrunapplication.core.model.running
 import java.time.LocalDateTime
 
 sealed class BattleEvent {
-    data class BattleReady(
+    data class BattleStart(
         val startTime: LocalDateTime = LocalDateTime.now()
     ) : BattleEvent()
 
-    data class BattleRunner(
+    data class BattleRunning(
         val isFinished: Boolean = false,
         val runnerId: String = "",
         val distance: Double = 0.0
+    ) : BattleEvent()
+
+    data class BattleFinished(
+        val runnerId: String = ""
     ) : BattleEvent()
 
     data class BattleDefault(

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/running/GpsData.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/running/GpsData.kt
@@ -6,5 +6,5 @@ data class GpsData(
     val latitude: Double,
     val longitude: Double,
     val altitude: Double,
-    val gpsTime: LocalDateTime = LocalDateTime.now()
+    val time: LocalDateTime = LocalDateTime.now()
 )

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/BattleEventResponse.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/BattleEventResponse.kt
@@ -6,18 +6,35 @@ import online.partyrun.partyrunapplication.core.model.util.LocalDateTimeAdapter
 import java.time.LocalDateTime
 
 sealed class BattleEventResponse {
-    data class BattleReadyResponse(
+    data class BattleBaseStartResponse(
         val type: String?,
-        @field:JsonAdapter(LocalDateTimeAdapter::class)
-        val startTime: LocalDateTime?
+        val data: BattleStartResponse?
     ): BattleEventResponse()
 
-    data class BattleRunnerResponse(
+    data class BattleStartResponse(
+        @field:JsonAdapter(LocalDateTimeAdapter::class)
+        val startTime: LocalDateTime?
+    )
+
+    data class BattleBaseRunningResponse(
         val type: String?,
+        val data: BattleRunningResponse?
+    ): BattleEventResponse()
+
+    data class BattleRunningResponse(
         val isFinished: Boolean?,
         val runnerId: String?,
         val distance: Double?
+    )
+
+    data class BattleBaseFinishedResponse(
+        val type: String?,
+        val data: BattleFinishedResponse?
     ): BattleEventResponse()
+
+    data class BattleFinishedResponse(
+        val runnerId: String?
+    )
 
     data class BattleDefaultResponse(
         val message: String = ""
@@ -26,11 +43,16 @@ sealed class BattleEventResponse {
 
 fun BattleEventResponse.toDomainModel(): BattleEvent {
     return when (this) {
-        is BattleEventResponse.BattleReadyResponse -> BattleEvent.BattleReady(startTime = this.startTime ?: LocalDateTime.now())
-        is BattleEventResponse.BattleRunnerResponse -> BattleEvent.BattleRunner(
-            isFinished = this.isFinished ?: false,
-            runnerId = this.runnerId ?: "",
-            distance = this.distance ?: 0.0
+        is BattleEventResponse.BattleBaseStartResponse -> BattleEvent.BattleStart(
+            startTime = this.data?.startTime ?: LocalDateTime.now()
+        )
+        is BattleEventResponse.BattleBaseRunningResponse -> BattleEvent.BattleRunning(
+            isFinished = this.data?.isFinished ?: false,
+            runnerId = this.data?.runnerId ?: "",
+            distance = this.data?.distance ?: 0.0
+        )
+        is BattleEventResponse.BattleBaseFinishedResponse -> BattleEvent.BattleFinished(
+            runnerId = this.data?.runnerId ?: ""
         )
         is BattleEventResponse.BattleDefaultResponse -> BattleEvent.BattleDefault(message = this.message)
     }

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/WaitingEventResponse.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/WaitingEventResponse.kt
@@ -5,7 +5,7 @@ import online.partyrun.partyrunapplication.core.model.match.WaitingStatus
 
 data class WaitingEventResponse(
     @SerializedName("status")
-    val status: WaitingStatus = WaitingStatus.CONNECT,
+    val status: WaitingStatus = WaitingStatus.CONNECTED,
     @SerializedName("message")
     val message: String?
 )

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/service/MatchDecisionApiService.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/service/MatchDecisionApiService.kt
@@ -7,12 +7,12 @@ import retrofit2.http.Body
 import retrofit2.http.POST
 
 interface MatchDecisionApiService {
-    @POST("/api/match")
+    @POST("/api/matching")
     suspend fun acceptMatch(
         @Body body: MatchDecisionRequest
     ): ApiResult<MatchStatusResponse>
 
-    @POST("/api/match")
+    @POST("/api/matching")
     suspend fun declineMatch(
         @Body body: MatchDecisionRequest
     ): ApiResult<MatchStatusResponse>

--- a/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/MatchUiState.kt
+++ b/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/MatchUiState.kt
@@ -35,8 +35,7 @@ data class WaitingRestState(
     val message: String = ""
 )
 data class WaitingEventState(
-    val status: WaitingStatus = WaitingStatus.CONNECT,
-    val message: String = "",
+    val status: WaitingStatus = WaitingStatus.CONNECTED,
 )
 
 data class MatchResultRestState(

--- a/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/MatchViewModel.kt
+++ b/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/MatchViewModel.kt
@@ -84,13 +84,9 @@ class MatchViewModel @Inject constructor(
     fun beginBattleMatchingProcess(runningDistance: RunningDistance) =
         viewModelScope.launch {
             try {
-                Timber.e("1")
                 registerMatch(runningDistance)
-                Timber.e("2")
                 connectWaitingEventSource()
-                Timber.e("3")
                 handleUserMatchDecision()
-                Timber.e("4")
                 connectMatchResultEventSource()
                 verifyMatchSuccess()
             } catch (e: MatchingProcessException) {
@@ -223,13 +219,11 @@ class MatchViewModel @Inject constructor(
             WaitingEvent::class.java
         )
         Timber.tag("Event").d("Event Received: status -: ${eventData.status}")
-        Timber.tag("Event").d("Event Received: message -: ${eventData.message}")
         _matchUiState.update {
             it.copy(
                 matchProgress = if (eventData.status == WaitingStatus.MATCHED) MatchProgress.DECISION else it.matchProgress,
                 waitingEventState = WaitingEventState(
-                    status = eventData.status,
-                    message = eventData.message
+                    status = eventData.status
                 )
             )
         }


### PR DESCRIPTION
## Description
서버 측에서 새로 수정한 API 명세대로 기존에 작성한 코드를 수정하고
collect()를 통해 flow가 emit한 값을 소비할 수 있도록 해 배틀스트림을 처리할 수 있게 변경한다.

## Implementation
1. 매치 서비스 부분 API 명세대로 data class 필드 수정
2. 대결 부분 API 명세대로 data class 필드 수정
3. collect() 추가
4. 불필요한 부분 리팩토링