### PR TITLE
#PAR-294 : 매칭 취소 시 SSE 재수행 과정에서의 CompletableDeferred 문제

### DIFF
--- a/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/MatchDialogScreen.kt
+++ b/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/MatchDialogScreen.kt
@@ -62,6 +62,7 @@ fun MatchDialog(
                 setShowDialog = setShowDialog,
                 disconnectMatching = {
                     matchViewModel.cancelMatchWaitingEvent()
+                    matchViewModel.disconnectMatchEventSource()
                 },
                 exoPlayer = exoPlayer,
                 isBuffering = isBuffering

--- a/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/ui/MatchWaitingDialog.kt
+++ b/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/ui/MatchWaitingDialog.kt
@@ -112,7 +112,7 @@ private fun ExoPlayerBox(
 
 @Composable
 private fun CancelButton(
-    disconnectSSE: () -> Unit,
+    disconnectMatching: () -> Unit,
     setShowDialog: (Boolean) -> Unit
 ) {
     PartyRunGradientIconButton(
@@ -120,7 +120,7 @@ private fun CancelButton(
             .size(48.dp)
             .shadow(5.dp, CircleShape),
         onClick = {
-            disconnectSSE()
+            disconnectMatching()
             setShowDialog(false)
         }
     ) {


### PR DESCRIPTION
## Description
 매칭 과정에서 대기열 등록 REST 이후 러너들이 3인 모일 때까지 대기하는 SSE 커넥션에서 CompletableDeferred를 통해 SSE 연결~종료까지의 순차성을 보장하고 있다.

그러나 이때, 만약 사용자가 매칭 잡기를 누르고 취소를 한다면 CompletableDeferred가 새로운 CompletableDeferred 인스턴스로 초기화가 되지 않는 문제 발생
waitingEventSSEstate가 closeMatchDialog 호출 이후에 초기화되어야 하지만, connectWaitingEventSource 함수를 호출할 때 여전히 Complete 상태로 유지되는 것이 이유라고 판단했고, 새로운 connectWaitingEventSource 호출마다 새로운 waitingEventSSEstate 인스턴스를 보장하기 위한 작업을 진행한다.

## Implementation

## 변경 전
https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/f6c26488-35d4-4054-8478-240b0dedafbb

---

## 변경 후 
https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/b8ef61ec-36f6-46d9-8410-3cfa55ec32bf



