### PR TITLE
#PAR-296 : matchSnackbarMessage를 BattleMainScreen에서 처리

### DIFF
--- a/feature/battle/src/main/java/online/partyrun/partyrunapplication/feature/battle/BattleMainScreen.kt
+++ b/feature/battle/src/main/java/online/partyrun/partyrunapplication/feature/battle/BattleMainScreen.kt
@@ -44,6 +44,7 @@ fun BattleMainScreen(
     val battleMainUiState by battleMainViewModel.battleMainUiState.collectAsState()
     val matchUiState by matchViewModel.matchUiState.collectAsState()
     val battleMainSnackbarMessage by battleMainViewModel.snackbarMessage.collectAsStateWithLifecycle()
+    val matchSnackbarMessage by matchViewModel.snackbarMessage.collectAsStateWithLifecycle()
 
     Content(
         modifier = modifier,
@@ -53,6 +54,7 @@ fun BattleMainScreen(
         navigateToBattleRunning = navigateToBattleRunning,
         matchUiState = matchUiState,
         battleMainSnackbarMessage = battleMainSnackbarMessage,
+        matchSnackbarMessage = matchSnackbarMessage,
         onShowSnackbar = onShowSnackbar
     )
 }
@@ -66,6 +68,7 @@ fun Content(
     navigateToBattleRunning: () -> Unit,
     matchUiState: MatchUiState,
     battleMainSnackbarMessage: String,
+    matchSnackbarMessage: String,
     onShowSnackbar: (String) -> Unit,
 ) {
     if (matchUiState.isAllRunnersAccepted) {
@@ -80,6 +83,13 @@ fun Content(
         }
     }
 
+    LaunchedEffect(matchSnackbarMessage) {
+        if (matchSnackbarMessage.isNotEmpty()) {
+            onShowSnackbar(matchSnackbarMessage)
+            matchViewModel.clearSnackbarMessage()
+        }
+    }
+
     Box(modifier = modifier) {
         when (battleMainUiState) {
             is BattleMainUiState.Loading -> LoadingBody()
@@ -88,6 +98,7 @@ fun Content(
                 matchViewModel = matchViewModel,
                 matchUiState = matchUiState
             )
+
             is BattleMainUiState.LoadFailed -> LoadingBody()
         }
     }


### PR DESCRIPTION
## Description
매칭 취소 시 스낵 메세지 처리 로직을 Dialog에 속하게 하여 처리했을 때 다이얼로그 로직과 스낵 메세지 로직이 겹쳐 레이아웃이 원하는대로 구성되지 않는 문제 발생
따라서, matchSnackbarMessage를 BattleMainScreen에서 처리하도록 처리
-> 정상적으로 매칭 취소 로직 시나리오 시 스낵메세지 표시

## Implementation
 

https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/d1ddc701-4c57-4276-ab5b-d6cb02cfbc24


