### PR TITLE
#PAR-290 : 매칭 취소 관련 Snackbar Message

### DIFF
--- a/feature/battle/src/main/java/online/partyrun/partyrunapplication/feature/battle/BattleMainScreen.kt
+++ b/feature/battle/src/main/java/online/partyrun/partyrunapplication/feature/battle/BattleMainScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -41,16 +42,14 @@ fun BattleMainScreen(
 ) {
     val battleMainUiState by battleViewModel.battleMainUiState.collectAsState()
     val matchUiState by matchViewModel.matchUiState.collectAsState()
-
-    if (matchUiState.isAllRunnersAccepted) {
-        navigateToBattleRunning()
-        matchViewModel.closeMatchDialog() // 다이얼로그를 닫고 초기화 수행
-    }
+    val matchSnackbarMessage by matchViewModel.snackbarMessage.collectAsState()
 
     Content(
         battleMainUiState = battleMainUiState,
         matchViewModel = matchViewModel,
+        navigateToBattleRunning = navigateToBattleRunning,
         matchUiState = matchUiState,
+        matchSnackbarMessage = matchSnackbarMessage,
         onShowSnackbar = onShowSnackbar
     )
 
@@ -61,9 +60,23 @@ fun Content(
     modifier: Modifier = Modifier,
     battleMainUiState: BattleMainUiState,
     matchViewModel: MatchViewModel,
+    navigateToBattleRunning: () -> Unit,
     matchUiState: MatchUiState,
+    matchSnackbarMessage: String,
     onShowSnackbar: (String) -> Unit,
 ) {
+    if (matchUiState.isAllRunnersAccepted) {
+        navigateToBattleRunning()
+        matchViewModel.closeMatchDialog() // 다이얼로그를 닫고 초기화 수행
+    }
+
+    LaunchedEffect(matchSnackbarMessage) {
+        if (matchSnackbarMessage.isNotEmpty()) {
+            onShowSnackbar(matchSnackbarMessage)
+            matchViewModel.clearSnackbarMessage()
+        }
+    }
+
     Box(modifier = modifier) {
         when (battleMainUiState) {
             is BattleMainUiState.Loading -> LoadingBody()

--- a/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/MatchDialogScreen.kt
+++ b/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/MatchDialogScreen.kt
@@ -60,9 +60,8 @@ fun MatchDialog(
         MatchProgress.WAITING.name ->
             MatchWaitingDialog(
                 setShowDialog = setShowDialog,
-                disconnectSSE = {
+                disconnectMatching = {
                     matchViewModel.cancelMatchWaitingEvent()
-                    matchViewModel.disconnectMatchEventSource()
                 },
                 matchUiState = matchState,
                 exoPlayer = exoPlayer,

--- a/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/ui/MatchWaitingDialog.kt
+++ b/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/ui/MatchWaitingDialog.kt
@@ -42,14 +42,14 @@ import online.partyrun.partyrunapplication.feature.match.buildPlayerView
 @Composable
 fun MatchWaitingDialog(
     setShowDialog: (Boolean) -> Unit,
-    disconnectSSE: () -> Unit,
+    disconnectMatching: () -> Unit,
     matchUiState: MatchUiState,
     exoPlayer: ExoPlayer,
     isBuffering: MutableState<Boolean>
 ) {
     PartyRunMatchDialog(
         onDismissRequest = {
-            disconnectSSE()
+            disconnectMatching()
             setShowDialog(false)
         },
     ) {
@@ -75,7 +75,7 @@ fun MatchWaitingDialog(
             }
             Spacer(modifier = Modifier.size(20.dp))
 
-            CancelButton(disconnectSSE, setShowDialog)
+            CancelButton(disconnectMatching, setShowDialog)
         }
     }
 }


### PR DESCRIPTION
## Description
매칭 취소 시 SSE 커넥션 부분에서 onFailure로 식별되어 나오는 에러가 있기에
이 부분에서 에러가 떴을 시 클라이언트에게 알려주는 UI 스낵바를 우선적으로 추가한다.

## Implementation
<img width="378" alt="스크린샷 2023-08-17 오후 1 53 33" src="https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/e5db84cc-df55-430e-941a-cc655dbd49ed">
