### PR TITLE
fix : 매칭이 완료된 후 러닝 스크린으로 넘어가기 전 매칭 과정 초기화 수행

### DIFF
--- a/feature/battle/src/main/java/online/partyrun/partyrunapplication/feature/battle/BattleMainScreen.kt
+++ b/feature/battle/src/main/java/online/partyrun/partyrunapplication/feature/battle/BattleMainScreen.kt
@@ -40,6 +40,7 @@ import online.partyrun.partyrunapplication.core.ui.KmInfoCard
 import online.partyrun.partyrunapplication.feature.match.MatchDialog
 import online.partyrun.partyrunapplication.feature.match.MatchUiState
 import online.partyrun.partyrunapplication.feature.match.MatchViewModel
+import timber.log.Timber
 
 @Composable
 fun BattleMainScreen(
@@ -80,6 +81,7 @@ fun BattleMainScreen(
 
     if (matchUiState.isAllRunnersAccepted) {
         navigateToBattleRunningWithArgs(battleId, runnerIdsJson)
+        matchViewModel.closeMatchDialog() // 다이얼로그를 닫고 초기화 수행
     }
 
     Content(matchViewModel, matchUiState, exoPlayer, isBuffering)


### PR DESCRIPTION
## Description
매칭이 완료되고 다음 Running 스크린으로 넘어가기 전에 아직 연결되어있을지 모르는 SSE 연결과, 다이얼로그 오픈 상태,
즉, 매칭 프로세스에 필요한 진행 상태, 저장 값 등에 대한 전체적인 부분들을 초기화하는 과정을 수행한다.