### PR TITLE
#PAR-280 : 배틀 화면에 대한 데이터를 서버로부터 가져와 UI 바인딩

### DIFF
--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentViewModel.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentViewModel.kt
@@ -194,9 +194,18 @@ class BattleContentViewModel @Inject constructor(
             currentBattleState[runnerIndex] = updatedRunnerState
         }
 
+        // 거리에 따라 러너들을 정렬
+        val sortedRunners = currentBattleState.sortedByDescending { it.distance }
+
+        // 순위 업데이트
+        val rankedRunners = sortedRunners.mapIndexed { index, runner ->
+            runner.copy(currentRank = index + 1)
+        }
+
+        // 업데이트된 상태로 저장
         _battleUiState.update { state ->
             state.copy(
-                battleState = BattleStatus(battleInfo = currentBattleState)
+                battleState = BattleStatus(battleInfo = rankedRunners)
             )
         }
     }

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentViewModel.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentViewModel.kt
@@ -86,13 +86,13 @@ class BattleContentViewModel @Inject constructor(
     }
 
     private fun getUserId() = viewModelScope.launch {
-            userId = getUserIdUseCase()
-            _battleUiState.update { state ->
-                state.copy(
-                    userId = userId
-                )
-            }
+        userId = getUserIdUseCase()
+        _battleUiState.update { state ->
+            state.copy(
+                userId = userId
+            )
         }
+    }
 
     private fun getBattleId() {
         viewModelScope.launch {
@@ -183,7 +183,6 @@ class BattleContentViewModel @Inject constructor(
 
         val updatedRunnerState = existingRunnerState?.copy(
             distance = result.distance,
-            currentRank = 1,  // 적절한 값으로 변경
             currentRound = 1,  // 적절한 값으로 변경
             totalRounds = 1  // 적절한 값으로 변경
         )
@@ -356,4 +355,9 @@ class BattleContentViewModel @Inject constructor(
         )
     }
 
+    fun getRunnerDistance(): String {
+        val runnerStatus = _battleUiState.value.battleState.battleInfo.find { it.runnerId == userId }
+        val distance = runnerStatus?.distance?.toInt() ?: 0
+        return "${distance}m"
+    }
 }

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/running/BattleRunningScreen.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/running/BattleRunningScreen.kt
@@ -257,7 +257,7 @@ fun TrackWithMultipleUsers(
                             .height(40.dp)
                             .background(
                                 color = Color.Black.copy(alpha = 0.5f),
-                                shape = RoundedCornerShape(20.dp) // 모서리를 둥글게 하기 위한 값
+                                shape = RoundedCornerShape(25.dp) // 모서리를 둥글게 하기 위한 값
                             )
                             .padding(10.dp)
                     ) {

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/running/BattleRunningScreen.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/running/BattleRunningScreen.kt
@@ -142,9 +142,7 @@ fun BattleRunningScreen(
                         verticalArrangement = Arrangement.Center,
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
-                        FormatElapsedTimer(
-                            contentColor = MaterialTheme.colorScheme.onPrimary
-                        )
+                        UserDistanceDisplay(battleContentViewModel)
                         Row(
                             modifier = Modifier.padding(top = 10.dp)
                         ) {
@@ -155,7 +153,7 @@ fun BattleRunningScreen(
                             )
                             Text(
                                 modifier = Modifier.padding(start = 3.dp, bottom = 2.dp),
-                                text = stringResource(id = R.string.average_pace),
+                                text = stringResource(id = R.string.running_distance),
                             )
                         }
                     }
@@ -177,6 +175,15 @@ fun BattleRunningScreen(
             }
         }
     }
