### PR TITLE
#PAR-279 : 배틀 트랙 위에 러너들이 겹칠 때 본인의 마커가 최상단에 위치하도록 변경

### DIFF
--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentViewModel.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentViewModel.kt
@@ -58,6 +58,7 @@ class BattleContentViewModel @Inject constructor(
         const val STATE_SHARE_SUBSCRIPTION_TIMEOUT = 3000L
     }
 
+    private lateinit var userId: String
     private lateinit var locationCallback: LocationCallback
     private val locationRequest: LocationRequest
     private var isFirstBattleStreamCall = true // onEach 분기를 위한 boolean
@@ -79,7 +80,17 @@ class BattleContentViewModel @Inject constructor(
         )).build()
 
         getBattleId()
+        getUserId()
     }
+
+    private fun getUserId() = viewModelScope.launch {
+            userId = getUserIdUseCase()
+            _battleUiState.update { state ->
+                state.copy(
+                    userId = userId
+                )
+            }
+        }
 
     private fun getBattleId() {
         viewModelScope.launch {
@@ -301,7 +312,6 @@ class BattleContentViewModel @Inject constructor(
     }
 
     private suspend fun handleBattleFinished(runnerId: String) {
-        val userId = getUserIdUseCase()
         if (runnerId == userId) {  // 내 아이디와 비교하는 작업 수행
             _battleUiState.update { state ->
                 state.copy(

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleUiState.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleUiState.kt
@@ -7,6 +7,8 @@ data class BattleUiState(
     val isConnecting: Boolean = true,
     // 목표 거리에 도달했는지 여부 판단
     val isFinished: Boolean = false,
+    // 유저 id
+    val userId: String = "",
     // 사용자가 선택한 목표 거리
     val selectedDistance: Int = 1000,
     // 현재 보여줘야 할 스크린

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/running/BattleRunningScreen.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/running/BattleRunningScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.res.imageResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import kotlinx.coroutines.delay
 import online.partyrun.partyrunapplication.core.designsystem.component.PartyRunGradientText
@@ -101,6 +102,7 @@ fun BattleRunningScreen(
                     TrackWithMultipleUsers(
                         battleContentViewModel = battleContentViewModel,
                         totalTrackDistance = battleUiState.selectedDistance,
+                        userId = battleUiState.userId,
                         runners = battleState.battleInfo
                     )
                 }
@@ -205,6 +207,7 @@ private fun RunningTopAppBar() {
 fun TrackWithMultipleUsers(
     battleContentViewModel: BattleContentViewModel,
     totalTrackDistance: Int,
+    userId: String,
     runners: List<RunnerStatus>
 ) {
     // 트랙 이미지 리소스를 사용
@@ -236,11 +239,14 @@ fun TrackWithMultipleUsers(
                 trackWidth = trackWidth,
                 trackHeight = trackHeight
             )
+            val zIndex = if (runner.runnerId == userId) 1f else 0f // 해당 runnerId가 userId와 같으면 z-index를 1로 설정
             Box(
-                modifier = Modifier.offset(
-                    x = currentX.dp,
-                    y = currentY.dp
-                )
+                modifier = Modifier
+                    .offset(
+                        x = currentX.dp,
+                        y = currentY.dp
+                    )
+                    .zIndex(zIndex) // 여기에 z-index 설정하여 user라면 최상단에 마커를 위치
             ) {
                 Column() {
                     Box(


### PR DESCRIPTION
## Description
배틀 트랙 위에서 러너들의 마커가 같은 위치에 있을 경우, 겹치게 되어 본인의 마커가 가려질 수 있다.
따라서, 본인의 마커가 최상단에 위치하도록 인터페이스에서 보여줄 수 있게 변경한다.
zIndex 속성을 통해 특정 컴포넌트의 Z축 위치를 조정하여 본인의 마커가 최상단에 위치하도록 변경


## Implementation
<img width="856" alt="image" src="https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/8e213e4f-3a49-4090-8763-632a703d3fd8">

* 왼쪽 애뮬레이터는 '석석'으로 로그인 했기에 '석석'이 최상단에 위치
* 오른쪽 애뮬레이터는 '우성진'으로 로그인 했기에 '우성진'이 최상단에 위치
