### PR TITLE
refactor : TokenExpirationNotifier 네이밍 수정 및 intent bundle 제거 

### DIFF
--- a/app/src/main/java/online/partyrun/partyrunapplication/di/RefreshTokenExpirationNotifier.kt
+++ b/app/src/main/java/online/partyrun/partyrunapplication/di/RefreshTokenExpirationNotifier.kt
@@ -3,24 +3,22 @@ package online.partyrun.partyrunapplication.di
 import android.content.Context
 import android.content.Intent
 import online.partyrun.partyrunapplication.AuthActivity
-import online.partyrun.partyrunapplication.core.common.ExtraConstants.EXTRA_FROM_MAIN
-import online.partyrun.partyrunapplication.core.common.ExtraConstants.SIGN_IN
 import online.partyrun.partyrunapplication.core.common.extension.setIntentActivity
-import online.partyrun.partyrunapplication.core.common.network.RefreshTokenExpirationNotifier
+import online.partyrun.partyrunapplication.core.common.network.TokenExpirationNotifier
 import timber.log.Timber
 
 class RefreshTokenExpirationNotifier(
     private val context: Context
-): RefreshTokenExpirationNotifier {
+) : TokenExpirationNotifier {
 
     override fun notifyRefreshTokenExpired() {
         Timber.tag("RefreshTokenExpirationNotifier").d("Refresh token expired")
+        /**
+         * 리프래시 토큰 만료 시 Auth부터 다시 진행하도록 수행
+         */
         context.setIntentActivity(
             AuthActivity::class.java,
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-        ) {
-            putString(EXTRA_FROM_MAIN, SIGN_IN)
-        }
+        )
     }
-
 }

--- a/app/src/main/java/online/partyrun/partyrunapplication/di/TokenExpirationModule.kt
+++ b/app/src/main/java/online/partyrun/partyrunapplication/di/TokenExpirationModule.kt
@@ -6,7 +6,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
-import online.partyrun.partyrunapplication.core.common.network.RefreshTokenExpirationNotifier
+import online.partyrun.partyrunapplication.core.common.network.TokenExpirationNotifier
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -15,7 +15,7 @@ object TokenExpirationModule {
     @Provides
     fun provideRefreshTokenExpirationNotifier(
         @ApplicationContext context: Context
-    ): RefreshTokenExpirationNotifier =
+    ): TokenExpirationNotifier =
         RefreshTokenExpirationNotifier(context)
 
 }

--- a/core/common/src/main/java/online/partyrun/partyrunapplication/core/common/network/TokenExpirationNotifier.kt
+++ b/core/common/src/main/java/online/partyrun/partyrunapplication/core/common/network/TokenExpirationNotifier.kt
@@ -1,5 +1,5 @@
 package online.partyrun.partyrunapplication.core.common.network
 
-interface RefreshTokenExpirationNotifier {
+interface TokenExpirationNotifier {
     fun notifyRefreshTokenExpired()
 }

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/AuthAuthenticator.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/AuthAuthenticator.kt
@@ -9,7 +9,7 @@ import okhttp3.*
 import okhttp3.logging.HttpLoggingInterceptor
 import online.partyrun.partyrunapplication.core.network.model.response.SignInTokenResponse
 import online.partyrun.partyrunapplication.core.common.Constants.BASE_URL
-import online.partyrun.partyrunapplication.core.common.network.RefreshTokenExpirationNotifier
+import online.partyrun.partyrunapplication.core.common.network.TokenExpirationNotifier
 import online.partyrun.partyrunapplication.core.datastore.datasource.TokenDataSource
 import online.partyrun.partyrunapplication.core.network.service.SignInApiService
 import retrofit2.Retrofit
@@ -26,7 +26,7 @@ import javax.inject.Singleton
 class AuthAuthenticator @Inject constructor(
     private val tokenDataSource: TokenDataSource,
     private val context: Context,
-    private val refreshTokenExpirationNotifier: RefreshTokenExpirationNotifier
+    private val tokenExpirationNotifier: TokenExpirationNotifier
 ) : Authenticator {
 
     private val googleAuthUiClient by lazy {
@@ -49,7 +49,7 @@ class AuthAuthenticator @Inject constructor(
                 googleAuthUiClient.signOutGoogleAuth() // Google 로그아웃
                 tokenDataSource.deleteAccessToken()
                 // Token 만료 알림 -> 이벤트 브로드캐스팅
-                refreshTokenExpirationNotifier.notifyRefreshTokenExpired()
+                tokenExpirationNotifier.notifyRefreshTokenExpired()
                 return@runBlocking null
             }else {
                 /* 정상적으로 새로운 Token Set을 받아온 경우 */

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/di/NetworkModule.kt
@@ -12,7 +12,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.logging.HttpLoggingInterceptor
 import online.partyrun.partyrunapplication.core.common.Constants.BASE_URL
-import online.partyrun.partyrunapplication.core.common.network.RefreshTokenExpirationNotifier
+import online.partyrun.partyrunapplication.core.common.network.TokenExpirationNotifier
 import online.partyrun.partyrunapplication.core.datastore.datasource.TokenDataSource
 import online.partyrun.partyrunapplication.core.network.AuthAuthenticator
 import online.partyrun.partyrunapplication.core.network.AuthInterceptor
@@ -38,9 +38,9 @@ object NetworkModule {
     fun provideAuthAuthenticator(
         tokenDataSource: TokenDataSource,
         @ApplicationContext context: Context,
-        refreshTokenExpirationNotifier: RefreshTokenExpirationNotifier
+        tokenExpirationNotifier: TokenExpirationNotifier
     ): AuthAuthenticator =
-        AuthAuthenticator(tokenDataSource, context, refreshTokenExpirationNotifier)
+        AuthAuthenticator(tokenDataSource, context, tokenExpirationNotifier)
 
     /* SignInClient 인스턴스 생성 */
     @Provides


### PR DESCRIPTION
## Description
1. 기존에는 로그아웃 시 스플래시, 약관동의를 생략하고 로그인 창으로 가도록 하기 위한 intent bundle를 제공했지만,
현재는 로그아웃 시 스플래시, 약관동의 둘 다 보여줄 것이므로 RefreshTokenExpirationNotifier에서 intent bundle 제거

2. TokenNotifier interface 네이밍 변경
