### PR TITLE
#PAR-277 : 매칭 취소 시 취소에 대한 요청을 보낸다.

### DIFF
--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/MatchRepository.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/MatchRepository.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.flow.Flow
 import okhttp3.sse.EventSource
 import okhttp3.sse.EventSourceListener
 import online.partyrun.partyrunapplication.core.common.network.ApiResponse
+import online.partyrun.partyrunapplication.core.model.match.CancelMatch
 import online.partyrun.partyrunapplication.core.model.match.MatchDecision
 import online.partyrun.partyrunapplication.core.model.match.MatchStatus
 import online.partyrun.partyrunapplication.core.model.match.RunnerIds
@@ -20,6 +21,7 @@ interface MatchRepository {
     suspend fun acceptMatch(matchDecision: MatchDecision): Flow<ApiResponse<MatchStatus>>
     suspend fun declineMatch(matchDecision: MatchDecision): Flow<ApiResponse<MatchStatus>>
     suspend fun getRunnerIds(): Flow<ApiResponse<RunnerIds>>
+    suspend fun cancelMatchWaitingEvent(): Flow<ApiResponse<CancelMatch>>
 
     /* SSE */
     fun createMatchEventSourceListener(onEvent: (data: String) -> Unit, onClosed: () -> Unit, onFailure: () -> Unit): EventSourceListener

--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/MatchRepositoryImpl.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/MatchRepositoryImpl.kt
@@ -8,6 +8,7 @@ import online.partyrun.partyrunapplication.core.common.Constants.BASE_URL
 import online.partyrun.partyrunapplication.core.common.network.ApiResponse
 import online.partyrun.partyrunapplication.core.common.network.apiRequestFlow
 import online.partyrun.partyrunapplication.core.datastore.datasource.BattlePreferencesDataSource
+import online.partyrun.partyrunapplication.core.model.match.CancelMatch
 import online.partyrun.partyrunapplication.core.model.match.MatchDecision
 import online.partyrun.partyrunapplication.core.model.match.MatchStatus
 import online.partyrun.partyrunapplication.core.model.match.RunnerIds
@@ -63,6 +64,17 @@ class MatchRepositoryImpl @Inject constructor(
 
     override suspend fun getRunnerIds(): Flow<ApiResponse<RunnerIds>> {
         return apiRequestFlow { matchDataSource.getRunnerIds() }
+            .map { apiResponse ->
+                when (apiResponse) {
+                    is ApiResponse.Loading -> ApiResponse.Loading
+                    is ApiResponse.Success -> ApiResponse.Success(apiResponse.data.toDomainModel())
+                    is ApiResponse.Failure -> ApiResponse.Failure(apiResponse.errorMessage, apiResponse.code)
+                }
+            }
+    }
+
+    override suspend fun cancelMatchWaitingEvent(): Flow<ApiResponse<CancelMatch>> {
+        return apiRequestFlow { matchDataSource.cancelMatchWaitingEvent() }
             .map { apiResponse ->
                 when (apiResponse) {
                     is ApiResponse.Loading -> ApiResponse.Loading

--- a/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/match/CancelMatchWaitingUseCase.kt
+++ b/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/match/CancelMatchWaitingUseCase.kt
@@ -1,0 +1,10 @@
+package online.partyrun.partyrunapplication.core.domain.match
+
+import online.partyrun.partyrunapplication.core.data.repository.MatchRepository
+import javax.inject.Inject
+
+class CancelMatchWaitingUseCase @Inject constructor(
+    private val matchRepository: MatchRepository
+) {
+    suspend operator fun invoke() = matchRepository.cancelMatchWaitingEvent()
+}

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/match/CancelMatch.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/match/CancelMatch.kt
@@ -1,0 +1,5 @@
+package online.partyrun.partyrunapplication.core.model.match
+
+data class CancelMatch(
+    val message: String = ""
+)

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/MatchDataSource.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/MatchDataSource.kt
@@ -6,6 +6,7 @@ import online.partyrun.partyrunapplication.core.common.network.ApiResult
 import online.partyrun.partyrunapplication.core.network.model.request.MatchDecisionRequest
 import online.partyrun.partyrunapplication.core.network.model.response.MatchStatusResponse
 import online.partyrun.partyrunapplication.core.network.model.request.RunningDistanceRequest
+import online.partyrun.partyrunapplication.core.network.model.response.CancelMatchResponse
 import online.partyrun.partyrunapplication.core.network.model.response.MatchInfoResponse
 
 interface MatchDataSource {
@@ -14,6 +15,7 @@ interface MatchDataSource {
     suspend fun acceptMatch(matchDecisionRequest: MatchDecisionRequest): ApiResult<MatchStatusResponse>
     suspend fun declineMatch(matchDecisionRequest: MatchDecisionRequest): ApiResult<MatchStatusResponse>
     suspend fun getRunnerIds(): ApiResult<MatchInfoResponse>
+    suspend fun cancelMatchWaitingEvent(): ApiResult<CancelMatchResponse>
 
     fun createMatchEventSourceListener(onEvent: (data: String) -> Unit, onClosed: () -> Unit, onFailure: () -> Unit): EventSourceListener
     fun createEventSource(url: String, listener: EventSourceListener): EventSource

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/MatchDataSourceImpl.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/MatchDataSourceImpl.kt
@@ -12,6 +12,7 @@ import online.partyrun.partyrunapplication.core.network.model.response.MatchStat
 import online.partyrun.partyrunapplication.core.network.di.SSEOkHttpClient
 import online.partyrun.partyrunapplication.core.network.di.SSERequestBuilder
 import online.partyrun.partyrunapplication.core.network.model.request.RunningDistanceRequest
+import online.partyrun.partyrunapplication.core.network.model.response.CancelMatchResponse
 import online.partyrun.partyrunapplication.core.network.model.response.MatchInfoResponse
 import online.partyrun.partyrunapplication.core.network.service.MatchApiService
 import online.partyrun.partyrunapplication.core.network.service.MatchDecisionApiService
@@ -40,6 +41,10 @@ class MatchDataSourceImpl @Inject constructor(
 
     override suspend fun getRunnerIds(): ApiResult<MatchInfoResponse> =
         matchApiService.getRunnerIds()
+
+    override suspend fun cancelMatchWaitingEvent(): ApiResult<CancelMatchResponse> =
+        matchApiService.cancelMatchWaitingEvent()
+
 
     override fun createMatchEventSourceListener(
         onEvent: (data: String) -> Unit,

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/CancelMatchResponse.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/CancelMatchResponse.kt
@@ -1,0 +1,13 @@
+package online.partyrun.partyrunapplication.core.network.model.response
+
+import com.google.gson.annotations.SerializedName
+import online.partyrun.partyrunapplication.core.model.match.CancelMatch
+
+data class CancelMatchResponse(
+    @SerializedName("message")
+    val message: String?
+)
+
+fun CancelMatchResponse.toDomainModel() = CancelMatch(
+    message = this.message ?: ""
+)

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/service/MatchApiService.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/service/MatchApiService.kt
@@ -1,12 +1,17 @@
 package online.partyrun.partyrunapplication.core.network.service
 
 import online.partyrun.partyrunapplication.core.common.network.ApiResult
+import online.partyrun.partyrunapplication.core.network.model.response.CancelMatchResponse
 import online.partyrun.partyrunapplication.core.network.model.response.MatchInfoResponse
 import retrofit2.http.GET
+import retrofit2.http.POST
 
 interface MatchApiService {
 
     @GET("/api/matching/recent/members")
     suspend fun getRunnerIds(): ApiResult<MatchInfoResponse>
+
+    @POST("/api/waiting/event/cancel")
+    suspend fun cancelMatchWaitingEvent(): ApiResult<CancelMatchResponse>
 
 }

--- a/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/MatchDialogScreen.kt
+++ b/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/MatchDialogScreen.kt
@@ -61,6 +61,7 @@ fun MatchDialog(
             MatchWaitingDialog(
                 setShowDialog = setShowDialog,
                 disconnectSSE = {
+                    matchViewModel.cancelMatchWaitingEvent()
                     matchViewModel.disconnectMatchEventSource()
                 },
                 matchUiState = matchState,

--- a/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/MatchViewModel.kt
+++ b/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/MatchViewModel.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import online.partyrun.partyrunapplication.core.common.network.ApiResponse
+import online.partyrun.partyrunapplication.core.domain.match.CancelMatchWaitingUseCase
 import online.partyrun.partyrunapplication.core.domain.match.ConnectMatchResultEventSourceUseCase
 import online.partyrun.partyrunapplication.core.domain.match.ConnectWaitingEventSourceUseCase
 import online.partyrun.partyrunapplication.core.domain.match.CreateMatchEventSourceListenerUseCase
@@ -51,7 +52,8 @@ class MatchViewModel @Inject constructor(
     private val disconnectMatchResultEventSourceUseCase: DisconnectMatchResultEventSourceUseCase,
     private val getRunnerIdsUseCase: GetRunnerIdsUseCase,
     private val getRunnersInfoUseCase: GetRunnersInfoUseCase,
-    private val saveRunnersInfoUseCase: SaveRunnersInfoUseCase
+    private val saveRunnersInfoUseCase: SaveRunnersInfoUseCase,
+    private val cancelMatchWaitingUseCase: CancelMatchWaitingUseCase
 ) : ViewModel() {
 
     private val _matchUiState = MutableStateFlow(MatchUiState())
@@ -363,5 +365,24 @@ class MatchViewModel @Inject constructor(
                 }
             }
         }
+
+    fun cancelMatchWaitingEvent() = viewModelScope.launch {
+        cancelMatchWaitingUseCase().collect {
+            when (it) {
+                is ApiResponse.Success -> {
+                    Timber.d("정상적으로 매칭 취소 완료")
+                }
+
+                is ApiResponse.Failure -> {
+                    Timber.tag("MatchViewModel").e("${it.code} ${it.errorMessage}")
+                }
+
+                ApiResponse.Loading -> {
+                    Timber.d("$it")
+                }
+            }
+        }
+    }
+
 
 }


### PR DESCRIPTION
## Description
서버 측에서 클라이언트와의 SSE 연결이 끊겼음을 판단해 새로운 매칭이 들어올 수 있게 싱크를 맞추는 과정을 수행할 때, 

단순히 클라이언트의 일방적인 SSE Cancel로는 이를 처리하지 못함.

이에 따라 SSE 연결을 정상적으로 끊기 위한 REST 요청 로직 추가