### PR TITLE
#PAR-261 : Proto DataStore 설정

### DIFF
--- a/core/datastore/build.gradle.kts
+++ b/core/datastore/build.gradle.kts
@@ -16,6 +16,24 @@ android {
     }
 }
 
+protobuf {
+    protoc {
+        artifact = libs.protobuf.protoc.get().toString()
+    }
+    generateProtoTasks {
+        all().forEach { task ->
+            task.builtins {
+                register("java") {
+                    option("lite")
+                }
+                register("kotlin") {
+                    option("lite")
+                }
+            }
+        }
+    }
+}
+
 dependencies {
     implementation(project(":core:common"))
     implementation(project(":core:model"))

--- a/core/datastore/build.gradle.kts
+++ b/core/datastore/build.gradle.kts
@@ -4,6 +4,9 @@ plugins {
 }
 
 android {
+    defaultConfig {
+        consumerProguardFiles("consumer-proguard-rules.pro")
+    }
     namespace = "online.partyrun.partyrunapplication.core.datastore"
     testOptions {
         unitTests {

--- a/core/datastore/build.gradle.kts
+++ b/core/datastore/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("nohjunh.android.library")
     id("nohjunh.android.hilt")
+    id("com.google.protobuf") version "0.9.3"
 }
 
 android {
@@ -21,6 +22,7 @@ dependencies {
     implementation(libs.androidx.dataStore.core)
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.timber)
+    implementation(libs.protobuf.kotlin.lite)
 
     testImplementation(project(":core:testing"))
 }

--- a/core/datastore/consumer-proguard-rules.pro
+++ b/core/datastore/consumer-proguard-rules.pro
@@ -1,0 +1,3 @@
+-keepclassmembers class * extends com.google.protobuf.GeneratedMessageLite* {
+   <fields>;
+}

--- a/core/datastore/src/main/java/online/partyrun/partyrunapplication/core/datastore/UserPreferencesSerializer.kt
+++ b/core/datastore/src/main/java/online/partyrun/partyrunapplication/core/datastore/UserPreferencesSerializer.kt
@@ -1,0 +1,42 @@
+package online.partyrun.partyrunapplication.core.datastore
+
+import androidx.datastore.core.CorruptionException
+import androidx.datastore.core.Serializer
+import androidx.datastore.preferences.protobuf.InvalidProtocolBufferException
+import java.io.InputStream
+import java.io.OutputStream
+import javax.inject.Inject
+
+/**
+ * UserPreferences Protobuf 타입의 직렬화 및 역직렬화 작업 수행
+ * 직렬화: 객체를 스트림으로 변환하는 과정
+ * 역직렬화: 스트림에서 객체로 변환하는 과정
+ * readFrom과 writeTo 메소드는 DataStore의 백그라운드 스레드에서 호출되므로 별도의 코루틴 디스패처를 지정할 필요 X
+ */
+class UserPreferencesSerializer @Inject constructor() : Serializer<UserPreferences> {
+    /**
+     * UserPreferences 타입의 기본 인스턴스를 제공. 데이터가 손상된 경우나 초기 상태가 필요한 경우 사용
+     */
+    override val defaultValue: UserPreferences = UserPreferences.getDefaultInstance()
+
+    /**
+     * UserPreferences: 입력 스트림에서 UserPreferences 객체를 읽어옴.
+     * serPreferences.parseFrom(input)를 통해 입력 스트림에서 Protobuf 형식의 데이터를 역직렬화.
+     * 만약 데이터 형식이 올바르지 않거나 문제가 발생하면 InvalidProtocolBufferException 예외가 발생하며, 이 경우 CorruptionException으로 래핑하여 throw.
+     */
+    override suspend fun readFrom(input: InputStream): UserPreferences =
+        try {
+            UserPreferences.parseFrom(input)
+        } catch (exception: InvalidProtocolBufferException) {
+            throw CorruptionException("Cannot read proto.", exception)
+        }
+
+    /**
+     * writeTo(t: UserPreferences, output: OutputStream):
+     * UserPreferences 객체를 출력 스트림에 쓰는 작업 수행
+     * t.writeTo(output)를 통해 객체를 직렬화하고 출력 스트림에 작성
+     */
+    override suspend fun writeTo(t: UserPreferences, output: OutputStream) {
+        t.writeTo(output)
+    }
+}

--- a/core/datastore/src/main/java/online/partyrun/partyrunapplication/core/datastore/datasource/UserPreferencesDataSource.kt
+++ b/core/datastore/src/main/java/online/partyrun/partyrunapplication/core/datastore/datasource/UserPreferencesDataSource.kt
@@ -1,0 +1,46 @@
+package online.partyrun.partyrunapplication.core.datastore.datasource
+
+import androidx.datastore.core.DataStore
+import kotlinx.coroutines.flow.map
+import online.partyrun.partyrunapplication.core.datastore.UserPreferences
+import online.partyrun.partyrunapplication.core.model.user.User
+import javax.inject.Inject
+
+class UserPreferencesDataSource @Inject constructor(
+    private val userPreferences: DataStore<UserPreferences>,
+) {
+    // 매핑을 통해 필요한 사용자 데이터 생성
+    val userData = userPreferences.data
+        .map { preferences ->
+            User(
+                id = preferences.id,
+                name = preferences.name,
+                profile = preferences.profile
+            )
+        }
+
+    suspend fun setUserName(userName: String) {
+        userPreferences.updateData { currentPreferences ->
+            currentPreferences.toBuilder()
+                .setName(userName)
+                .build()
+        }
+    }
+
+    suspend fun setUserProfile(userProfile: String) {
+        userPreferences.updateData { currentPreferences ->
+            currentPreferences.toBuilder()
+                .setProfile(userProfile)
+                .build()
+        }
+    }
+
+    suspend fun setUserId(userId: String) {
+        userPreferences.updateData { currentPreferences ->
+            currentPreferences.toBuilder()
+                .setId(userId)
+                .build()
+        }
+    }
+
+}

--- a/core/datastore/src/main/java/online/partyrun/partyrunapplication/core/datastore/di/DataStoreModule.kt
+++ b/core/datastore/src/main/java/online/partyrun/partyrunapplication/core/datastore/di/DataStoreModule.kt
@@ -2,7 +2,9 @@ package online.partyrun.partyrunapplication.core.datastore.di
 
 import android.content.Context
 import androidx.datastore.core.DataStore
+import androidx.datastore.core.DataStoreFactory
 import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.dataStoreFile
 import androidx.datastore.preferences.SharedPreferencesMigration
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
@@ -18,6 +20,8 @@ import online.partyrun.partyrunapplication.core.datastore.datasource.TokenDataSo
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import online.partyrun.partyrunapplication.core.datastore.UserPreferences
+import online.partyrun.partyrunapplication.core.datastore.UserPreferencesSerializer
 import online.partyrun.partyrunapplication.core.datastore.datasource.AgreementDataSource
 import online.partyrun.partyrunapplication.core.datastore.datasource.TokenDataSource
 import javax.inject.Named
@@ -29,6 +33,20 @@ object DataStoreModule {
 
     private const val AGREEMENT_PREFERENCES = "agreement_pref"
     private const val TOKEN_PREFERENCES = "token_pref"
+
+    @Provides
+    @Singleton
+    fun providesUserPreferencesDataStore(
+        @ApplicationContext context: Context,
+        userPreferencesSerializer: UserPreferencesSerializer,
+    ): DataStore<UserPreferences> =
+        DataStoreFactory.create(
+            serializer = userPreferencesSerializer,
+            scope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
+            corruptionHandler = null
+        ) {
+            context.dataStoreFile("user_preferences.pb")
+        }
 
     @Singleton
     @Provides

--- a/core/datastore/src/main/proto/user_preferences.proto
+++ b/core/datastore/src/main/proto/user_preferences.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+option java_package = "online.partyrun.partyrunapplication.core.datastore";
+option java_multiple_files = true;
+
+message UserPreferences {
+  string id = 1;
+  string name = 2;
+  string profile = 3;
+}

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/user/User.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/user/User.kt
@@ -1,0 +1,7 @@
+package online.partyrun.partyrunapplication.core.model.user
+
+data class User(
+    val id: String,
+    val name: String,
+    val profile: String
+)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,8 @@ mockk = "1.13.54"
 lottie = "6.0.0"
 gson = "2.10.1"
 mock = "4.10.0"
+protobuf = "3.23.4"
+protobufPlugin = "0.9.3"
 coil = "2.2.2"
 kotlinBom = "1.8.0"
 firebaseBom = "31.2.3"
@@ -114,6 +116,10 @@ exo-player = { group = "com.google.android.exoplayer", name = "exoplayer", versi
 # Lottie
 lottie-compose = { module = "com.airbnb.android:lottie-compose", version.ref = "lottie"}
 
+# protobuf
+protobuf-kotlin-lite = { group = "com.google.protobuf", name = "protobuf-kotlin-lite", version.ref = "protobuf" }
+protobuf-protoc = { group = "com.google.protobuf", name = "protoc", version.ref = "protobuf" }
+
 # firebase, google
 firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics-ktx" }
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
@@ -183,4 +189,5 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+protobuf = { id = "com.google.protobuf", version.ref = "protobufPlugin" }
 secrets = { id = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin", version.ref = "secrets" }


### PR DESCRIPTION
## Description
DataStore Protobuf를 셋팅하여 유저 데이터를 저장한다.

Protocol Buffers는 구글에서 개발한 이진 직렬화 포맷.
Protobuf 플랫폼 및 언어에 독립적이며, 다양한 언어와 시스템에서 데이터를 효율적으로 전송하기 위해 사용됨.
주요 장점은 작은 메시지 크기, 빠른 직렬화/역직렬화 속도 및 강력한 타입 안정성을 제공

## Implementation
https://velog.io/@nohjunh/유저-정보-저장을-위한-Proto-DataStore-Setting