### PR TITLE
fix : 백엔드 서버와의 회원가입 시도 실패 시 파이어베이스 로그아웃 보장

### DIFF
--- a/feature/sign_in/src/main/java/online/partyrun/partyrunapplication/feature/sign_in/SignInViewModel.kt
+++ b/feature/sign_in/src/main/java/online/partyrun/partyrunapplication/feature/sign_in/SignInViewModel.kt
@@ -18,6 +18,7 @@ import online.partyrun.partyrunapplication.core.model.auth.GoogleIdToken
 import online.partyrun.partyrunapplication.core.domain.auth.GetSignInTokenUseCase
 import online.partyrun.partyrunapplication.core.common.network.ApiResponse
 import online.partyrun.partyrunapplication.core.domain.auth.GoogleSignInUseCase
+import online.partyrun.partyrunapplication.core.domain.auth.GoogleSignOutUseCase
 import online.partyrun.partyrunapplication.core.domain.auth.SaveTokensUseCase
 import online.partyrun.partyrunapplication.core.domain.member.GetUserDataUseCase
 import online.partyrun.partyrunapplication.core.domain.member.SaveUserDataUseCase
@@ -28,6 +29,7 @@ import javax.inject.Inject
 @HiltViewModel
 class SignInViewModel @Inject constructor(
     private val getSignInTokenUseCase: GetSignInTokenUseCase,
+    private val googleSignOutUseCase: GoogleSignOutUseCase,
     private val saveTokensUseCase: SaveTokensUseCase,
     private val googleSignInUseCase: GoogleSignInUseCase,
     private val getUserDataUseCase: GetUserDataUseCase,
@@ -105,6 +107,7 @@ class SignInViewModel @Inject constructor(
                 }
                 is ApiResponse.Failure -> {
                     _snackbarMessage.value = "로그인 실패"
+                    signOutFromGoogle()
                     _signInGoogleState.update { state ->
                         state.copy(
                             isSignInSuccessful = false
@@ -142,6 +145,10 @@ class SignInViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    fun signOutFromGoogle() = viewModelScope.launch {
+        googleSignOutUseCase()
     }
 
     fun resetState() {

--- a/feature/sign_in/src/test/java/online/partyrun/partyrunapplication/feature/sign_in/SignInViewModelTest.kt
+++ b/feature/sign_in/src/test/java/online/partyrun/partyrunapplication/feature/sign_in/SignInViewModelTest.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.test.runTest
 import online.partyrun.partyrunapplication.core.common.network.ApiResponse
 import online.partyrun.partyrunapplication.core.domain.auth.GetSignInTokenUseCase
 import online.partyrun.partyrunapplication.core.domain.auth.GoogleSignInUseCase
+import online.partyrun.partyrunapplication.core.domain.auth.GoogleSignOutUseCase
 import online.partyrun.partyrunapplication.core.domain.auth.SaveTokensUseCase
 import online.partyrun.partyrunapplication.core.domain.member.GetUserDataUseCase
 import online.partyrun.partyrunapplication.core.domain.member.SaveUserDataUseCase
@@ -40,6 +41,9 @@ class SignInViewModelTest {
     private val saveUserDataUseCase = SaveUserDataUseCase(
         memberRepository = memberRepository
     )
+    private val googleSignOutUseCase = GoogleSignOutUseCase(
+        googleAuthRepository = googleAuthRepository
+    )
 
     private lateinit var viewModel: SignInViewModel
 
@@ -52,6 +56,7 @@ class SignInViewModelTest {
             getSignInTokenUseCase = getSignInTokenUseCase,
             saveTokensUseCase = saveTokensUseCase,
             googleSignInUseCase = googleSignInUseCase,
+            googleSignOutUseCase = googleSignOutUseCase,
             getUserDataUseCase = getUserDataUseCase,
             saveUserDataUseCase = saveUserDataUseCase
         )


### PR DESCRIPTION
## Description
사용자가 구글을 통해 회원가입을 시도 시 백엔드 서버로부터 회원가입이 정상적으로 이루어지지 않았다는 응답을 받게 되면,
기존 파이어베이스 서버와의 로그인 연결 시도 또한 취소되어야 하므로 만약, 정상적으로 로그인 요청이 진행되었다면 로그아웃을 하도록 수정