+}
+
+@Composable
+private fun UserDistanceDisplay(battleContentViewModel: BattleContentViewModel) {
+    Text(
+        text = battleContentViewModel.getRunnerDistance(),
+        style = MaterialTheme.typography.titleMedium,
+        color = MaterialTheme.colorScheme.onPrimary
+    )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/running/BattleRunningScreen.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/running/BattleRunningScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -27,6 +28,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
@@ -35,12 +37,14 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.imageResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import online.partyrun.partyrunapplication.core.designsystem.component.PartyRunGradientText
 import online.partyrun.partyrunapplication.core.designsystem.component.PartyRunOutlinedText
 import online.partyrun.partyrunapplication.core.designsystem.component.PartyRunTopAppBar
+import online.partyrun.partyrunapplication.core.designsystem.component.RenderAsyncUrlImage
 import online.partyrun.partyrunapplication.core.designsystem.icon.PartyRunIcons
 import online.partyrun.partyrunapplication.core.model.battle.RunnerStatus
 import online.partyrun.partyrunapplication.core.ui.BackgroundBlurImage
@@ -244,7 +248,9 @@ fun TrackWithMultipleUsers(
                     )
                     .zIndex(zIndex) // 여기에 z-index 설정하여 user라면 최상단에 마커를 위치
             ) {
-                Column() {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
                     Box(
                         contentAlignment = Alignment.Center,
                         modifier = Modifier
@@ -261,13 +267,36 @@ fun TrackWithMultipleUsers(
                             color = MaterialTheme.colorScheme.onPrimary
                         )
                     }
-                    Image(
-                        modifier = Modifier.size(60.dp),
-                        painter = painterResource(id = R.drawable.runner_img_marker),
-                        contentDescription = stringResource(id = R.string.runner_img_marker)
-                    )
+
+                    RunnerMarker(runner)
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun RunnerMarker(runner: RunnerStatus) {
+    Box (
+        contentAlignment = Alignment.Center
+    ) {
+        // 마커 프레임
+        Image(
+            modifier = Modifier.size(70.dp),
+            painter = painterResource(id = R.drawable.runner_img_marker),
+            contentDescription = stringResource(id = R.string.runner_img_marker)
+        )
+        // 유저 프로필 이미지
+        Box(
+            modifier = Modifier
+                .size(42.dp)
+                .offset(y = (-6).dp)
+                .clip(CircleShape)
+        ) {
+            RenderAsyncUrlImage(
+                imageUrl = runner.runnerProfile,
+                contentDescription = null
+            )
         }
     }
 }
@@ -349,5 +378,55 @@ fun TrackDistanceDistanceBox(
             style = MaterialTheme.typography.titleMedium,
             color = MaterialTheme.colorScheme.primary
         )
+    }
+}
+
+@Preview(showBackground = false)
+@Composable
+fun RunnerImagePreview(
+    imageUrl: String = "https://avatars.githubusercontent.com/u/134378498?s=400&u=72e57bdb2eafcad3d0c8b8e137349397eefce35f&v=4" // 대체 이미지 URL
+) {
+    Box() {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .height(40.dp)
+                    .background(
+                        color = Color.Black.copy(alpha = 0.5f),
+                        shape = RoundedCornerShape(20.dp) // 모서리를 둥글게 하기 위한 값
+                    )
+                    .padding(10.dp)
+            ) {
+                Text(
+                    text = "김말숙",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onPrimary
+                )
+            }
+
+            Box(
+                contentAlignment = Alignment.Center
+            ) {
+                Image(
+                    modifier = Modifier.size(70.dp),
+                    painter = painterResource(id = R.drawable.runner_img_marker),
+                    contentDescription = stringResource(id = R.string.runner_img_marker)
+                )
+                Box(
+                    modifier = Modifier
+                        .size(45.dp)
+                        .offset(y = (-6).dp)
+                        .clip(CircleShape)
+                ) {
+                    RenderAsyncUrlImage(
+                        imageUrl = imageUrl,
+                        contentDescription = null
+                    )
+                }
+            }
+        }
     }
 }

--- a/feature/running/src/main/res/values/strings.xml
+++ b/feature/running/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="menu_desc">메뉴 아이콘</string>
     <string name="track_img">달리기 트랙 이미지</string>
     <string name="runner_img_marker">러너 프로필 이미지</string>
+    <string name="running_distance">달린 거리</string>
     <string name="ranking">등</string>
     <string name="schedule_desc">진행 시간 아이콘</string>
     <string name="pace_desc">평균 페이스 아이콘</string>


### PR DESCRIPTION
## Description
서버로부터 받은 데이터를 UI 각 항목에 전처리 후 매핑하는 작업 수행 

## Implementation
### 1. 배틀 트랙 위 본인의 마커에 프로필 이미지 삽입
<img width="750" alt="스크린샷 2023-08-12 오전 2 01 03" src="https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/f6b74e6c-9f64-456f-8375-f65ef7ea497b">

### 2. 배틀 과정 중에 실시간으로 순위 변동을 계산해 표시
<img width="362" alt="스크린샷 2023-08-12 오전 3 28 33" src="https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/9fab21ad-7efa-4a21-8a91-a27e6498e503">

### 3. 러너가 현재 달린 거리를 스크린 상에 표시
<img width="383" alt="image" src="https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/d8e27688-1dec-4610-8843-5631330b0b45">

