### PR TITLE
#PAR-276 : 배틀 종료 시 웹소켓 토픽 구독과 연결을 끊는다.

### DIFF
--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/BattleRepository.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/BattleRepository.kt
@@ -18,5 +18,6 @@ interface BattleRepository {
     suspend fun terminateOngoingBattle(): Flow<ApiResponse<TerminateBattle>>
     fun getBattleStream(battleId: String): Flow<BattleEvent>
     suspend fun sendRecordData(battleId: String, recordData: RecordData)
+    suspend fun disposeSocketResources()
     suspend fun close()
 }

--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/BattleRepositoryImpl.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/BattleRepositoryImpl.kt
@@ -64,5 +64,7 @@ class BattleRepositoryImpl @Inject constructor(
     override suspend fun sendRecordData(battleId: String, recordData: RecordData) =
         realtimeBattleClient.sendRecordData(battleId, recordData.toRequestModel())
 
-    override suspend fun close() = realtimeBattleClient.close()
+    override suspend fun close() = realtimeBattleClient.closeSocket()
+    override suspend fun disposeSocketResources() = realtimeBattleClient.disposeSocketResources()
+
 }

--- a/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/running/DisposeSocketResourcesUseCase.kt
+++ b/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/running/DisposeSocketResourcesUseCase.kt
@@ -1,0 +1,10 @@
+package online.partyrun.partyrunapplication.core.domain.running
+
+import online.partyrun.partyrunapplication.core.data.repository.BattleRepository
+import javax.inject.Inject
+
+class DisposeSocketResourcesUseCase @Inject constructor(
+    private val battleRepository: BattleRepository
+) {
+    suspend operator fun invoke() = battleRepository.disposeSocketResources()
+}

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/RealtimeBattleClient.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/RealtimeBattleClient.kt
@@ -152,7 +152,7 @@ class RealtimeBattleClient(
     /**
      * 웹소켓 연결을 종료하는 메소드
      */
-    suspend fun close() {
+    suspend fun closeSocket() {
         stompConnection.dispose()
     }
 
@@ -164,4 +164,12 @@ class RealtimeBattleClient(
         topic.dispose()
     }
 
+    /**
+     * 웹소켓 연결과 토픽 구독을 종료하고 관련 리소스 정리 수행
+     */
+    suspend fun disposeSocketResources() {
+        disposeTopic()
+        closeSocket()
+    }
 }
+

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentScreen.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentScreen.kt
@@ -60,7 +60,7 @@ fun Content(
     ) {
         when (battleUiState.screenState) {
             is BattleScreenState.Ready -> BattleReadyScreen(isConnecting = battleUiState.isConnecting)
-            is BattleScreenState.Running -> BattleRunningScreen(battleUiState, navigationToRunningResult)
+            is BattleScreenState.Running -> BattleRunningScreen(battleUiState = battleUiState)
             BattleScreenState.Finish -> FinishScreen()
         }
     }

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentViewModel.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentViewModel.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import online.partyrun.partyrunapplication.core.common.network.ApiResponse
 import online.partyrun.partyrunapplication.core.domain.running.BattleStreamUseCase
+import online.partyrun.partyrunapplication.core.domain.running.DisposeSocketResourcesUseCase
 import online.partyrun.partyrunapplication.core.domain.running.GetBattleIdUseCase
 import online.partyrun.partyrunapplication.core.domain.running.GetBattleStatusUseCase
 import online.partyrun.partyrunapplication.core.domain.running.GetUserIdUseCase
@@ -50,6 +51,7 @@ class BattleContentViewModel @Inject constructor(
     private val getBattleStatusUseCase: GetBattleStatusUseCase,
     private val saveBattleIdUseCase: SaveBattleIdUseCase,
     private val getUserIdUseCase: GetUserIdUseCase,
+    private val disposeSocketResourcesUseCase: DisposeSocketResourcesUseCase,
     private val fusedLocationProviderClient: FusedLocationProviderClient
 ): ViewModel() {
     companion object {
@@ -300,6 +302,10 @@ class BattleContentViewModel @Inject constructor(
         }
     }
 
+    suspend fun disposeSocketResources() {
+        disposeSocketResourcesUseCase()
+    }
+
     private suspend fun handleBattleFinished(runnerId: String) {
         val userId = getUserIdUseCase()
         if (runnerId == userId) {  // 내 아이디와 비교하는 작업 수행
@@ -309,6 +315,8 @@ class BattleContentViewModel @Inject constructor(
                     screenState = BattleScreenState.Finish
                 )
             }
+            Timber.tag("handleBattleFinished").d("웹소켓 리소스 해제")
+            disposeSocketResources() // 웹소켓 리소스 해제
         }
     }
 

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/running/BattleRunningScreen.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/running/BattleRunningScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
@@ -38,7 +37,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import kotlinx.coroutines.delay
 import online.partyrun.partyrunapplication.core.designsystem.component.PartyRunGradientText
 import online.partyrun.partyrunapplication.core.designsystem.component.PartyRunOutlinedText
 import online.partyrun.partyrunapplication.core.designsystem.component.PartyRunTopAppBar
@@ -49,13 +47,11 @@ import online.partyrun.partyrunapplication.core.ui.FormatElapsedTimer
 import online.partyrun.partyrunapplication.feature.running.R
 import online.partyrun.partyrunapplication.feature.running.battle.BattleContentViewModel
 import online.partyrun.partyrunapplication.feature.running.battle.BattleUiState
-import online.partyrun.partyrunapplication.feature.running.battle.finish.FinishScreen
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BattleRunningScreen(
     battleUiState: BattleUiState,
-    navigationToRunningResult: () -> Unit = {},
     battleContentViewModel: BattleContentViewModel = hiltViewModel()
 ) {
     val battleState = battleUiState.battleState // 배틀 상태 state


### PR DESCRIPTION
## Description
배틀 종료 시, 정책 상 서버측에서는 웹소켓 연결을 일방적으로 끊을 수 없다.

이에 따라 배틀 종료 시, 종료가 된 러너가 직접 토픽 구독과 연결을 끊는 로직을 구현한다.