### PR TITLE
#PAR-288 :  Running 스크린에서 onBackPressedCallback 종료 분기 처리

### DIFF
--- a/app/src/main/java/online/partyrun/partyrunapplication/navigation/MainNavHost.kt
+++ b/app/src/main/java/online/partyrun/partyrunapplication/navigation/MainNavHost.kt
@@ -45,7 +45,9 @@ fun SetUpMainNavGraph(
         battleRoute(
             navigateToBattleRunning = {
                 navController.navigate(MainNavRoutes.BattleRunning.route) {
-                    popUpTo(MainNavRoutes.BattleRunning.route)
+                    popUpTo(MainNavRoutes.Battle.route) {
+                        inclusive = true
+                    }
                 }
             },
             onShowSnackbar = onShowSnackbar

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentScreen.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentScreen.kt
@@ -1,16 +1,38 @@
 package online.partyrun.partyrunapplication.feature.running.battle
 
+import android.app.Activity
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.delay
+import online.partyrun.partyrunapplication.core.designsystem.component.PartyRunGradientButton
+import online.partyrun.partyrunapplication.core.designsystem.component.PartyRunOutlinedButton
 import online.partyrun.partyrunapplication.core.ui.CountdownDialog
+import online.partyrun.partyrunapplication.feature.running.R
 import online.partyrun.partyrunapplication.feature.running.battle.finish.FinishScreen
 import online.partyrun.partyrunapplication.feature.running.battle.ready.BattleReadyScreen
 import online.partyrun.partyrunapplication.feature.running.battle.running.BattleRunningScreen
@@ -24,6 +46,8 @@ fun BattleContentScreen(
 ) {
     val battleUiState by viewModel.battleUiState.collectAsStateWithLifecycle()
     val battleId by viewModel.battleId.collectAsStateWithLifecycle()
+
+    RunningBackNavigationHandler() // 대결 중 BackPressed 수행 시 처리할 핸들러
 
     LaunchedEffect(battleId) {
         battleId?.let { id ->
@@ -96,5 +120,105 @@ private fun StartBattleRunning(
         onDispose {
             viewModel.stopLocationUpdates()
         }
+    }
+}
+
+@Composable
+fun RunningBackNavigationHandler() {
+    val context = LocalContext.current
+    val activity = context as? Activity
+    val onBackPressedDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
+    val openDialog = remember { mutableStateOf(false) }
+
+    RunningExitConfirmationDialog(openDialog) {
+        // 액티비티 재시작
+        activity?.let {
+            val intent = it.intent
+            it.startActivity(intent)
+            it.overridePendingTransition(R.anim.slide_in_right, R.anim.slide_out_left)
+
+            it.finish()
+            it.overridePendingTransition(R.anim.slide_in_left, R.anim.slide_out_right)
+        }
+    }
+
+    DisposableEffect(Unit) {
+        val onBackPressedCallback = object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                openDialog.value = true
+            }
+        }
+
+        onBackPressedDispatcher?.addCallback(onBackPressedCallback)
+
+        onDispose { onBackPressedCallback.remove() }
+    }
+}
+
+@Composable
+fun RunningExitConfirmationDialog(
+    openDialog: MutableState<Boolean>,
+    confirmExit: () -> Unit
+) {
+    if (openDialog.value) {
+        AlertDialog(
+            onDismissRequest = {
+                openDialog.value = false
+            },
+            title = {
+                Column(
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.exit_dialog_title),
+                        style = MaterialTheme.typography.titleLarge,
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
+                    Text(
+                        text = stringResource(id = R.string.exit_dialog_subtitle),
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
+                }
+            },
+            confirmButton = {
+                PartyRunGradientButton(
+                    onClick = {
+                        confirmExit()
+                        openDialog.value = false
+                    },
+                    modifier = Modifier
+                        .width(90.dp)
+                        .height(50.dp)
+                        .shadow(5.dp, shape = CircleShape),
+                    contentColor = Color.White,
+                    containerColor = Color.Unspecified
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.exit_dialog_confirm),
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
+                }
+            },
+            dismissButton = {
+                PartyRunOutlinedButton(
+                    onClick = {
+                        openDialog.value = false
+                    },
+                    shape = RoundedCornerShape(35.dp),
+                    borderStrokeWidth = 5.dp,
+                    modifier = Modifier
+                        .height(50.dp)
+                        .shadow(5.dp, shape = CircleShape),
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.exit_dialog_cancel),
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                }
+            }
+        )
     }
 }

--- a/feature/running/src/main/res/anim/slide_in_left.xml
+++ b/feature/running/src/main/res/anim/slide_in_left.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:interpolator="@android:anim/accelerate_decelerate_interpolator"
+        android:fromXDelta="-100%p"
+        android:toXDelta="0"
+        android:duration="250"/>
+</set>

--- a/feature/running/src/main/res/anim/slide_in_right.xml
+++ b/feature/running/src/main/res/anim/slide_in_right.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:interpolator="@android:anim/accelerate_decelerate_interpolator"
+        android:fromXDelta="100%p"
+        android:toXDelta="0"
+        android:duration="200"/>
+</set>

--- a/feature/running/src/main/res/anim/slide_out_left.xml
+++ b/feature/running/src/main/res/anim/slide_out_left.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:interpolator="@android:anim/accelerate_decelerate_interpolator"
+        android:fromXDelta="0"
+        android:toXDelta="-100%p"
+        android:duration="200"/>
+</set>

--- a/feature/running/src/main/res/anim/slide_out_right.xml
+++ b/feature/running/src/main/res/anim/slide_out_right.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:interpolator="@android:anim/accelerate_decelerate_interpolator"
+        android:fromXDelta="0"
+        android:toXDelta="100%p"
+        android:duration="250"/>
+</set>

--- a/feature/running/src/main/res/values/strings.xml
+++ b/feature/running/src/main/res/values/strings.xml
@@ -16,4 +16,10 @@
     <string name="background_finish_blur">투명한 배경 블러 이미지</string>
     <string name="finish">Finish</string>
     <string name="finish_comment">대결이 종료됐습니다.</string>
+
+    <string name="exit_dialog_title">대결을 종료하시겠습니까?</string>
+    <string name="exit_dialog_subtitle">종료 시 현재 대결을 이어 달릴 수 없습니다.</string>
+    <string name="exit_dialog_confirm">예</string>
+    <string name="exit_dialog_cancel">아니오</string>
+
 </resources>


### PR DESCRIPTION
## Description 
달리는 상황에서는 뒤로 가기를 할 경우, 아예 대결 상황을 종료시켜야 한다.

따라서, RunningBackNavigationHandler를 적용해 종료 여부를 묻고 그에 따른 처리를 진행한다.

## Implementation

https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/4402cf31-2af6-46d5-a552-2796f5aa82ad

