### PR TITLE
#PAR-264 : 마이페이지에서 내 유저 정보를 확인한다.

### DIFF
--- a/core/designsystem/src/main/java/online/partyrun/partyrunapplication/core/designsystem/component/RenderAsyncImage.kt
+++ b/core/designsystem/src/main/java/online/partyrun/partyrunapplication/core/designsystem/component/RenderAsyncImage.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.Image
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.Placeholder
 import coil.compose.AsyncImagePainter
 import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
@@ -19,6 +18,28 @@ fun RenderAsyncImage(
         model = ImageRequest.Builder(LocalContext.current)
             .data(image)
             .size(size)
+            .crossfade(true)
+            .build(),
+    )
+    if (painter.state is AsyncImagePainter.State.Loading ||
+        painter.state is AsyncImagePainter.State.Error
+    ) {
+        CircularProgressIndicator()
+    }
+    Image(
+        painter = painter,
+        contentDescription = contentDescription
+    )
+}
+
+@Composable
+fun RenderAsyncUrlImage(
+    imageUrl: String, // URL 문자열.
+    contentDescription: String?,
+) {
+    val painter = rememberAsyncImagePainter(
+        model = ImageRequest.Builder(LocalContext.current)
+            .data(imageUrl) // URL을 data 메서드에 전달
             .crossfade(true)
             .build(),
     )

--- a/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/my_page/GetMyPageDataUseCase.kt
+++ b/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/my_page/GetMyPageDataUseCase.kt
@@ -1,0 +1,11 @@
+package online.partyrun.partyrunapplication.core.domain.my_page
+
+import kotlinx.coroutines.flow.first
+import online.partyrun.partyrunapplication.core.data.repository.MemberRepository
+import javax.inject.Inject
+
+class GetMyPageDataUseCase @Inject constructor(
+    private val memberRepository: MemberRepository
+) {
+    suspend operator fun invoke() = memberRepository.userData.first()
+}

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageScreen.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageScreen.kt
@@ -1,6 +1,5 @@
 package online.partyrun.partyrunapplication.feature.my_page
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -15,11 +14,13 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -31,13 +32,58 @@ import androidx.compose.ui.unit.max
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import online.partyrun.partyrunapplication.core.designsystem.component.RenderAsyncUrlImage
 import online.partyrun.partyrunapplication.core.designsystem.icon.PartyRunIcons
+import online.partyrun.partyrunapplication.core.model.user.User
 import online.partyrun.partyrunapplication.core.ui.ProfileSection
 
 @Composable
 fun MyPageScreen(
-    viewModel: MyPageViewModel = hiltViewModel(),
+    myPageViewModel: MyPageViewModel = hiltViewModel(),
     onSignOut: () -> Unit = {}
+) {
+    val myPageUiState by myPageViewModel.myPageUiState.collectAsStateWithLifecycle()
+
+    Content(
+        myPageViewModel = myPageViewModel,
+        myPageUiState = myPageUiState,
+        onSignOut = onSignOut
+    )
+}
+
+@Composable
+fun Content(
+    modifier: Modifier = Modifier,
+    myPageViewModel: MyPageViewModel,
+    myPageUiState: MyPageUiState,
+    onSignOut: () -> Unit
+) {
+    Box(modifier = modifier) {
+        when (myPageUiState) {
+            is MyPageUiState.Loading -> LoadingBody()
+            is MyPageUiState.Success -> MyPageBody(viewModel = myPageViewModel, onSignOut = onSignOut, userData = myPageUiState.user)
+            is MyPageUiState.LoadFailed -> LoadingBody()
+        }
+    }
+}
+
+@Composable
+private fun LoadingBody() {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+private fun MyPageBody(
+    viewModel: MyPageViewModel,
+    onSignOut: () -> Unit,
+    userData: User
 ) {
     Column(
         modifier = Modifier
@@ -56,7 +102,8 @@ fun MyPageScreen(
                 .heightIn(max = max(270.dp, with(LocalDensity.current) { 200.sp.toDp() }))
         ) {
             ProfileContent(
-                userName = "TEST"
+                userName = userData.name,
+                userProfile = userData.profile
             )
         }
 
@@ -88,7 +135,8 @@ private fun TopAppTitle(
 }
 @Composable
 private fun ProfileContent(
-    userName: String
+    userName: String,
+    userProfile: String
 ) {
     Column(
         verticalArrangement = Arrangement.Center,
@@ -97,7 +145,9 @@ private fun ProfileContent(
         ProfileHeader(
             userName = userName
         )
-        ProfileImage()
+        ProfileImage(
+            userProfile = userProfile
+        )
     }
 }
 
@@ -137,7 +187,9 @@ private fun ProfileHeader(
 }
 
 @Composable
-private fun ProfileImage() {
+private fun ProfileImage(
+    userProfile: String
+) {
     Box(
         contentAlignment = Alignment.Center,
         modifier = Modifier
@@ -145,9 +197,9 @@ private fun ProfileImage() {
             .clip(CircleShape)
             .zIndex(1f)
     ) {
-        Image(
-            painter = painterResource(id = R.drawable.mock_img),
-            contentDescription = stringResource(id = R.string.profile_img_desc)
+        RenderAsyncUrlImage(
+            imageUrl = userProfile,
+            contentDescription = null
         )
     }
 }

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageUiState.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageUiState.kt
@@ -1,0 +1,17 @@
+package online.partyrun.partyrunapplication.feature.my_page
+
+import online.partyrun.partyrunapplication.core.model.user.User
+
+sealed class MyPageUiState {
+    object Loading : MyPageUiState()
+
+    data class Success(
+        val user: User = User(
+            id = "",
+            name = "",
+            profile = ""
+        )
+    ) : MyPageUiState()
+
+    object LoadFailed : MyPageUiState()
+}

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageViewModel.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageViewModel.kt
@@ -3,16 +3,36 @@ package online.partyrun.partyrunapplication.feature.my_page
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import online.partyrun.partyrunapplication.core.domain.agreement.SaveAgreementStateUseCase
 import online.partyrun.partyrunapplication.core.domain.auth.GoogleSignOutUseCase
+import online.partyrun.partyrunapplication.core.domain.my_page.GetMyPageDataUseCase
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
 class MyPageViewModel @Inject constructor(
     private val googleSignOutUseCase: GoogleSignOutUseCase,
-    private val saveAgreementUseCase: SaveAgreementStateUseCase
+    private val saveAgreementUseCase: SaveAgreementStateUseCase,
+    private val getMyPageDataUseCase: GetMyPageDataUseCase
 ): ViewModel() {
+
+    private val _myPageUiState = MutableStateFlow<MyPageUiState>(MyPageUiState.Loading)
+    val myPageUiState = _myPageUiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            try {
+                val user = getMyPageDataUseCase()
+                _myPageUiState.value = MyPageUiState.Success(user = user)
+            } catch (e: Exception) {
+                Timber.e(e)
+            }
+        }
+    }
+
     fun signOutFromGoogle() = viewModelScope.launch {
         googleSignOutUseCase()
     }


### PR DESCRIPTION
## Description
마이페이지 스크린에서 유저 닉네임과 유저 프로필 이미지를 볼 수 있어야 한다.
마이페이지를 바텀네비게이션바에서 클릭했을 때 정상적으로 Datastore protobuf에서 유저정보를 불러와 렌더링이 되어 정보 확인이 가능해야 한다.

## Implementation
![image](https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/a29eb1e6-5b15-4959-9aa7-c8ddbc701c9a)
