### PR TITLE
#PAR-248 : 네트워크 딜레이, 트래픽을 줄이기 위한 ExoPlayer Cache 작업 

### DIFF
--- a/feature/battle/src/main/java/online/partyrun/partyrunapplication/feature/battle/util/ExoPlayerCache.kt
+++ b/feature/battle/src/main/java/online/partyrun/partyrunapplication/feature/battle/util/ExoPlayerCache.kt
@@ -1,0 +1,36 @@
+package online.partyrun.partyrunapplication.feature.battle.util
+
+import android.content.Context
+import com.google.android.exoplayer2.database.StandaloneDatabaseProvider
+import com.google.android.exoplayer2.upstream.DataSource
+import com.google.android.exoplayer2.upstream.DefaultHttpDataSource
+import com.google.android.exoplayer2.upstream.cache.Cache
+import com.google.android.exoplayer2.upstream.cache.CacheDataSource
+import com.google.android.exoplayer2.upstream.cache.LeastRecentlyUsedCacheEvictor
+import com.google.android.exoplayer2.upstream.cache.SimpleCache
+import java.io.File
+
+// cache를 저장할 폴더명
+val cacheFoler = ".playerCache"
+
+object ExoPlayerCache {
+    private var cache: Cache? = null
+
+    fun get(context: Context): Cache {
+        if (cache == null) {
+            val cacheSize: Long = 30 * 1024 * 1024 //LRU 방식으로 30MB 사용
+            cache = SimpleCache(
+                File(context.cacheDir, cacheFoler),
+                LeastRecentlyUsedCacheEvictor(cacheSize),
+                StandaloneDatabaseProvider(context.applicationContext)
+            )
+        }
+        return cache!!
+    }
+}
+
+fun getCacheDataSourceFactory(cache: Cache): DataSource.Factory {
+    return CacheDataSource.Factory()
+        .setCache(cache)
+        .setUpstreamDataSourceFactory(DefaultHttpDataSource.Factory())
+}


### PR DESCRIPTION
## Description
서버에 존재하는 미디어를 매번 다운로드 받아 재생하기에는 네트워크 딜레이, 트래픽 부담이 크기에 동일 url이라면 cache에 저장된 media를 재생할 수 있게끔 적용

