### PR TITLE
#PAR-272 : 앱이 처음 구동될 때 기존에 존재하던 배틀 웹소켓 연결을 끊는 요청 전송

### DIFF
--- a/app/src/main/java/online/partyrun/partyrunapplication/MainActivity.kt
+++ b/app/src/main/java/online/partyrun/partyrunapplication/MainActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.viewModels
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
@@ -15,10 +16,13 @@ import online.partyrun.partyrunapplication.ui.PartyRunMain
 import online.partyrun.partyrunapplication.core.common.extension.setIntentActivity
 import online.partyrun.partyrunapplication.core.designsystem.component.PartyRunBackground
 import online.partyrun.partyrunapplication.core.designsystem.theme.PartyRunApplicationTheme
+import online.partyrun.partyrunapplication.feature.battle.BattleMainViewModel
 import timber.log.Timber
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    private val battleViewModel: BattleMainViewModel by viewModels()
 
     /**
      * 사용자로부터 위치 접근 권한을 요청하고 그 결과를 받아 처리하기 위한 코드
@@ -45,6 +49,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        battleViewModel.terminateOngoingBattle() // 앱이 처음 시작될 때 진행 중인 배틀이 있다면 종료 요청
         askPermissions() // 권한 확인 및 요청
 
         setContent {

--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/BattleRepository.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/BattleRepository.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.flow.Flow
 import online.partyrun.partyrunapplication.core.common.network.ApiResponse
 import online.partyrun.partyrunapplication.core.model.battle.BattleId
 import online.partyrun.partyrunapplication.core.model.battle.BattleStatus
+import online.partyrun.partyrunapplication.core.model.battle.TerminateBattle
 import online.partyrun.partyrunapplication.core.model.running.BattleEvent
 import online.partyrun.partyrunapplication.core.model.running.RecordData
 
@@ -14,6 +15,7 @@ interface BattleRepository {
     suspend fun setBattleId(battleId: String)
 
     suspend fun getBattleId(): Flow<ApiResponse<BattleId>>
+    suspend fun terminateOngoingBattle(): Flow<ApiResponse<TerminateBattle>>
     fun getBattleStream(battleId: String): Flow<BattleEvent>
     suspend fun sendRecordData(battleId: String, recordData: RecordData)
     suspend fun close()

--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/BattleRepositoryImpl.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/BattleRepositoryImpl.kt
@@ -7,6 +7,7 @@ import online.partyrun.partyrunapplication.core.common.network.apiRequestFlow
 import online.partyrun.partyrunapplication.core.datastore.datasource.BattlePreferencesDataSource
 import online.partyrun.partyrunapplication.core.model.battle.BattleId
 import online.partyrun.partyrunapplication.core.model.battle.BattleStatus
+import online.partyrun.partyrunapplication.core.model.battle.TerminateBattle
 import online.partyrun.partyrunapplication.core.model.running.BattleEvent
 import online.partyrun.partyrunapplication.core.model.running.RecordData
 import online.partyrun.partyrunapplication.core.network.RealtimeBattleClient
@@ -31,6 +32,20 @@ class BattleRepositoryImpl @Inject constructor(
 
     override suspend fun getBattleId(): Flow<ApiResponse<BattleId>> {
         return apiRequestFlow { battleDataSource.getBattleId() }
+            .map { apiResponse ->
+                when (apiResponse) {
+                    is ApiResponse.Loading -> ApiResponse.Loading
+                    is ApiResponse.Success -> ApiResponse.Success(apiResponse.data.toDomainModel())
+                    is ApiResponse.Failure -> ApiResponse.Failure(
+                        apiResponse.errorMessage,
+                        apiResponse.code
+                    )
+                }
+            }
+    }
+
+    override suspend fun terminateOngoingBattle(): Flow<ApiResponse<TerminateBattle>> {
+        return apiRequestFlow { battleDataSource.terminateOngoingBattle() }
             .map { apiResponse ->
                 when (apiResponse) {
                     is ApiResponse.Loading -> ApiResponse.Loading

--- a/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/running/TerminateOngoingBattleUseCase.kt
+++ b/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/running/TerminateOngoingBattleUseCase.kt
@@ -1,0 +1,12 @@
+package online.partyrun.partyrunapplication.core.domain.running
+
+import online.partyrun.partyrunapplication.core.data.repository.BattleRepository
+import javax.inject.Inject
+
+class TerminateOngoingBattleUseCase @Inject constructor(
+    private val battleRepository: BattleRepository
+) {
+    suspend operator fun invoke() =
+        battleRepository.terminateOngoingBattle()
+
+}

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/battle/TerminateBattle.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/battle/TerminateBattle.kt
@@ -1,0 +1,5 @@
+package online.partyrun.partyrunapplication.core.model.battle
+
+data class TerminateBattle(
+    val message: String = ""
+)

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/BattleDataSource.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/BattleDataSource.kt
@@ -2,7 +2,9 @@ package online.partyrun.partyrunapplication.core.network.datasource
 
 import online.partyrun.partyrunapplication.core.common.network.ApiResult
 import online.partyrun.partyrunapplication.core.network.model.response.BattleIdResponse
+import online.partyrun.partyrunapplication.core.network.model.response.TerminateBattleResponse
 
 interface BattleDataSource {
     suspend fun getBattleId(): ApiResult<BattleIdResponse>
+    suspend fun terminateOngoingBattle(): ApiResult<TerminateBattleResponse>
 }

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/BattleDataSourceImpl.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/BattleDataSourceImpl.kt
@@ -2,6 +2,7 @@ package online.partyrun.partyrunapplication.core.network.datasource
 
 import online.partyrun.partyrunapplication.core.common.network.ApiResult
 import online.partyrun.partyrunapplication.core.network.model.response.BattleIdResponse
+import online.partyrun.partyrunapplication.core.network.model.response.TerminateBattleResponse
 import online.partyrun.partyrunapplication.core.network.service.BattleApiService
 import javax.inject.Inject
 
@@ -11,4 +12,6 @@ class BattleDataSourceImpl @Inject constructor(
     override suspend fun getBattleId(): ApiResult<BattleIdResponse> =
         battleApi.getBattleId()
 
+    override suspend fun terminateOngoingBattle(): ApiResult<TerminateBattleResponse> =
+        battleApi.terminateOngoingBattle()
 }

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/TerminateBattleResponse.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/TerminateBattleResponse.kt
@@ -1,0 +1,14 @@
+package online.partyrun.partyrunapplication.core.network.model.response
+
+import com.google.gson.annotations.SerializedName
+import online.partyrun.partyrunapplication.core.model.battle.TerminateBattle
+
+data class TerminateBattleResponse(
+    @SerializedName("message")
+    val message: String?
+)
+
+fun TerminateBattleResponse.toDomainModel() = TerminateBattle(
+    message = this.message ?: ""
+)
+

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/service/BattleApiService.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/service/BattleApiService.kt
@@ -2,9 +2,14 @@ package online.partyrun.partyrunapplication.core.network.service
 
 import online.partyrun.partyrunapplication.core.common.network.ApiResult
 import online.partyrun.partyrunapplication.core.network.model.response.BattleIdResponse
+import online.partyrun.partyrunapplication.core.network.model.response.TerminateBattleResponse
 import retrofit2.http.GET
+import retrofit2.http.POST
 
 interface BattleApiService {
     @GET("/api/battles/join")
     suspend fun getBattleId(): ApiResult<BattleIdResponse>
+
+    @POST("/api/battles/runners/finished")
+    suspend fun terminateOngoingBattle(): ApiResult<TerminateBattleResponse>
 }

--- a/feature/battle/src/main/java/online/partyrun/partyrunapplication/feature/battle/BattleMainViewModel.kt
+++ b/feature/battle/src/main/java/online/partyrun/partyrunapplication/feature/battle/BattleMainViewModel.kt
@@ -1,17 +1,43 @@
 package online.partyrun.partyrunapplication.feature.battle
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import online.partyrun.partyrunapplication.core.common.network.ApiResponse
+import online.partyrun.partyrunapplication.core.domain.running.TerminateOngoingBattleUseCase
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
 class BattleMainViewModel @Inject constructor(
-
+    private val terminateOngoingBattleUseCase: TerminateOngoingBattleUseCase
 ) : ViewModel() {
 
     private val _battleMainUiState = MutableStateFlow<BattleMainUiState>(BattleMainUiState.Success)
     val battleMainUiState = _battleMainUiState.asStateFlow()
+
+    /**
+     * 앱이 처음 시작될 때(MainActivity가 onCreate될 때) 진행 중인 배틀이 있다면 종료 요청 수행
+     */
+    fun terminateOngoingBattle() = viewModelScope.launch {
+        terminateOngoingBattleUseCase().collect {
+            when (it) {
+                is ApiResponse.Success -> {
+                    Timber.tag("BattleMainViewModel").d("현재 진행 중인 배틀이 있다면 종료 요청 성공")
+                }
+
+                is ApiResponse.Failure -> {
+                    Timber.tag("BattleMainViewModel").e("${it.code} ${it.errorMessage}")
+                }
+
+                ApiResponse.Loading -> {
+                    Timber.tag("BattleMainViewModel").d("Loading")
+                }
+            }
+        }
+    }
 
 }


### PR DESCRIPTION
## Description
클라이언트 측에서 배틀이 진행 중인 상황에서 앱을 강제종료 시키면 서버 측에서는 웹소켓 연결이 끊긴 상황을 파악할 수 없다.
따라서, 앱이 다시 구동될 때 최초 1회 기존에 존재하는 배틀 상태가 있다면 종료 시키라는 요청을 보냄으로써 서버 측에서 해당 유저의 배틀 상태를 초기화하는 과정을 수행할 수 있게 한다.

* 현재는 종료만을 제공하지만, 추후 재연결 프로세스 추가 예정