### PR TITLE
#PAR-267  : 매칭 과정에서 러너 정보를 가져온 뒤 저장하고 성공 시 매칭 방 번호를 서버로부터 받아오는 과정 수행 

### DIFF
--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/di/DataModule.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/di/DataModule.kt
@@ -14,8 +14,8 @@ import online.partyrun.partyrunapplication.core.data.repository.BattleRepository
 import online.partyrun.partyrunapplication.core.data.repository.BattleRepositoryImpl
 import online.partyrun.partyrunapplication.core.data.repository.GoogleAuthRepository
 import online.partyrun.partyrunapplication.core.data.repository.GoogleAuthRepositoryImpl
-import online.partyrun.partyrunapplication.core.data.repository.RunningResultRepository
-import online.partyrun.partyrunapplication.core.data.repository.RunningResultRepositoryImpl
+import online.partyrun.partyrunapplication.core.data.repository.ResultRepository
+import online.partyrun.partyrunapplication.core.data.repository.ResultRepositoryImpl
 import online.partyrun.partyrunapplication.core.data.repository.TokenRepository
 import online.partyrun.partyrunapplication.core.data.repository.TokenRepositoryImpl
 import online.partyrun.partyrunapplication.core.data.repository.MemberRepository
@@ -67,9 +67,9 @@ internal interface DataModule {
 
     @Singleton
     @Binds
-    fun bindRunningResultRepository (
-        runningResultRepository: RunningResultRepositoryImpl
-    ): RunningResultRepository
+    fun bindResultRepository (
+        resultRepository: ResultRepositoryImpl
+    ): ResultRepository
 
     @Singleton
     @Binds

--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/BattleRepository.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/BattleRepository.kt
@@ -1,10 +1,18 @@
 package online.partyrun.partyrunapplication.core.data.repository
 
 import kotlinx.coroutines.flow.Flow
+import online.partyrun.partyrunapplication.core.common.network.ApiResponse
+import online.partyrun.partyrunapplication.core.model.battle.BattleStatus
 import online.partyrun.partyrunapplication.core.model.running.BattleEvent
 import online.partyrun.partyrunapplication.core.model.running.RecordData
 
 interface BattleRepository {
+
+    val battleData: Flow<BattleStatus>
+
+    suspend fun setBattleId(battleId: String)
+
+    suspend fun getBattleId(): Flow<ApiResponse<String>>
     fun getBattleStream(battleId: String): Flow<BattleEvent>
     suspend fun sendRecordData(battleId: String, recordData: RecordData)
     suspend fun close()

--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/BattleRepository.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/BattleRepository.kt
@@ -2,6 +2,7 @@ package online.partyrun.partyrunapplication.core.data.repository
 
 import kotlinx.coroutines.flow.Flow
 import online.partyrun.partyrunapplication.core.common.network.ApiResponse
+import online.partyrun.partyrunapplication.core.model.battle.BattleId
 import online.partyrun.partyrunapplication.core.model.battle.BattleStatus
 import online.partyrun.partyrunapplication.core.model.running.BattleEvent
 import online.partyrun.partyrunapplication.core.model.running.RecordData
@@ -12,7 +13,7 @@ interface BattleRepository {
 
     suspend fun setBattleId(battleId: String)
 
-    suspend fun getBattleId(): Flow<ApiResponse<String>>
+    suspend fun getBattleId(): Flow<ApiResponse<BattleId>>
     fun getBattleStream(battleId: String): Flow<BattleEvent>
     suspend fun sendRecordData(battleId: String, recordData: RecordData)
     suspend fun close()

--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/BattleRepositoryImpl.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/BattleRepositoryImpl.kt
@@ -5,12 +5,14 @@ import kotlinx.coroutines.flow.map
 import online.partyrun.partyrunapplication.core.common.network.ApiResponse
 import online.partyrun.partyrunapplication.core.common.network.apiRequestFlow
 import online.partyrun.partyrunapplication.core.datastore.datasource.BattlePreferencesDataSource
+import online.partyrun.partyrunapplication.core.model.battle.BattleId
 import online.partyrun.partyrunapplication.core.model.battle.BattleStatus
 import online.partyrun.partyrunapplication.core.model.running.BattleEvent
 import online.partyrun.partyrunapplication.core.model.running.RecordData
 import online.partyrun.partyrunapplication.core.network.RealtimeBattleClient
 import online.partyrun.partyrunapplication.core.network.datasource.BattleDataSource
 import online.partyrun.partyrunapplication.core.network.model.request.toRequestModel
+import online.partyrun.partyrunapplication.core.network.model.response.toDomainModel
 import online.partyrun.partyrunapplication.core.network.model.toDomainModel
 import javax.inject.Inject
 
@@ -27,12 +29,12 @@ class BattleRepositoryImpl @Inject constructor(
         battlePreferencesDataSource.setBattleId(battleId)
     }
 
-    override suspend fun getBattleId(): Flow<ApiResponse<String>> {
+    override suspend fun getBattleId(): Flow<ApiResponse<BattleId>> {
         return apiRequestFlow { battleDataSource.getBattleId() }
             .map { apiResponse ->
                 when (apiResponse) {
                     is ApiResponse.Loading -> ApiResponse.Loading
-                    is ApiResponse.Success -> ApiResponse.Success(apiResponse.data)
+                    is ApiResponse.Success -> ApiResponse.Success(apiResponse.data.toDomainModel())
                     is ApiResponse.Failure -> ApiResponse.Failure(
                         apiResponse.errorMessage,
                         apiResponse.code

--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/BattleRepositoryImpl.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/BattleRepositoryImpl.kt
@@ -2,16 +2,44 @@ package online.partyrun.partyrunapplication.core.data.repository
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import online.partyrun.partyrunapplication.core.common.network.ApiResponse
+import online.partyrun.partyrunapplication.core.common.network.apiRequestFlow
+import online.partyrun.partyrunapplication.core.datastore.datasource.BattlePreferencesDataSource
+import online.partyrun.partyrunapplication.core.model.battle.BattleStatus
 import online.partyrun.partyrunapplication.core.model.running.BattleEvent
 import online.partyrun.partyrunapplication.core.model.running.RecordData
 import online.partyrun.partyrunapplication.core.network.RealtimeBattleClient
+import online.partyrun.partyrunapplication.core.network.datasource.BattleDataSource
 import online.partyrun.partyrunapplication.core.network.model.request.toRequestModel
 import online.partyrun.partyrunapplication.core.network.model.toDomainModel
 import javax.inject.Inject
 
 class BattleRepositoryImpl @Inject constructor(
-    private val realtimeBattleClient: RealtimeBattleClient
-) : BattleRepository {
+    private val realtimeBattleClient: RealtimeBattleClient,
+    private val battleDataSource: BattleDataSource,
+    private val battlePreferencesDataSource: BattlePreferencesDataSource
+    ) : BattleRepository {
+
+    override val battleData: Flow<BattleStatus> =
+        battlePreferencesDataSource.battleData
+
+    override suspend fun setBattleId(battleId: String) {
+        battlePreferencesDataSource.setBattleId(battleId)
+    }
+
+    override suspend fun getBattleId(): Flow<ApiResponse<String>> {
+        return apiRequestFlow { battleDataSource.getBattleId() }
+            .map { apiResponse ->
+                when (apiResponse) {
+                    is ApiResponse.Loading -> ApiResponse.Loading
+                    is ApiResponse.Success -> ApiResponse.Success(apiResponse.data)
+                    is ApiResponse.Failure -> ApiResponse.Failure(
+                        apiResponse.errorMessage,
+                        apiResponse.code
+                    )
+                }
+            }
+    }
 
     override fun getBattleStream(battleId: String) : Flow<BattleEvent> =
         realtimeBattleClient.getBattleStream(battleId).map { it.toDomainModel() }

--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/MatchRepository.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/MatchRepository.kt
@@ -6,14 +6,20 @@ import okhttp3.sse.EventSourceListener
 import online.partyrun.partyrunapplication.core.common.network.ApiResponse
 import online.partyrun.partyrunapplication.core.model.match.MatchDecision
 import online.partyrun.partyrunapplication.core.model.match.MatchStatus
+import online.partyrun.partyrunapplication.core.model.match.RunnerIds
+import online.partyrun.partyrunapplication.core.model.match.RunnerInfoData
 import online.partyrun.partyrunapplication.core.model.match.RunningDistance
 
 interface MatchRepository {
+
+    suspend fun setRunners(runners: RunnerInfoData)
+
 
     /* REST */
     suspend fun registerMatch(runningDistance: RunningDistance): Flow<ApiResponse<MatchStatus>>
     suspend fun acceptMatch(matchDecision: MatchDecision): Flow<ApiResponse<MatchStatus>>
     suspend fun declineMatch(matchDecision: MatchDecision): Flow<ApiResponse<MatchStatus>>
+    suspend fun getRunnerIds(): Flow<ApiResponse<RunnerIds>>
 
     /* SSE */
     fun createMatchEventSourceListener(onEvent: (data: String) -> Unit, onClosed: () -> Unit, onFailure: () -> Unit): EventSourceListener

--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/MemberRepository.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/MemberRepository.kt
@@ -2,11 +2,15 @@ package online.partyrun.partyrunapplication.core.data.repository
 
 import kotlinx.coroutines.flow.Flow
 import online.partyrun.partyrunapplication.core.common.network.ApiResponse
+import online.partyrun.partyrunapplication.core.model.match.RunnerIds
+import online.partyrun.partyrunapplication.core.model.match.RunnerInfoData
 import online.partyrun.partyrunapplication.core.model.user.User
 
 interface MemberRepository {
 
     val userData: Flow<User>
+
+    suspend fun getRunnersInfo(runnerIds: RunnerIds): Flow<ApiResponse<RunnerInfoData>>
 
     suspend fun getUserData(): Flow<ApiResponse<User>>
 

--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/ResultRepository.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/ResultRepository.kt
@@ -4,6 +4,6 @@ import kotlinx.coroutines.flow.Flow
 import online.partyrun.partyrunapplication.core.common.network.ApiResponse
 import online.partyrun.partyrunapplication.core.model.running_result.BattleResult
 
-interface RunningResultRepository {
-    suspend fun getBattleResults(battleId: String): Flow<ApiResponse<BattleResult>>
+interface ResultRepository {
+    suspend fun getBattleResults(): Flow<ApiResponse<BattleResult>>
 }

--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/ResultRepositoryImpl.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/ResultRepositoryImpl.kt
@@ -1,21 +1,26 @@
 package online.partyrun.partyrunapplication.core.data.repository
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import online.partyrun.partyrunapplication.core.common.network.ApiResponse
 import online.partyrun.partyrunapplication.core.common.network.apiRequestFlow
+import online.partyrun.partyrunapplication.core.datastore.datasource.BattlePreferencesDataSource
 import online.partyrun.partyrunapplication.core.model.running_result.BattleResult
-import online.partyrun.partyrunapplication.core.network.datasource.RunningResultDataSource
+import online.partyrun.partyrunapplication.core.network.datasource.ResultDataSource
 import online.partyrun.partyrunapplication.core.network.model.response.toDomainModel
 import javax.inject.Inject
 
-class RunningResultRepositoryImpl @Inject constructor(
-    private val runningResultDataSource: RunningResultDataSource
-) : RunningResultRepository {
+class ResultRepositoryImpl @Inject constructor(
+    private val resultDataSource: ResultDataSource,
+    private val battlePreferencesDataSource: BattlePreferencesDataSource
+) : ResultRepository {
 
-    override suspend fun getBattleResults(battleId: String): Flow<ApiResponse<BattleResult>> {
-        return apiRequestFlow { runningResultDataSource.getBattleResults(battleId) }
-            .map { apiResponse ->
+    override suspend fun getBattleResults(): Flow<ApiResponse<BattleResult>> {
+        return apiRequestFlow {
+            val battleId = battlePreferencesDataSource.battleData.first().battleId
+            resultDataSource.getBattleResults(battleId)
+        }.map { apiResponse ->
                 when (apiResponse) {
                     is ApiResponse.Loading -> ApiResponse.Loading
                     is ApiResponse.Success -> ApiResponse.Success(apiResponse.data.toDomainModel())

--- a/core/datastore/src/main/java/online/partyrun/partyrunapplication/core/datastore/BattlePreferencesSerializer.kt
+++ b/core/datastore/src/main/java/online/partyrun/partyrunapplication/core/datastore/BattlePreferencesSerializer.kt
@@ -1,0 +1,25 @@
+package online.partyrun.partyrunapplication.core.datastore
+
+import androidx.datastore.core.CorruptionException
+import androidx.datastore.core.Serializer
+import androidx.datastore.preferences.protobuf.InvalidProtocolBufferException
+import java.io.InputStream
+import java.io.OutputStream
+import javax.inject.Inject
+
+class BattlePreferencesSerializer @Inject constructor() : Serializer<BattlePreferences> {
+
+    override val defaultValue: BattlePreferences = BattlePreferences.getDefaultInstance()
+
+    override suspend fun readFrom(input: InputStream): BattlePreferences =
+        try {
+            BattlePreferences.parseFrom(input)
+        } catch (exception: InvalidProtocolBufferException) {
+            throw CorruptionException("Cannot read proto.", exception)
+        }
+
+    override suspend fun writeTo(t: BattlePreferences, output: OutputStream) {
+        t.writeTo(output)
+    }
+
+}

--- a/core/datastore/src/main/java/online/partyrun/partyrunapplication/core/datastore/datasource/BattlePreferencesDataSource.kt
+++ b/core/datastore/src/main/java/online/partyrun/partyrunapplication/core/datastore/datasource/BattlePreferencesDataSource.kt
@@ -1,0 +1,52 @@
+package online.partyrun.partyrunapplication.core.datastore.datasource
+
+import androidx.datastore.core.DataStore
+import kotlinx.coroutines.flow.map
+import online.partyrun.partyrunapplication.core.datastore.BattlePreferences
+import online.partyrun.partyrunapplication.core.datastore.BattleRunner
+import online.partyrun.partyrunapplication.core.model.battle.BattleStatus
+import online.partyrun.partyrunapplication.core.model.battle.RunnerStatus
+import online.partyrun.partyrunapplication.core.model.match.RunnerInfoData
+import javax.inject.Inject
+
+class BattlePreferencesDataSource @Inject constructor(
+    private val battlePreferences: DataStore<BattlePreferences>
+) {
+    // 매핑을 통해 필요한 대결 멤버 데이터 생성
+    val battleData = battlePreferences.data
+        .map { preferences ->
+            BattleStatus(
+                battleId = preferences.battleId,
+                battleInfo = preferences.runnersList.map {
+                    RunnerStatus(
+                        runnerId = it.id,
+                        runnerName = it.name,
+                        runnerProfile = it.profile
+                    )
+                }
+            )
+        }
+
+    suspend fun setRunners(runnerInfoData: RunnerInfoData) {
+        battlePreferences.updateData { currentPreferences ->
+            currentPreferences.toBuilder()
+                .clearRunners()
+                .addAllRunners(runnerInfoData.runners.map {
+                    BattleRunner.newBuilder()
+                        .setId(it.id)
+                        .setName(it.name)
+                        .setProfile(it.profile)
+                        .build()
+                })
+                .build()
+        }
+    }
+
+    suspend fun setBattleId(battleId: String) {
+        battlePreferences.updateData { currentPreferences ->
+            currentPreferences.toBuilder()
+                .setBattleId(battleId)
+                .build()
+        }
+    }
+}

--- a/core/datastore/src/main/java/online/partyrun/partyrunapplication/core/datastore/di/DataStoreModule.kt
+++ b/core/datastore/src/main/java/online/partyrun/partyrunapplication/core/datastore/di/DataStoreModule.kt
@@ -20,6 +20,8 @@ import online.partyrun.partyrunapplication.core.datastore.datasource.TokenDataSo
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import online.partyrun.partyrunapplication.core.datastore.BattlePreferences
+import online.partyrun.partyrunapplication.core.datastore.BattlePreferencesSerializer
 import online.partyrun.partyrunapplication.core.datastore.UserPreferences
 import online.partyrun.partyrunapplication.core.datastore.UserPreferencesSerializer
 import online.partyrun.partyrunapplication.core.datastore.datasource.AgreementDataSource
@@ -46,6 +48,20 @@ object DataStoreModule {
             corruptionHandler = null
         ) {
             context.dataStoreFile("user_preferences.pb")
+        }
+
+    @Provides
+    @Singleton
+    fun providesBattlePreferencesDataStore(
+        @ApplicationContext context: Context,
+        battlePreferencesSerializer: BattlePreferencesSerializer,
+    ): DataStore<BattlePreferences> =
+        DataStoreFactory.create(
+            serializer = battlePreferencesSerializer,
+            scope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
+            corruptionHandler = null
+        ) {
+            context.dataStoreFile("battle_preferences.pb")
         }
 
     @Singleton

--- a/core/datastore/src/main/proto/battle_preferences.proto
+++ b/core/datastore/src/main/proto/battle_preferences.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+option java_package = "online.partyrun.partyrunapplication.core.datastore";
+option java_multiple_files = true;
+
+message BattleRunner {
+  string id = 1;
+  string name = 2;
+  string profile = 3;
+}
+
+message BattlePreferences {
+  string battleId = 1;
+  repeated BattleRunner runners = 2;
+}

--- a/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/match/GetRunnerIdsUseCase.kt
+++ b/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/match/GetRunnerIdsUseCase.kt
@@ -1,0 +1,14 @@
+package online.partyrun.partyrunapplication.core.domain.match
+
+import kotlinx.coroutines.flow.Flow
+import online.partyrun.partyrunapplication.core.common.network.ApiResponse
+import online.partyrun.partyrunapplication.core.data.repository.MatchRepository
+import online.partyrun.partyrunapplication.core.model.match.RunnerIds
+import javax.inject.Inject
+
+class GetRunnerIdsUseCase @Inject constructor(
+    private val matchRepository: MatchRepository
+) {
+    suspend operator fun invoke(): Flow<ApiResponse<RunnerIds>> =
+        matchRepository.getRunnerIds()
+}

--- a/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/match/GetRunnersInfoUseCase.kt
+++ b/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/match/GetRunnersInfoUseCase.kt
@@ -1,0 +1,16 @@
+package online.partyrun.partyrunapplication.core.domain.match
+
+import kotlinx.coroutines.flow.Flow
+import online.partyrun.partyrunapplication.core.common.network.ApiResponse
+import online.partyrun.partyrunapplication.core.data.repository.MemberRepository
+import online.partyrun.partyrunapplication.core.model.match.RunnerIds
+import online.partyrun.partyrunapplication.core.model.match.RunnerInfoData
+import javax.inject.Inject
+
+class GetRunnersInfoUseCase @Inject constructor(
+    private val memberRepository: MemberRepository
+) {
+    suspend operator fun invoke(runnerIds: RunnerIds): Flow<ApiResponse<RunnerInfoData>> =
+        memberRepository.getRunnersInfo(runnerIds)
+
+}

--- a/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/match/SaveRunnersInfoUseCase.kt
+++ b/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/match/SaveRunnersInfoUseCase.kt
@@ -1,0 +1,14 @@
+package online.partyrun.partyrunapplication.core.domain.match
+
+import online.partyrun.partyrunapplication.core.data.repository.MatchRepository
+import online.partyrun.partyrunapplication.core.model.match.RunnerInfoData
+import javax.inject.Inject
+
+class SaveRunnersInfoUseCase @Inject constructor(
+    private val matchRepository: MatchRepository
+) {
+    suspend operator fun invoke(runnerInfoData: RunnerInfoData) {
+        matchRepository.setRunners(runnerInfoData)
+    }
+
+}

--- a/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/running/GetBattleIdUseCase.kt
+++ b/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/running/GetBattleIdUseCase.kt
@@ -1,0 +1,13 @@
+package online.partyrun.partyrunapplication.core.domain.running
+
+import kotlinx.coroutines.flow.Flow
+import online.partyrun.partyrunapplication.core.common.network.ApiResponse
+import online.partyrun.partyrunapplication.core.data.repository.BattleRepository
+import javax.inject.Inject
+
+class GetBattleIdUseCase @Inject constructor(
+    private val battleRepository: BattleRepository
+) {
+    suspend operator fun invoke(): Flow<ApiResponse<String>> =
+        battleRepository.getBattleId()
+}

--- a/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/running/GetBattleIdUseCase.kt
+++ b/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/running/GetBattleIdUseCase.kt
@@ -3,11 +3,12 @@ package online.partyrun.partyrunapplication.core.domain.running
 import kotlinx.coroutines.flow.Flow
 import online.partyrun.partyrunapplication.core.common.network.ApiResponse
 import online.partyrun.partyrunapplication.core.data.repository.BattleRepository
+import online.partyrun.partyrunapplication.core.model.battle.BattleId
 import javax.inject.Inject
 
 class GetBattleIdUseCase @Inject constructor(
     private val battleRepository: BattleRepository
 ) {
-    suspend operator fun invoke(): Flow<ApiResponse<String>> =
+    suspend operator fun invoke(): Flow<ApiResponse<BattleId>> =
         battleRepository.getBattleId()
 }

--- a/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/running/GetBattleStatusUseCase.kt
+++ b/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/running/GetBattleStatusUseCase.kt
@@ -1,0 +1,12 @@
+package online.partyrun.partyrunapplication.core.domain.running
+
+import kotlinx.coroutines.flow.first
+import online.partyrun.partyrunapplication.core.data.repository.BattleRepository
+import javax.inject.Inject
+
+class GetBattleStatusUseCase @Inject constructor(
+    private val battleRepository: BattleRepository
+) {
+    suspend operator fun invoke() = battleRepository.battleData.first()
+
+}

--- a/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/running/SaveBattleIdUseCase.kt
+++ b/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/running/SaveBattleIdUseCase.kt
@@ -1,0 +1,12 @@
+package online.partyrun.partyrunapplication.core.domain.running
+
+import online.partyrun.partyrunapplication.core.data.repository.BattleRepository
+import javax.inject.Inject
+
+class SaveBattleIdUseCase @Inject constructor(
+    private val battleRepository: BattleRepository
+) {
+    suspend operator fun invoke(battleId: String) {
+        battleRepository.setBattleId(battleId)
+    }
+}

--- a/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/running_result/GetBattleResultUseCase.kt
+++ b/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/running_result/GetBattleResultUseCase.kt
@@ -2,13 +2,13 @@ package online.partyrun.partyrunapplication.core.domain.running_result
 
 import kotlinx.coroutines.flow.Flow
 import online.partyrun.partyrunapplication.core.common.network.ApiResponse
-import online.partyrun.partyrunapplication.core.data.repository.RunningResultRepository
+import online.partyrun.partyrunapplication.core.data.repository.ResultRepository
 import online.partyrun.partyrunapplication.core.model.running_result.BattleResult
 import javax.inject.Inject
 
 class GetBattleResultUseCase @Inject constructor(
-    private val runningResultRepository: RunningResultRepository
+    private val resultRepository: ResultRepository
 ) {
-    suspend operator fun invoke(battleId: String): Flow<ApiResponse<BattleResult>> =
-        runningResultRepository.getBattleResults(battleId)
+    suspend operator fun invoke(): Flow<ApiResponse<BattleResult>> =
+        resultRepository.getBattleResults()
 }

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/battle/BattleId.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/battle/BattleId.kt
@@ -1,0 +1,5 @@
+package online.partyrun.partyrunapplication.core.model.battle
+
+data class BattleId(
+    val id: String
+)

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/battle/BattleStatus.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/battle/BattleStatus.kt
@@ -1,5 +1,6 @@
 package online.partyrun.partyrunapplication.core.model.battle
 
 data class BattleStatus(
+    val battleId: String = "",
     val battleInfo: List<RunnerStatus> = emptyList()
 )

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/battle/RunnerIds.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/battle/RunnerIds.kt
@@ -1,5 +1,0 @@
-package online.partyrun.partyrunapplication.core.model.battle
-
-data class RunnerIds(
-    val runnerIdData: List<String> = emptyList()
-)

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/battle/RunnerStatus.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/battle/RunnerStatus.kt
@@ -3,6 +3,7 @@ package online.partyrun.partyrunapplication.core.model.battle
 data class RunnerStatus (
     val runnerId: String,
     val runnerName: String = "",
+    val runnerProfile: String = "",
     val distance: Double = 0.0,
     val currentRank: Int = 0,
     val currentRound: Int = 0,

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/match/MatchMember.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/match/MatchMember.kt
@@ -1,6 +1,6 @@
 package online.partyrun.partyrunapplication.core.model.match
 
-enum class PlayerStatus {
+enum class RunnerStatus {
     NO_RESPONSE,
     READY,
     CANCELED,

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/match/RunnerIds.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/match/RunnerIds.kt
@@ -1,0 +1,5 @@
+package online.partyrun.partyrunapplication.core.model.match
+
+data class RunnerIds(
+    val runnerIds: List<String> = emptyList()
+)

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/match/RunnerInfo.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/match/RunnerInfo.kt
@@ -1,0 +1,7 @@
+package online.partyrun.partyrunapplication.core.model.match
+
+data class RunnerInfo(
+    val id: String,
+    val name: String,
+    val profile: String
+)

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/match/RunnerInfoData.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/match/RunnerInfoData.kt
@@ -1,0 +1,5 @@
+package online.partyrun.partyrunapplication.core.model.match
+
+data class RunnerInfoData(
+    val runners: List<RunnerInfo>
+)

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/running_result/BattleRunnerStatus.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/running_result/BattleRunnerStatus.kt
@@ -3,6 +3,8 @@ package online.partyrun.partyrunapplication.core.model.running_result
 data class BattleRunnerStatus(
     val endTime: String = "",
     val id: String = "", // userId
+    val name: String = "",
+    val profile: String = "",
     val rank: Int = 0,
     val elapsedTime: String = "" // 총 달린 시간
 )

--- a/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/battle/BattleNavigation.kt
+++ b/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/battle/BattleNavigation.kt
@@ -6,11 +6,11 @@ import online.partyrun.partyrunapplication.core.navigation.main.MainNavRoutes
 import online.partyrun.partyrunapplication.feature.battle.BattleMainScreen
 
 fun NavGraphBuilder.battleRoute(
-    navigateToBattleRunningWithArgs: (String, String) -> Unit
+    navigateToBattleRunning: () -> Unit
 ) {
     composable(route = MainNavRoutes.Battle.route) {
         BattleMainScreen(
-            navigateToBattleRunningWithArgs = navigateToBattleRunningWithArgs
+            navigateToBattleRunning = navigateToBattleRunning
         )
     }
 }

--- a/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/battle_running/BattleRunningNavigation.kt
+++ b/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/battle_running/BattleRunningNavigation.kt
@@ -1,50 +1,20 @@
 package online.partyrun.partyrunapplication.core.navigation.battle_running
 
 import androidx.navigation.NavGraphBuilder
-import androidx.navigation.NavType
 import androidx.navigation.compose.composable
-import androidx.navigation.navArgument
-import com.google.gson.Gson
-import online.partyrun.partyrunapplication.core.model.battle.RunnerIds
 import online.partyrun.partyrunapplication.core.navigation.main.MainNavRoutes
 import online.partyrun.partyrunapplication.feature.running.battle.BattleContentScreen
-import java.net.URLDecoder
-
-private const val ARG_BATTLE_ID = "battleId"
-private const val ARG_RUNNER_IDS_JSON = "runnerIdsJson"
-private const val DEFAULT_VALUE = ""
 
 fun NavGraphBuilder.battleRunningRoute(
     navigateToBattleOnWebSocketError: () -> Unit,
     navigationToRunningResult: () -> Unit
 ) {
     composable(
-        route = "${MainNavRoutes.BattleRunning.route}?battleId={$ARG_BATTLE_ID}&runnerIdsJson={$ARG_RUNNER_IDS_JSON}",
-        arguments = listOf(
-            navArgument(ARG_BATTLE_ID) {
-                type = NavType.StringType
-                defaultValue = DEFAULT_VALUE
-            },
-            navArgument(ARG_RUNNER_IDS_JSON) {
-                type = NavType.StringType
-                defaultValue = DEFAULT_VALUE
-            }
-        )
-    ) { backStackEntry ->
-        val battleId = backStackEntry.arguments?.getString(ARG_BATTLE_ID)
-        val runnerIdsJson = backStackEntry.arguments?.getString(ARG_RUNNER_IDS_JSON) ?: DEFAULT_VALUE
-        val decodedRunnerIds = runnerIdsJson.let {
-            URLDecoder.decode(it, "UTF-8")
-        }
-        val runnerIds = decodedRunnerIds?.let {
-            Gson().fromJson(it, RunnerIds::class.java)
-        } ?: RunnerIds(emptyList())
-
+        route = MainNavRoutes.BattleRunning.route,
+    ) {
         BattleContentScreen(
             navigateToBattleOnWebSocketError = navigateToBattleOnWebSocketError,
             navigationToRunningResult = navigationToRunningResult,
-            battleId = battleId,
-            runnerIds = runnerIds
         )
     }
 }

--- a/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/main/MainNavGraph.kt
+++ b/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/main/MainNavGraph.kt
@@ -31,8 +31,10 @@ fun SetUpMainNavGraph(
         startDestination = startDestination,
     ) {
         battleRoute(
-            navigateToBattleRunningWithArgs = { battleId, runnerIdsJson ->
-                navController.navigate("${MainNavRoutes.BattleRunning.route}?battleId=$battleId&runnerIdsJson=$runnerIdsJson")
+            navigateToBattleRunning = {
+                navController.navigate(MainNavRoutes.BattleRunning.route) {
+                    popUpTo(MainNavRoutes.BattleRunning.route)
+                }
             }
         )
 

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/BattleDataSource.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/BattleDataSource.kt
@@ -1,7 +1,8 @@
 package online.partyrun.partyrunapplication.core.network.datasource
 
 import online.partyrun.partyrunapplication.core.common.network.ApiResult
+import online.partyrun.partyrunapplication.core.network.model.response.BattleIdResponse
 
 interface BattleDataSource {
-    suspend fun getBattleId(): ApiResult<String>
+    suspend fun getBattleId(): ApiResult<BattleIdResponse>
 }

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/BattleDataSource.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/BattleDataSource.kt
@@ -1,0 +1,7 @@
+package online.partyrun.partyrunapplication.core.network.datasource
+
+import online.partyrun.partyrunapplication.core.common.network.ApiResult
+
+interface BattleDataSource {
+    suspend fun getBattleId(): ApiResult<String>
+}

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/BattleDataSourceImpl.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/BattleDataSourceImpl.kt
@@ -1,0 +1,13 @@
+package online.partyrun.partyrunapplication.core.network.datasource
+
+import online.partyrun.partyrunapplication.core.common.network.ApiResult
+import online.partyrun.partyrunapplication.core.network.service.BattleApiService
+import javax.inject.Inject
+
+class BattleDataSourceImpl @Inject constructor(
+    private val battleApi: BattleApiService
+) : BattleDataSource {
+    override suspend fun getBattleId(): ApiResult<String> =
+        battleApi.getBattleId()
+
+}

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/BattleDataSourceImpl.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/BattleDataSourceImpl.kt
@@ -1,13 +1,14 @@
 package online.partyrun.partyrunapplication.core.network.datasource
 
 import online.partyrun.partyrunapplication.core.common.network.ApiResult
+import online.partyrun.partyrunapplication.core.network.model.response.BattleIdResponse
 import online.partyrun.partyrunapplication.core.network.service.BattleApiService
 import javax.inject.Inject
 
 class BattleDataSourceImpl @Inject constructor(
     private val battleApi: BattleApiService
 ) : BattleDataSource {
-    override suspend fun getBattleId(): ApiResult<String> =
+    override suspend fun getBattleId(): ApiResult<BattleIdResponse> =
         battleApi.getBattleId()
 
 }

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/MatchDataSource.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/MatchDataSource.kt
@@ -6,12 +6,14 @@ import online.partyrun.partyrunapplication.core.common.network.ApiResult
 import online.partyrun.partyrunapplication.core.network.model.request.MatchDecisionRequest
 import online.partyrun.partyrunapplication.core.network.model.response.MatchStatusResponse
 import online.partyrun.partyrunapplication.core.network.model.request.RunningDistanceRequest
+import online.partyrun.partyrunapplication.core.network.model.response.MatchInfoResponse
 
 interface MatchDataSource {
 
     suspend fun registerMatch(runningDistanceRequest: RunningDistanceRequest): ApiResult<MatchStatusResponse>
     suspend fun acceptMatch(matchDecisionRequest: MatchDecisionRequest): ApiResult<MatchStatusResponse>
     suspend fun declineMatch(matchDecisionRequest: MatchDecisionRequest): ApiResult<MatchStatusResponse>
+    suspend fun getRunnerIds(): ApiResult<MatchInfoResponse>
 
     fun createMatchEventSourceListener(onEvent: (data: String) -> Unit, onClosed: () -> Unit, onFailure: () -> Unit): EventSourceListener
     fun createEventSource(url: String, listener: EventSourceListener): EventSource

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/MatchDataSourceImpl.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/MatchDataSourceImpl.kt
@@ -12,6 +12,8 @@ import online.partyrun.partyrunapplication.core.network.model.response.MatchStat
 import online.partyrun.partyrunapplication.core.network.di.SSEOkHttpClient
 import online.partyrun.partyrunapplication.core.network.di.SSERequestBuilder
 import online.partyrun.partyrunapplication.core.network.model.request.RunningDistanceRequest
+import online.partyrun.partyrunapplication.core.network.model.response.MatchInfoResponse
+import online.partyrun.partyrunapplication.core.network.service.MatchApiService
 import online.partyrun.partyrunapplication.core.network.service.MatchDecisionApiService
 import online.partyrun.partyrunapplication.core.network.service.WaitingMatchApiService
 import timber.log.Timber
@@ -21,7 +23,8 @@ class MatchDataSourceImpl @Inject constructor(
     @SSEOkHttpClient private val okHttpClient: OkHttpClient,
     @SSERequestBuilder private val request: Request.Builder,
     private val waitingMatchApiService: WaitingMatchApiService,
-    private val matchDecisionApiService: MatchDecisionApiService
+    private val matchDecisionApiService: MatchDecisionApiService,
+    private val matchApiService: MatchApiService
 ) : MatchDataSource {
     private lateinit var matchEventSource: EventSource
     private lateinit var matchResultSource: EventSource
@@ -34,6 +37,9 @@ class MatchDataSourceImpl @Inject constructor(
 
     override suspend fun declineMatch(matchDecisionRequest: MatchDecisionRequest): ApiResult<MatchStatusResponse> =
         matchDecisionApiService.declineMatch(matchDecisionRequest)
+
+    override suspend fun getRunnerIds(): ApiResult<MatchInfoResponse> =
+        matchApiService.getRunnerIds()
 
     override fun createMatchEventSourceListener(
         onEvent: (data: String) -> Unit,

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/MemberDataSource.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/MemberDataSource.kt
@@ -1,9 +1,10 @@
 package online.partyrun.partyrunapplication.core.network.datasource
 
 import online.partyrun.partyrunapplication.core.common.network.ApiResult
+import online.partyrun.partyrunapplication.core.network.model.response.BattleMembersInfoResponse
 import online.partyrun.partyrunapplication.core.network.model.response.UserResponse
 
 interface MemberDataSource {
     suspend fun getUserData(): ApiResult<UserResponse>
-
+    suspend fun getRunnersInfo(runnerIds: List<String>): ApiResult<BattleMembersInfoResponse>
 }

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/MemberDataSourceImpl.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/MemberDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package online.partyrun.partyrunapplication.core.network.datasource
 
 import online.partyrun.partyrunapplication.core.common.network.ApiResult
+import online.partyrun.partyrunapplication.core.network.model.response.BattleMembersInfoResponse
 import online.partyrun.partyrunapplication.core.network.model.response.UserResponse
 import online.partyrun.partyrunapplication.core.network.service.MemberApiService
 import javax.inject.Inject
@@ -10,5 +11,8 @@ class MemberDataSourceImpl @Inject constructor(
 ) : MemberDataSource{
     override suspend fun getUserData(): ApiResult<UserResponse> =
         memberApi.getUserData()
+
+    override suspend fun getRunnersInfo(runnerIds: List<String>): ApiResult<BattleMembersInfoResponse> =
+        memberApi.getRunnersInfo(runnerIds)
 
 }

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/ResultDataSource.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/ResultDataSource.kt
@@ -3,6 +3,6 @@ package online.partyrun.partyrunapplication.core.network.datasource
 import online.partyrun.partyrunapplication.core.common.network.ApiResult
 import online.partyrun.partyrunapplication.core.network.model.response.BattleResultResponse
 
-interface RunningResultDataSource {
+interface ResultDataSource {
     suspend fun getBattleResults(battleId: String): ApiResult<BattleResultResponse>
 }

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/ResultDataSourceImpl.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/ResultDataSourceImpl.kt
@@ -2,13 +2,13 @@ package online.partyrun.partyrunapplication.core.network.datasource
 
 import online.partyrun.partyrunapplication.core.common.network.ApiResult
 import online.partyrun.partyrunapplication.core.network.model.response.BattleResultResponse
-import online.partyrun.partyrunapplication.core.network.service.BattleResultApiService
+import online.partyrun.partyrunapplication.core.network.service.ResultApiService
 import javax.inject.Inject
 
-class RunningResultDataSourceImpl @Inject constructor(
-    private val battleResultApi: BattleResultApiService
-) : RunningResultDataSource {
+class ResultDataSourceImpl @Inject constructor(
+    private val resultApi: ResultApiService
+) : ResultDataSource {
     override suspend fun getBattleResults(battleId: String): ApiResult<BattleResultResponse> =
-        battleResultApi.getBattleResults(battleId)
+        resultApi.getBattleResults(battleId)
 
 }

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/di/ApiServiceModule.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/di/ApiServiceModule.kt
@@ -60,6 +60,13 @@ object ApiServiceModule {
             .build()
             .create(MemberApiService::class.java)
 
+    @Provides
+    fun provideBattleApiService(@RESTOkHttpClient okHttpClient: OkHttpClient, retrofit: Retrofit.Builder): BattleApiService =
+        retrofit
+            .client(okHttpClient)
+            .build()
+            .create(BattleApiService::class.java)
+
     @Singleton
     @Provides
     fun provideMatchApiService(@RESTOkHttpClient okHttpClient: OkHttpClient, retrofit: Retrofit.Builder): MatchApiService =

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/di/ApiServiceModule.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/di/ApiServiceModule.kt
@@ -5,9 +5,11 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import okhttp3.OkHttpClient
-import online.partyrun.partyrunapplication.core.network.service.BattleResultApiService
+import online.partyrun.partyrunapplication.core.network.service.ResultApiService
 import online.partyrun.partyrunapplication.core.network.service.MatchDecisionApiService
 import online.partyrun.partyrunapplication.core.network.service.MemberApiService
+import online.partyrun.partyrunapplication.core.network.service.BattleApiService
+import online.partyrun.partyrunapplication.core.network.service.MatchApiService
 import online.partyrun.partyrunapplication.core.network.service.SignInApiService
 import online.partyrun.partyrunapplication.core.network.service.WaitingMatchApiService
 import retrofit2.Retrofit
@@ -44,11 +46,11 @@ object ApiServiceModule {
 
     @Singleton
     @Provides
-    fun provideBattleResultApiService(@RESTOkHttpClient okHttpClient: OkHttpClient, retrofit: Retrofit.Builder): BattleResultApiService =
+    fun provideResultApiService(@RESTOkHttpClient okHttpClient: OkHttpClient, retrofit: Retrofit.Builder): ResultApiService =
         retrofit
             .client(okHttpClient)
             .build()
-            .create(BattleResultApiService::class.java)
+            .create(ResultApiService::class.java)
 
     @Singleton
     @Provides
@@ -57,5 +59,14 @@ object ApiServiceModule {
             .client(okHttpClient)
             .build()
             .create(MemberApiService::class.java)
+
+    @Singleton
+    @Provides
+    fun provideMatchApiService(@RESTOkHttpClient okHttpClient: OkHttpClient, retrofit: Retrofit.Builder): MatchApiService =
+        retrofit
+            .client(okHttpClient)
+            .build()
+            .create(MatchApiService::class.java)
+
 
 }

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/di/DataSourceModule.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/di/DataSourceModule.kt
@@ -6,15 +6,19 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import online.partyrun.partyrunapplication.core.network.datasource.RunningResultDataSource
-import online.partyrun.partyrunapplication.core.network.datasource.RunningResultDataSourceImpl
+import online.partyrun.partyrunapplication.core.network.datasource.BattleDataSource
+import online.partyrun.partyrunapplication.core.network.datasource.BattleDataSourceImpl
+import online.partyrun.partyrunapplication.core.network.datasource.ResultDataSource
+import online.partyrun.partyrunapplication.core.network.datasource.ResultDataSourceImpl
 import online.partyrun.partyrunapplication.core.network.datasource.MatchDataSource
 import online.partyrun.partyrunapplication.core.network.datasource.MatchDataSourceImpl
 import online.partyrun.partyrunapplication.core.network.datasource.MemberDataSource
 import online.partyrun.partyrunapplication.core.network.datasource.MemberDataSourceImpl
 import online.partyrun.partyrunapplication.core.network.datasource.SignInDataSource
 import online.partyrun.partyrunapplication.core.network.datasource.SignInDataSourceImpl
-import online.partyrun.partyrunapplication.core.network.service.BattleResultApiService
+import online.partyrun.partyrunapplication.core.network.service.BattleApiService
+import online.partyrun.partyrunapplication.core.network.service.MatchApiService
+import online.partyrun.partyrunapplication.core.network.service.ResultApiService
 import online.partyrun.partyrunapplication.core.network.service.MatchDecisionApiService
 import online.partyrun.partyrunapplication.core.network.service.MemberApiService
 import online.partyrun.partyrunapplication.core.network.service.SignInApiService
@@ -31,9 +35,10 @@ object DataSourceModule {
         @SSEOkHttpClient okHttpClient: OkHttpClient,
         @SSERequestBuilder request: Request.Builder,
         waitingMatchApiService: WaitingMatchApiService,
-        matchDecisionApiService: MatchDecisionApiService
+        matchDecisionApiService: MatchDecisionApiService,
+        matchApiService: MatchApiService
     ): MatchDataSource {
-        return MatchDataSourceImpl(okHttpClient, request, waitingMatchApiService, matchDecisionApiService)
+        return MatchDataSourceImpl(okHttpClient, request, waitingMatchApiService, matchDecisionApiService, matchApiService)
     }
 
     @Singleton
@@ -44,9 +49,9 @@ object DataSourceModule {
 
     @Singleton
     @Provides
-    fun provideRunningResultDataSource(
-        battleResultApiService: BattleResultApiService
-    ): RunningResultDataSource = RunningResultDataSourceImpl(battleResultApiService)
+    fun provideResultDataSource(
+        resultApiService: ResultApiService
+    ): ResultDataSource = ResultDataSourceImpl(resultApiService)
 
     @Singleton
     @Provides

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/di/DataSourceModule.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/di/DataSourceModule.kt
@@ -59,4 +59,9 @@ object DataSourceModule {
         memberApiService: MemberApiService
     ): MemberDataSource = MemberDataSourceImpl(memberApiService)
 
+    @Singleton
+    @Provides
+    fun provideBattleDataSource(
+        battleApiService: BattleApiService
+    ): BattleDataSource = BattleDataSourceImpl(battleApiService)
 }

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/BattleIdResponse.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/BattleIdResponse.kt
@@ -1,0 +1,14 @@
+package online.partyrun.partyrunapplication.core.network.model.response
+
+
+import com.google.gson.annotations.SerializedName
+import online.partyrun.partyrunapplication.core.model.battle.BattleId
+
+data class BattleIdResponse(
+    @SerializedName("id")
+    val id: String
+)
+
+fun BattleIdResponse.toDomainModel() = BattleId(
+    id = this.id
+)

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/BattleMemberResponse.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/BattleMemberResponse.kt
@@ -1,0 +1,19 @@
+package online.partyrun.partyrunapplication.core.network.model.response
+
+import com.google.gson.annotations.SerializedName
+import online.partyrun.partyrunapplication.core.model.match.RunnerInfo
+
+data class BattleMemberResponse(
+    @SerializedName("id")
+    val id: String,
+    @SerializedName("name")
+    val name: String,
+    @SerializedName("profile")
+    val profile: String
+)
+
+fun BattleMemberResponse.toDomainModel() = RunnerInfo(
+    id = this.id,
+    name = this.name,
+    profile = this.profile
+)

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/BattleMembersInfoResponse.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/BattleMembersInfoResponse.kt
@@ -1,0 +1,13 @@
+package online.partyrun.partyrunapplication.core.network.model.response
+
+import com.google.gson.annotations.SerializedName
+import online.partyrun.partyrunapplication.core.model.match.RunnerInfoData
+
+data class BattleMembersInfoResponse(
+    @SerializedName("members")
+    val members: List<BattleMemberResponse>
+)
+
+fun BattleMembersInfoResponse.toDomainModel() = RunnerInfoData(
+    runners = this.members.map { it.toDomainModel() }
+)

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/MatchInfoResponse.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/MatchInfoResponse.kt
@@ -1,0 +1,13 @@
+package online.partyrun.partyrunapplication.core.network.model.response
+
+import com.google.gson.annotations.SerializedName
+import online.partyrun.partyrunapplication.core.model.match.RunnerIds
+
+data class MatchInfoResponse(
+    @SerializedName("members")
+    val members: List<MatchMemberResponse>
+)
+
+fun MatchInfoResponse.toDomainModel(): RunnerIds {
+    return RunnerIds(runnerIds = this.members.map { it.id })
+}

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/MatchMemberResponse.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/MatchMemberResponse.kt
@@ -1,0 +1,10 @@
+package online.partyrun.partyrunapplication.core.network.model.response
+
+import com.google.gson.annotations.SerializedName
+
+data class MatchMemberResponse(
+    @SerializedName("id")
+    val id: String,
+    @SerializedName("status")
+    val status: String
+)

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/service/BattleApiService.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/service/BattleApiService.kt
@@ -1,0 +1,9 @@
+package online.partyrun.partyrunapplication.core.network.service
+
+import online.partyrun.partyrunapplication.core.common.network.ApiResult
+import retrofit2.http.GET
+
+interface BattleApiService {
+    @GET("/api/battles/join")
+    suspend fun getBattleId(): ApiResult<String>
+}

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/service/BattleApiService.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/service/BattleApiService.kt
@@ -1,9 +1,10 @@
 package online.partyrun.partyrunapplication.core.network.service
 
 import online.partyrun.partyrunapplication.core.common.network.ApiResult
+import online.partyrun.partyrunapplication.core.network.model.response.BattleIdResponse
 import retrofit2.http.GET
 
 interface BattleApiService {
     @GET("/api/battles/join")
-    suspend fun getBattleId(): ApiResult<String>
+    suspend fun getBattleId(): ApiResult<BattleIdResponse>
 }

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/service/MatchApiService.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/service/MatchApiService.kt
@@ -1,0 +1,12 @@
+package online.partyrun.partyrunapplication.core.network.service
+
+import online.partyrun.partyrunapplication.core.common.network.ApiResult
+import online.partyrun.partyrunapplication.core.network.model.response.MatchInfoResponse
+import retrofit2.http.GET
+
+interface MatchApiService {
+
+    @GET("/api/matching/recent/members")
+    suspend fun getRunnerIds(): ApiResult<MatchInfoResponse>
+
+}

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/service/MatchDecisionApiService.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/service/MatchDecisionApiService.kt
@@ -7,12 +7,12 @@ import retrofit2.http.Body
 import retrofit2.http.POST
 
 interface MatchDecisionApiService {
-    @POST("/api/matching")
+    @POST("/api/matching/members/join")
     suspend fun acceptMatch(
         @Body body: MatchDecisionRequest
     ): ApiResult<MatchStatusResponse>
 
-    @POST("/api/matching")
+    @POST("/api/matching/members/join")
     suspend fun declineMatch(
         @Body body: MatchDecisionRequest
     ): ApiResult<MatchStatusResponse>

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/service/MemberApiService.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/service/MemberApiService.kt
@@ -1,11 +1,16 @@
 package online.partyrun.partyrunapplication.core.network.service
 
 import online.partyrun.partyrunapplication.core.common.network.ApiResult
+import online.partyrun.partyrunapplication.core.network.model.response.BattleMembersInfoResponse
 import online.partyrun.partyrunapplication.core.network.model.response.UserResponse
 import retrofit2.http.GET
+import retrofit2.http.Query
 
 interface MemberApiService {
     @GET("/api/members/me")
     suspend fun getUserData(): ApiResult<UserResponse>
+
+    @GET("api/members")
+    suspend fun getRunnersInfo(@Query("ids") runnerIds: List<String>): ApiResult<BattleMembersInfoResponse>
 
 }

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/service/ResultApiService.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/service/ResultApiService.kt
@@ -5,7 +5,7 @@ import online.partyrun.partyrunapplication.core.network.model.response.BattleRes
 import retrofit2.http.GET
 import retrofit2.http.Path
 
-interface BattleResultApiService {
+interface ResultApiService {
 
     @GET("/api/battles/{battleId}")
     suspend fun getBattleResults(

--- a/core/testing/src/main/java/online/partyrun/partyrunapplication/core/testing/repository/TestMemberRepository.kt
+++ b/core/testing/src/main/java/online/partyrun/partyrunapplication/core/testing/repository/TestMemberRepository.kt
@@ -6,6 +6,8 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flowOf
 import online.partyrun.partyrunapplication.core.common.network.ApiResponse
 import online.partyrun.partyrunapplication.core.data.repository.MemberRepository
+import online.partyrun.partyrunapplication.core.model.match.RunnerIds
+import online.partyrun.partyrunapplication.core.model.match.RunnerInfoData
 import online.partyrun.partyrunapplication.core.model.user.User
 
 class TestMemberRepository : MemberRepository {
@@ -17,6 +19,10 @@ class TestMemberRepository : MemberRepository {
 
     override val userData: Flow<User>
         get() = flowOf(User(id = userId ?: "", name = userName ?: "", profile = userProfile ?: ""))
+
+    override suspend fun getRunnersInfo(runnerIds: RunnerIds): Flow<ApiResponse<RunnerInfoData>> {
+        TODO("Not yet implemented")
+    }
 
     override suspend fun getUserData(): Flow<ApiResponse<User>> = user
 

--- a/feature/battle/src/main/java/online/partyrun/partyrunapplication/feature/battle/BattleMainScreen.kt
+++ b/feature/battle/src/main/java/online/partyrun/partyrunapplication/feature/battle/BattleMainScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -20,7 +21,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import online.partyrun.partyrunapplication.core.designsystem.component.BottomHalfOvalGradientShape
 import online.partyrun.partyrunapplication.core.designsystem.component.PartyRunMatchButton
 import online.partyrun.partyrunapplication.core.model.match.RunningDistance
@@ -38,8 +38,8 @@ fun BattleMainScreen(
     matchViewModel: MatchViewModel = hiltViewModel(),
     navigateToBattleRunning: () -> Unit
 ) {
-    val battleMainUiState by battleViewModel.battleMainUiState.collectAsStateWithLifecycle()
-    val matchUiState by matchViewModel.matchUiState.collectAsStateWithLifecycle()
+    val battleMainUiState by battleViewModel.battleMainUiState.collectAsState()
+    val matchUiState by matchViewModel.matchUiState.collectAsState()
 
     if (matchUiState.isAllRunnersAccepted) {
         navigateToBattleRunning()

--- a/feature/battle/src/main/java/online/partyrun/partyrunapplication/feature/battle/BattleMainScreen.kt
+++ b/feature/battle/src/main/java/online/partyrun/partyrunapplication/feature/battle/BattleMainScreen.kt
@@ -21,10 +21,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.google.gson.Gson
 import online.partyrun.partyrunapplication.core.designsystem.component.BottomHalfOvalGradientShape
 import online.partyrun.partyrunapplication.core.designsystem.component.PartyRunMatchButton
-import online.partyrun.partyrunapplication.core.model.battle.RunnerIds
 import online.partyrun.partyrunapplication.core.model.match.RunningDistance
 import online.partyrun.partyrunapplication.core.ui.BackgroundBlurImage
 import online.partyrun.partyrunapplication.core.ui.HeadLine
@@ -38,19 +36,13 @@ fun BattleMainScreen(
     modifier: Modifier = Modifier,
     battleViewModel: BattleMainViewModel = hiltViewModel(),
     matchViewModel: MatchViewModel = hiltViewModel(),
-    navigateToBattleRunningWithArgs: (String, String) -> Unit
+    navigateToBattleRunning: () -> Unit
 ) {
-    /* Mock Data */
-    val gson = Gson()
-    val runnerIds = RunnerIds(listOf("123", "456"))
-    val runnerIdsJson = gson.toJson(runnerIds)
-    val battleId = "64ae682dd780770fab6dca5d"
-
     val battleMainUiState by battleViewModel.battleMainUiState.collectAsStateWithLifecycle()
     val matchUiState by matchViewModel.matchUiState.collectAsStateWithLifecycle()
 
     if (matchUiState.isAllRunnersAccepted) {
-        navigateToBattleRunningWithArgs(battleId, runnerIdsJson)
+        navigateToBattleRunning()
         matchViewModel.closeMatchDialog() // 다이얼로그를 닫고 초기화 수행
     }
 

--- a/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/MatchUiState.kt
+++ b/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/MatchUiState.kt
@@ -1,6 +1,8 @@
 package online.partyrun.partyrunapplication.feature.match
 
+import online.partyrun.partyrunapplication.core.model.match.RunnerInfoData
 import online.partyrun.partyrunapplication.core.model.match.MatchMember
+import online.partyrun.partyrunapplication.core.model.match.RunnerIds
 import online.partyrun.partyrunapplication.core.model.match.WaitingStatus
 
 enum class MatchProgress {
@@ -24,6 +26,8 @@ enum class MatchResultStatus {
 data class MatchUiState(
     val isOpen: Boolean = false,
     val isAllRunnersAccepted: Boolean = false,
+    val runnerIds: RunnerIds = RunnerIds(emptyList()),
+    val runnerInfoData: RunnerInfoData = RunnerInfoData(emptyList()),
     val matchProgress: MatchProgress = MatchProgress.WAITING,
     val WaitingRestState: WaitingRestState = WaitingRestState(),
     val waitingEventState: WaitingEventState = WaitingEventState(),

--- a/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/ui/MatchResultDialog.kt
+++ b/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/ui/MatchResultDialog.kt
@@ -2,6 +2,7 @@ package online.partyrun.partyrunapplication.feature.match.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -13,6 +14,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Divider
@@ -30,9 +32,9 @@ import androidx.compose.ui.unit.dp
 import online.partyrun.partyrunapplication.core.designsystem.component.PartyRunGradientText
 import online.partyrun.partyrunapplication.core.designsystem.component.PartyRunOutlinedText
 import online.partyrun.partyrunapplication.core.designsystem.component.PartyRunResultDialog
-import online.partyrun.partyrunapplication.core.designsystem.component.RenderAsyncImage
+import online.partyrun.partyrunapplication.core.designsystem.component.RenderAsyncUrlImage
 import online.partyrun.partyrunapplication.core.model.match.MatchMember
-import online.partyrun.partyrunapplication.core.model.match.PlayerStatus
+import online.partyrun.partyrunapplication.core.model.match.RunnerStatus
 import online.partyrun.partyrunapplication.core.ui.FormatRemainingTimer
 import online.partyrun.partyrunapplication.feature.match.MatchResultEventState
 import online.partyrun.partyrunapplication.feature.match.MatchResultStatus
@@ -167,14 +169,23 @@ fun DisplayMatchStatus(
         itemsIndexed(
             matchUiState.matchResultEventState.members
         ) { index, item ->
-            MatchStatusItem(player = item)
+            // 아이디와 일치하는 RunnerInfo 찾기
+            val runnerInfo = matchUiState.runnerInfoData.runners.firstOrNull { it.id == item.id }
+
+            // 일치하는 RunnerInfo가 있으면 해당 이름과 프로필을 사용하고, 없으면 디폴트 텍스트를 사용
+            val runnerName = runnerInfo?.name ?: "이름 없음"
+            val runnerProfile = runnerInfo?.profile ?: ""
+
+            MatchStatusItem(runnerName, runnerProfile, item.status)
         }
     }
 }
 
 @Composable
 fun MatchStatusItem(
-    player: MatchMember
+    runnerName: String,
+    runnerProfile: String,
+    runnerStatus: String
 ) {
     Row(
         modifier = Modifier
@@ -188,30 +199,34 @@ fun MatchStatusItem(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Center
         ) {
-            RenderAsyncImage(
-                image = R.drawable.mock_profile,
-                size = 120,
-                contentDescription = null
-            )
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .size(45.dp)
+                    .clip(CircleShape)
+            ) {
+                RenderAsyncUrlImage(
+                    imageUrl = runnerProfile,
+                    contentDescription = null
+                )
+            }
             Text(
                 modifier = Modifier.padding(start = 10.dp),
-                text = player.id,
+                text = runnerName,
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.secondary
             )
         }
-        ConvertPlayerStatus(player)
+        ConvertPlayerStatus(runnerStatus)
     }
 }
 
 @Composable
-private fun ConvertPlayerStatus(player: MatchMember) {
-    when (player.status) {
-        PlayerStatus.NO_RESPONSE.name ->
+private fun ConvertPlayerStatus(runnerStatus: String) {
+    when (runnerStatus) {
+        RunnerStatus.NO_RESPONSE.name ->
             PartyRunOutlinedText(
-                modifier = Modifier
-                    .width(68.dp)
-                    .height(32.dp)
+                modifier = Modifier.padding(vertical = 8.dp, horizontal = 12.dp),
             ) {
                 Text(
                     text = stringResource(id = R.string.waiting_for_user),
@@ -220,11 +235,9 @@ private fun ConvertPlayerStatus(player: MatchMember) {
                 )
             }
 
-        PlayerStatus.READY.name ->
+        RunnerStatus.READY.name ->
             PartyRunGradientText(
-                modifier = Modifier
-                    .width(68.dp)
-                    .height(32.dp)
+                modifier = Modifier.padding(vertical = 8.dp, horizontal = 20.dp),
             ) {
                 Text(
                     text = stringResource(id = R.string.accept_matching_status),
@@ -233,11 +246,9 @@ private fun ConvertPlayerStatus(player: MatchMember) {
                 )
             }
 
-        PlayerStatus.CANCELED.name ->
+        RunnerStatus.CANCELED.name ->
             PartyRunOutlinedText(
-                modifier = Modifier
-                    .width(64.dp)
-                    .height(32.dp)
+                modifier = Modifier.padding(vertical = 8.dp, horizontal = 12.dp),
             ) {
                 Text(
                     text = stringResource(id = R.string.decline_matching_status),
@@ -256,11 +267,11 @@ fun PartyRunResultDialogPreview() {
             listOf(
                 MatchMember(
                     id = "TEST1",
-                    status = PlayerStatus.NO_RESPONSE.name
+                    status = RunnerStatus.NO_RESPONSE.name
                 ),
                 MatchMember(
                     id = "TEST2",
-                    status = PlayerStatus.READY.name
+                    status = RunnerStatus.READY.name
                 )
             ),
         status = MatchResultStatus.WAIT

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentViewModel.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentViewModel.kt
@@ -23,15 +23,18 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import online.partyrun.partyrunapplication.core.common.network.ApiResponse
 import online.partyrun.partyrunapplication.core.domain.running.BattleStreamUseCase
+import online.partyrun.partyrunapplication.core.domain.running.GetBattleIdUseCase
+import online.partyrun.partyrunapplication.core.domain.running.GetBattleStatusUseCase
+import online.partyrun.partyrunapplication.core.domain.running.SaveBattleIdUseCase
 import online.partyrun.partyrunapplication.core.domain.running.SendRecordDataUseCase
 import online.partyrun.partyrunapplication.core.model.battle.BattleStatus
-import online.partyrun.partyrunapplication.core.model.battle.RunnerIds
-import online.partyrun.partyrunapplication.core.model.battle.RunnerStatus
 import online.partyrun.partyrunapplication.core.model.running.BattleEvent
 import online.partyrun.partyrunapplication.core.model.running.GpsData
 import online.partyrun.partyrunapplication.core.model.running.RecordData
 import online.partyrun.partyrunapplication.feature.running.battle.util.distanceToCoordinatesMapper
+import timber.log.Timber
 import java.net.ConnectException
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
@@ -42,6 +45,9 @@ import javax.inject.Inject
 class BattleContentViewModel @Inject constructor(
     private val battleStreamUseCase: BattleStreamUseCase,
     private val sendRecordDataUseCase: SendRecordDataUseCase,
+    private val getBattleIdUseCase: GetBattleIdUseCase,
+    private val getBattleStatusUseCase: GetBattleStatusUseCase,
+    private val saveBattleIdUseCase: SaveBattleIdUseCase,
     private val fusedLocationProviderClient: FusedLocationProviderClient
 ): ViewModel() {
     companion object {
@@ -57,6 +63,9 @@ class BattleContentViewModel @Inject constructor(
     private val _battleUiState = MutableStateFlow(BattleUiState())
     val battleUiState: StateFlow<BattleUiState> = _battleUiState
 
+    private val _battleId = MutableStateFlow<String?>(null)
+    val battleId: StateFlow<String?> = _battleId
+
     private lateinit var runnersState: StateFlow<BattleEvent>
 
     private val recordData = mutableListOf<GpsData>() // 1초마다 업데이트한 GPS 데이터를 쌓기 위함
@@ -66,6 +75,29 @@ class BattleContentViewModel @Inject constructor(
         locationRequest = LocationRequest.Builder(priority, TimeUnit.SECONDS.toMillis(
             LOCATION_UPDATE_INTERVAL_SECONDS
         )).build()
+
+        getBattleId()
+    }
+
+    private fun getBattleId() {
+        viewModelScope.launch {
+            getBattleIdUseCase().collect {
+                when (it) {
+                    is ApiResponse.Success -> {
+                        saveBattleIdUseCase(it.data) // DataStore에 BattleId 저장
+                        _battleId.value = it.data
+                    }
+
+                    is ApiResponse.Failure -> {
+                        Timber.e("$it")
+                    }
+
+                    ApiResponse.Loading -> {
+                        Timber.d("Loading")
+                    }
+                }
+            }
+        }
     }
 
     suspend fun startBattleStream(
@@ -212,19 +244,16 @@ class BattleContentViewModel @Inject constructor(
         }
     }
 
-    fun initBattleState(runnerIds: RunnerIds) {
-        // RunnerIds 객체에서 각 id를 가져와 RunnerState 객체 생성
-        val runnerStates = runnerIds.runnerIdData.map { id ->
-            RunnerStatus(
-                runnerId = id,
-                runnerName = "테스트"
-            )
-        }
-        // 생성된 RunnerState 객체들로 BattleState 객체 생성
-        _battleUiState.update { state ->
-            state.copy(
-                battleState = BattleStatus(battleInfo = runnerStates)
-            )
+    fun initBattleState() {
+        viewModelScope.launch {
+            val battleData = getBattleStatusUseCase()
+
+            // 생성된 RunnerState 객체들로 BattleState 객체 생성
+            _battleUiState.update { state ->
+                state.copy(
+                    battleState = battleData
+                )
+            }
         }
     }
 

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentViewModel.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentViewModel.kt
@@ -84,8 +84,8 @@ class BattleContentViewModel @Inject constructor(
             getBattleIdUseCase().collect {
                 when (it) {
                     is ApiResponse.Success -> {
-                        saveBattleIdUseCase(it.data) // DataStore에 BattleId 저장
-                        _battleId.value = it.data
+                        saveBattleIdUseCase(it.data.id) // DataStore에 BattleId 저장
+                        _battleId.value = it.data.id
                     }
 
                     is ApiResponse.Failure -> {

--- a/feature/running_result/src/main/java/online/partyrun/partyrunapplication/feature/running_result/RunningResultViewModel.kt
+++ b/feature/running_result/src/main/java/online/partyrun/partyrunapplication/feature/running_result/RunningResultViewModel.kt
@@ -22,7 +22,7 @@ class RunningResultViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            getBattleResultUseCase(battleId = battleId).collect {
+            getBattleResultUseCase().collect {
                 when(it) {
                     is ApiResponse.Success -> {
                         _runningResultUiState.value =


### PR DESCRIPTION
## Description
추가 예정

## Implementation
## 1. 러너 정보를 가져와 저장하고 다른 유저들의 수락 / 수락 전 여부를 파악하는 곳에서 러너 닉네임과 프로필을 보여줄 수 있게 변경

https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/fbd62c48-9e9c-429e-bc07-b284bdf4f79f

