### PR TITLE
#PAR-263 : 최초 로그인 시 유저 데이터를 가져와 protobuf에 저장한 뒤 메인 스크린으로 이동

### DIFF
--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/di/DataModule.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/di/DataModule.kt
@@ -18,6 +18,8 @@ import online.partyrun.partyrunapplication.core.data.repository.RunningResultRep
 import online.partyrun.partyrunapplication.core.data.repository.RunningResultRepositoryImpl
 import online.partyrun.partyrunapplication.core.data.repository.TokenRepository
 import online.partyrun.partyrunapplication.core.data.repository.TokenRepositoryImpl
+import online.partyrun.partyrunapplication.core.data.repository.MemberRepository
+import online.partyrun.partyrunapplication.core.data.repository.MemberRepositoryImpl
 import javax.inject.Singleton
 
 /*
@@ -68,5 +70,11 @@ internal interface DataModule {
     fun bindRunningResultRepository (
         runningResultRepository: RunningResultRepositoryImpl
     ): RunningResultRepository
+
+    @Singleton
+    @Binds
+    fun bindMemberRepository (
+        memberRepository: MemberRepositoryImpl
+    ): MemberRepository
 
 }

--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/MemberRepository.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/MemberRepository.kt
@@ -1,0 +1,18 @@
+package online.partyrun.partyrunapplication.core.data.repository
+
+import kotlinx.coroutines.flow.Flow
+import online.partyrun.partyrunapplication.core.common.network.ApiResponse
+import online.partyrun.partyrunapplication.core.model.user.User
+
+interface MemberRepository {
+
+    val userData: Flow<User>
+
+    suspend fun getUserData(): Flow<ApiResponse<User>>
+
+    suspend fun setUserName(userName: String)
+
+    suspend fun setUserProfile(userProfile: String)
+
+    suspend fun setUserId(userId: String)
+}

--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/MemberRepositoryImpl.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/MemberRepositoryImpl.kt
@@ -1,0 +1,46 @@
+package online.partyrun.partyrunapplication.core.data.repository
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import online.partyrun.partyrunapplication.core.common.network.ApiResponse
+import online.partyrun.partyrunapplication.core.common.network.apiRequestFlow
+import online.partyrun.partyrunapplication.core.datastore.datasource.UserPreferencesDataSource
+import online.partyrun.partyrunapplication.core.model.user.User
+import online.partyrun.partyrunapplication.core.network.datasource.MemberDataSource
+import online.partyrun.partyrunapplication.core.network.model.response.toDomainModel
+import javax.inject.Inject
+
+class MemberRepositoryImpl @Inject constructor(
+    private val userPreferencesDataSource: UserPreferencesDataSource,
+    private val memberDataSource: MemberDataSource
+) : MemberRepository {
+    override val userData: Flow<User> =
+        userPreferencesDataSource.userData
+
+    override suspend fun getUserData(): Flow<ApiResponse<User>> {
+        return apiRequestFlow { memberDataSource.getUserData() }
+            .map { apiResponse ->
+                when (apiResponse) {
+                    is ApiResponse.Loading -> ApiResponse.Loading
+                    is ApiResponse.Success -> ApiResponse.Success(apiResponse.data.toDomainModel())
+                    is ApiResponse.Failure -> ApiResponse.Failure(
+                        apiResponse.errorMessage,
+                        apiResponse.code
+                    )
+                }
+            }
+    }
+
+    override suspend fun setUserName(userName: String) {
+        userPreferencesDataSource.setUserName(userName)
+    }
+
+    override suspend fun setUserProfile(userProfile: String) {
+        userPreferencesDataSource.setUserProfile(userProfile)
+    }
+
+    override suspend fun setUserId(userId: String) {
+        userPreferencesDataSource.setUserId(userId)
+    }
+
+}

--- a/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/member/GetUserDataUseCase.kt
+++ b/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/member/GetUserDataUseCase.kt
@@ -1,0 +1,15 @@
+package online.partyrun.partyrunapplication.core.domain.member
+
+import kotlinx.coroutines.flow.Flow
+import online.partyrun.partyrunapplication.core.common.network.ApiResponse
+import online.partyrun.partyrunapplication.core.data.repository.MemberRepository
+import online.partyrun.partyrunapplication.core.model.user.User
+import javax.inject.Inject
+
+class GetUserDataUseCase @Inject constructor(
+    private val memberRepository: MemberRepository
+) {
+
+    suspend operator fun invoke(): Flow<ApiResponse<User>> =
+        memberRepository.getUserData()
+}

--- a/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/member/SaveUserDataUseCase.kt
+++ b/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/member/SaveUserDataUseCase.kt
@@ -1,0 +1,15 @@
+package online.partyrun.partyrunapplication.core.domain.member
+
+import online.partyrun.partyrunapplication.core.data.repository.MemberRepository
+import online.partyrun.partyrunapplication.core.model.user.User
+import javax.inject.Inject
+
+class SaveUserDataUseCase @Inject constructor(
+    private val memberRepository: MemberRepository
+) {
+    suspend operator fun invoke(userData: User) {
+        memberRepository.setUserId(userData.id)
+        memberRepository.setUserName(userData.name)
+        memberRepository.setUserProfile(userData.profile)
+    }
+}

--- a/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/member/SetUserNameUseCase.kt
+++ b/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/member/SetUserNameUseCase.kt
@@ -1,0 +1,10 @@
+package online.partyrun.partyrunapplication.core.domain.member
+
+import online.partyrun.partyrunapplication.core.data.repository.MemberRepository
+import javax.inject.Inject
+
+class SetUserNameUseCase @Inject constructor(
+    private val memberRepository: MemberRepository
+) {
+    suspend operator fun invoke(userName: String) = memberRepository.setUserName(userName)
+}

--- a/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/member/SetUserProfileUseCase.kt
+++ b/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/member/SetUserProfileUseCase.kt
@@ -1,0 +1,10 @@
+package online.partyrun.partyrunapplication.core.domain.member
+
+import online.partyrun.partyrunapplication.core.data.repository.MemberRepository
+import javax.inject.Inject
+
+class SetUserProfileUseCase @Inject constructor(
+    private val memberRepository: MemberRepository
+) {
+    suspend operator fun invoke(userProfile: String) = memberRepository.setUserProfile(userProfile)
+}

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/MemberDataSource.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/MemberDataSource.kt
@@ -1,0 +1,9 @@
+package online.partyrun.partyrunapplication.core.network.datasource
+
+import online.partyrun.partyrunapplication.core.common.network.ApiResult
+import online.partyrun.partyrunapplication.core.network.model.response.UserResponse
+
+interface MemberDataSource {
+    suspend fun getUserData(): ApiResult<UserResponse>
+
+}

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/MemberDataSourceImpl.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/MemberDataSourceImpl.kt
@@ -1,0 +1,14 @@
+package online.partyrun.partyrunapplication.core.network.datasource
+
+import online.partyrun.partyrunapplication.core.common.network.ApiResult
+import online.partyrun.partyrunapplication.core.network.model.response.UserResponse
+import online.partyrun.partyrunapplication.core.network.service.MemberApiService
+import javax.inject.Inject
+
+class MemberDataSourceImpl @Inject constructor(
+    private val memberApi: MemberApiService
+) : MemberDataSource{
+    override suspend fun getUserData(): ApiResult<UserResponse> =
+        memberApi.getUserData()
+
+}

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/di/ApiServiceModule.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/di/ApiServiceModule.kt
@@ -7,6 +7,7 @@ import dagger.hilt.components.SingletonComponent
 import okhttp3.OkHttpClient
 import online.partyrun.partyrunapplication.core.network.service.BattleResultApiService
 import online.partyrun.partyrunapplication.core.network.service.MatchDecisionApiService
+import online.partyrun.partyrunapplication.core.network.service.MemberApiService
 import online.partyrun.partyrunapplication.core.network.service.SignInApiService
 import online.partyrun.partyrunapplication.core.network.service.WaitingMatchApiService
 import retrofit2.Retrofit
@@ -48,5 +49,13 @@ object ApiServiceModule {
             .client(okHttpClient)
             .build()
             .create(BattleResultApiService::class.java)
+
+    @Singleton
+    @Provides
+    fun provideMemberApiService(@RESTOkHttpClient okHttpClient: OkHttpClient, retrofit: Retrofit.Builder): MemberApiService =
+        retrofit
+            .client(okHttpClient)
+            .build()
+            .create(MemberApiService::class.java)
 
 }

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/di/DataSourceModule.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/di/DataSourceModule.kt
@@ -10,10 +10,13 @@ import online.partyrun.partyrunapplication.core.network.datasource.RunningResult
 import online.partyrun.partyrunapplication.core.network.datasource.RunningResultDataSourceImpl
 import online.partyrun.partyrunapplication.core.network.datasource.MatchDataSource
 import online.partyrun.partyrunapplication.core.network.datasource.MatchDataSourceImpl
+import online.partyrun.partyrunapplication.core.network.datasource.MemberDataSource
+import online.partyrun.partyrunapplication.core.network.datasource.MemberDataSourceImpl
 import online.partyrun.partyrunapplication.core.network.datasource.SignInDataSource
 import online.partyrun.partyrunapplication.core.network.datasource.SignInDataSourceImpl
 import online.partyrun.partyrunapplication.core.network.service.BattleResultApiService
 import online.partyrun.partyrunapplication.core.network.service.MatchDecisionApiService
+import online.partyrun.partyrunapplication.core.network.service.MemberApiService
 import online.partyrun.partyrunapplication.core.network.service.SignInApiService
 import online.partyrun.partyrunapplication.core.network.service.WaitingMatchApiService
 import javax.inject.Singleton
@@ -44,5 +47,11 @@ object DataSourceModule {
     fun provideRunningResultDataSource(
         battleResultApiService: BattleResultApiService
     ): RunningResultDataSource = RunningResultDataSourceImpl(battleResultApiService)
+
+    @Singleton
+    @Provides
+    fun provideMemberDataSource(
+        memberApiService: MemberApiService
+    ): MemberDataSource = MemberDataSourceImpl(memberApiService)
 
 }

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/UserResponse.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/UserResponse.kt
@@ -1,0 +1,19 @@
+package online.partyrun.partyrunapplication.core.network.model.response
+
+import com.google.gson.annotations.SerializedName
+import online.partyrun.partyrunapplication.core.model.user.User
+
+data class UserResponse(
+    @SerializedName("id")
+    val userId: String?,
+    @SerializedName("name")
+    val userName: String?,
+    @SerializedName("profile")
+    val userProfile: String?,
+)
+
+fun UserResponse.toDomainModel() = User(
+    id = this.userId ?: "",
+    name = this.userName ?: "",
+    profile = this.userProfile ?: ""
+)

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/service/MemberApiService.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/service/MemberApiService.kt
@@ -1,0 +1,11 @@
+package online.partyrun.partyrunapplication.core.network.service
+
+import online.partyrun.partyrunapplication.core.common.network.ApiResult
+import online.partyrun.partyrunapplication.core.network.model.response.UserResponse
+import retrofit2.http.GET
+
+interface MemberApiService {
+    @GET("/api/members/me")
+    suspend fun getUserData(): ApiResult<UserResponse>
+
+}

--- a/core/testing/src/main/java/online/partyrun/partyrunapplication/core/testing/repository/TestMemberRepository.kt
+++ b/core/testing/src/main/java/online/partyrun/partyrunapplication/core/testing/repository/TestMemberRepository.kt
@@ -1,0 +1,34 @@
+package online.partyrun.partyrunapplication.core.testing.repository
+
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.flowOf
+import online.partyrun.partyrunapplication.core.common.network.ApiResponse
+import online.partyrun.partyrunapplication.core.data.repository.MemberRepository
+import online.partyrun.partyrunapplication.core.model.user.User
+
+class TestMemberRepository : MemberRepository {
+    private val user = MutableSharedFlow<ApiResponse<User>>(replay = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+
+    private var userId: String? = null
+    private var userName: String? = null
+    private var userProfile: String? = null
+
+    override val userData: Flow<User>
+        get() = flowOf(User(id = userId ?: "", name = userName ?: "", profile = userProfile ?: ""))
+
+    override suspend fun getUserData(): Flow<ApiResponse<User>> = user
+
+    override suspend fun setUserName(userName: String) {
+        this.userName = userName
+    }
+
+    override suspend fun setUserProfile(userProfile: String) {
+        this.userProfile = userProfile
+    }
+
+    override suspend fun setUserId(userId: String) {
+        this.userId = userId
+    }
+}

--- a/feature/sign_in/src/main/java/online/partyrun/partyrunapplication/feature/sign_in/SignInGoogleState.kt
+++ b/feature/sign_in/src/main/java/online/partyrun/partyrunapplication/feature/sign_in/SignInGoogleState.kt
@@ -3,5 +3,6 @@ data class SignInGoogleState(
     val isSignInSuccessful: Boolean = false,
     val hasSignInError: String? = null,
     val isIdTokenSentToServer: Boolean = false,
-    val isSignInIndicatorOn: Boolean = false
+    val isSignInIndicatorOn: Boolean = false,
+    val isUserDataSaved: Boolean = false
 )

--- a/feature/sign_in/src/main/java/online/partyrun/partyrunapplication/feature/sign_in/SignInScreen.kt
+++ b/feature/sign_in/src/main/java/online/partyrun/partyrunapplication/feature/sign_in/SignInScreen.kt
@@ -76,6 +76,12 @@ fun SignInScreen (
     LaunchedEffect(key1 = state.isIdTokenSentToServer) {
         if (state.isIdTokenSentToServer) {
             viewModel.resetState()
+            viewModel.saveUserData()
+        }
+    }
+
+    LaunchedEffect(key1 = state.isUserDataSaved) {
+        if (state.isUserDataSaved) {
             setIntentMainActivity()
         }
     }

--- a/feature/sign_in/src/test/java/online/partyrun/partyrunapplication/feature/sign_in/SignInViewModelTest.kt
+++ b/feature/sign_in/src/test/java/online/partyrun/partyrunapplication/feature/sign_in/SignInViewModelTest.kt
@@ -6,10 +6,13 @@ import online.partyrun.partyrunapplication.core.common.network.ApiResponse
 import online.partyrun.partyrunapplication.core.domain.auth.GetSignInTokenUseCase
 import online.partyrun.partyrunapplication.core.domain.auth.GoogleSignInUseCase
 import online.partyrun.partyrunapplication.core.domain.auth.SaveTokensUseCase
+import online.partyrun.partyrunapplication.core.domain.member.GetUserDataUseCase
+import online.partyrun.partyrunapplication.core.domain.member.SaveUserDataUseCase
 import online.partyrun.partyrunapplication.core.model.auth.GoogleIdToken
 import online.partyrun.partyrunapplication.core.network.model.response.SignInTokenResponse
 import online.partyrun.partyrunapplication.core.network.model.response.toDomainModel
 import online.partyrun.partyrunapplication.core.testing.repository.TestGoogleAuthRepository
+import online.partyrun.partyrunapplication.core.testing.repository.TestMemberRepository
 import online.partyrun.partyrunapplication.core.testing.repository.TestSignInRepository
 import online.partyrun.partyrunapplication.core.testing.repository.TestTokenRepository
 import org.junit.Before
@@ -20,6 +23,7 @@ class SignInViewModelTest {
 
     private val signInRepository = TestSignInRepository()
     private val tokenRepository = TestTokenRepository()
+    private val memberRepository = TestMemberRepository()
     private val googleAuthRepository = TestGoogleAuthRepository()
     private val getSignInTokenUseCase = GetSignInTokenUseCase(
         signInRepository = signInRepository
@@ -29,6 +33,12 @@ class SignInViewModelTest {
     )
     private val googleSignInUseCase = GoogleSignInUseCase(
         googleAuthRepository = googleAuthRepository
+    )
+    private val getUserDataUseCase = GetUserDataUseCase(
+        memberRepository = memberRepository
+    )
+    private val saveUserDataUseCase = SaveUserDataUseCase(
+        memberRepository = memberRepository
     )
 
     private lateinit var viewModel: SignInViewModel
@@ -41,7 +51,9 @@ class SignInViewModelTest {
         viewModel = SignInViewModel(
             getSignInTokenUseCase = getSignInTokenUseCase,
             saveTokensUseCase = saveTokensUseCase,
-            googleSignInUseCase = googleSignInUseCase
+            googleSignInUseCase = googleSignInUseCase,
+            getUserDataUseCase = getUserDataUseCase,
+            saveUserDataUseCase = saveUserDataUseCase
         )
     }
 


### PR DESCRIPTION
## Description
최초 로그인 시, 서버로부터 토큰 정보를 받고
해당 토큰을 다시 서버로 보내 멤버 서비스로부터 내 UserId, 이름, 이미지를 얻어와 DataSotre Protobuf에 저장하는 과정을 수행한다.
유저 데이터를 저장하고나서야 로그인 과정이 끝나면서 메인 스크린으로 이동.

## Implementation

https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/9214ffd0-3eeb-4a22-ba68-378082b716e4

