### PR TITLE
#PAR-297 : 로그아웃 후 스플래시에서 Firebase Auth 사용자 정보 조회 과정에서의 이슈

### DIFF
--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageScreen.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageScreen.kt
@@ -133,8 +133,9 @@ private fun MyPageBody(
         }
 
         SignOutButton(
-            onSignOut = {
+            onClick = {
                 viewModel.signOutFromGoogle()
+                viewModel.saveAgreementState(isChecked = false)
                 onSignOut()
             },
             modifier = Modifier.fillMaxWidth()
@@ -236,7 +237,7 @@ private fun ProfileImage(
 
 @Composable
 fun SignOutButton(
-    onSignOut: () -> Unit,
+    onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -245,7 +246,7 @@ fun SignOutButton(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Button(
-            onClick = { onSignOut() }
+            onClick = { onClick() }
         ) {
             Text(
                 text = stringResource(id = R.string.sign_out_btn),

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageViewModel.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageViewModel.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import online.partyrun.partyrunapplication.core.domain.agreement.SaveAgreementStateUseCase
 import online.partyrun.partyrunapplication.core.domain.auth.GoogleSignOutUseCase
 import online.partyrun.partyrunapplication.core.domain.my_page.GetMyPageDataUseCase
 import timber.log.Timber
@@ -15,8 +16,9 @@ import javax.inject.Inject
 @HiltViewModel
 class MyPageViewModel @Inject constructor(
     private val googleSignOutUseCase: GoogleSignOutUseCase,
+    private val saveAgreementStateUseCase: SaveAgreementStateUseCase,
     private val getMyPageDataUseCase: GetMyPageDataUseCase
-): ViewModel() {
+) : ViewModel() {
 
     private val _myPageUiState = MutableStateFlow<MyPageUiState>(MyPageUiState.Loading)
     val myPageUiState = _myPageUiState.asStateFlow()
@@ -41,6 +43,10 @@ class MyPageViewModel @Inject constructor(
 
     fun signOutFromGoogle() = viewModelScope.launch {
         googleSignOutUseCase()
+    }
+
+    fun saveAgreementState(isChecked: Boolean) = viewModelScope.launch {
+        saveAgreementStateUseCase(isChecked)
     }
 
 }

--- a/feature/splash/src/main/java/online/partyrun/partyrunapplication/feature/splash/splash/SplashScreen.kt
+++ b/feature/splash/src/main/java/online/partyrun/partyrunapplication/feature/splash/splash/SplashScreen.kt
@@ -25,11 +25,12 @@ fun SplashScreen(
     setIntentMainActivity: () -> Unit,
     navigationToAgreement: () -> Unit
 ) {
-    val googleUserState by splashViewModel.googleUser.collectAsStateWithLifecycle()
+    val splashUiState by splashViewModel.splashUiState.collectAsStateWithLifecycle()
 
-    LaunchedEffect(key1 = googleUserState) {
-        delay(1500L)
-        if (googleUserState != null) { // Google 로그인이 되어있는 상태라면
+    LaunchedEffect(splashUiState) {
+        showSplashForDuration(1500L)
+
+        if (isUserLoggedInAndAgreed(splashUiState)) { // Google 로그인이 되어있는 상태라면
             setIntentMainActivity()
         } else {
             navigationToAgreement()
@@ -51,4 +52,12 @@ fun SplashScreen(
             )
         }
     }
+}
+
+private fun isUserLoggedInAndAgreed(state: SplashUiState): Boolean {
+    return state.googleUser != null && state.isAgreementChecked
+}
+
+private suspend fun showSplashForDuration(duration: Long) {
+    delay(duration)
 }

--- a/feature/splash/src/main/java/online/partyrun/partyrunapplication/feature/splash/splash/SplashUiState.kt
+++ b/feature/splash/src/main/java/online/partyrun/partyrunapplication/feature/splash/splash/SplashUiState.kt
@@ -1,0 +1,8 @@
+package online.partyrun.partyrunapplication.feature.splash.splash
+
+import online.partyrun.partyrunapplication.core.model.auth.GoogleUserData
+
+data class SplashUiState(
+    val googleUser: GoogleUserData? = null,
+    val isAgreementChecked: Boolean = false
+)

--- a/feature/splash/src/main/java/online/partyrun/partyrunapplication/feature/splash/splash/SplashViewModel.kt
+++ b/feature/splash/src/main/java/online/partyrun/partyrunapplication/feature/splash/splash/SplashViewModel.kt
@@ -6,25 +6,43 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import online.partyrun.partyrunapplication.core.domain.agreement.GetAgreementStateUseCase
 import online.partyrun.partyrunapplication.core.domain.auth.GetGoogleAuthUserUseCase
-import online.partyrun.partyrunapplication.core.model.auth.GoogleUserData
 import javax.inject.Inject
 
 @HiltViewModel
 class SplashViewModel @Inject constructor(
-    private val getGoogleAuthUserUseCase: GetGoogleAuthUserUseCase
-): ViewModel() {
+    private val getGoogleAuthUserUseCase: GetGoogleAuthUserUseCase,
+    private val getAgreementStateUseCase: GetAgreementStateUseCase
+) : ViewModel() {
 
-    private val _googleUser = MutableStateFlow<GoogleUserData?>(null)
-    val googleUser: StateFlow<GoogleUserData?> = _googleUser.asStateFlow()
+    private val _splashUiState = MutableStateFlow(SplashUiState())
+    val splashUiState: StateFlow<SplashUiState> = _splashUiState.asStateFlow()
 
     init {
+        getAgreementState()
         getGoogleAuthUser()
     }
+
     private fun getGoogleAuthUser() = viewModelScope.launch {
         getGoogleAuthUserUseCase().collect {
-            _googleUser.value = it
+            _splashUiState.update { state ->
+                state.copy(
+                    googleUser = it
+                )
+            }
+        }
+    }
+
+    private fun getAgreementState() = viewModelScope.launch {
+        getAgreementStateUseCase().collect {
+            _splashUiState.update { state ->
+                state.copy(
+                    isAgreementChecked = it
+                )
+            }
         }
     }
 


### PR DESCRIPTION
## Description
스플래시 과정에서 다음과 같은 과정을 거쳐 구글 로그인이 되어있는지를 확인한다.
GoogleAuthClient에서 getGoogleAuthUser()를 통해 Firebase.auth에서 현재 구글에 로그인된 사용자 정보를 확인하고 UserData 객체로 반환하거나 혹은 사용자가 인증되어 있지 않다면 즉, 로그인이 되어있지 않다면 null을 반환한다.

로그아웃 시 스플래시부터 진행하고 이 때, 사용자 인증을 통해 인증이 없다면 로그인 과정부터 진행해야 하지만 Firebase.auth로부터 정보를 확인하는 과정에서 일부 로그아웃 처리가 되기 전 상태를 받아와 메인 액티비티로 진행되는 이슈 발견

이를 보장하기 위해 기존 약관동의 상태를 활용해 약관동의 상태와 Firebase.auth의 인증 정보가 모두 존재할 시 메인 액티비티로 넘어가도록 수정