### PR TITLE
#PAR-245 : 스크린 화면 세로모드 고정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:screenOrientation="portrait"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:usesCleartextTraffic="true"
         android:supportsRtl="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="LockedOrientationActivity">
 
     <uses-permission android:name="android.permission.INTERNET"/>
 
@@ -17,7 +18,6 @@
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:screenOrientation="portrait"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:usesCleartextTraffic="true"
         android:supportsRtl="true"
@@ -26,6 +26,7 @@
         <activity
             android:name=".AuthActivity"
             android:exported="true"
+            android:screenOrientation="portrait"
             android:theme="@style/Theme.PartyRunApplication">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -37,6 +38,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:screenOrientation="portrait"
             android:theme="@style/Theme.PartyRunApplication">
         </activity>
     </application>


### PR DESCRIPTION
## Description
달리기 앱의 특성상 앱의 화면이 고정되어 있어야 하고, 세로모드로 전체적인 정보를 전달해야 하기에,
가로 방향으로 스크린 방향이 바뀌는 것을 방지한다.
따라서, 파티런 애플리케이션은 세로모드만으로 동작하도록 고정한다.

## Implementation
```
<activity android:screenOrientation="portrait"> // 세로 모드
<activity android:screenOrientation="landscape"> // 가로 모드
 ```
가로모드를 방지하고 앱 내에서는 세로 모드로만 고정할 것이기에
```<activity android:screenOrientation="portrait">``` 를 manifest에 추가 
또한,
```
<manifest xmlns:android="http://schemas.android.com/apk/res/android"
    xmlns:tools="http://schemas.android.com/tools"
    tools:ignore="LockedOrientationActivity">
```
manifest에 tools:ignore="LockedOrientationActivity"를 추가하여 화면 방향과 관련된 린트 경고를 제거