### PR TITLE
#PAR-298 : 매칭 잡기를 중복으로 클릭할 수 없도록 변경

### DIFF
--- a/feature/battle/src/main/java/online/partyrun/partyrunapplication/feature/battle/BattleMainScreen.kt
+++ b/feature/battle/src/main/java/online/partyrun/partyrunapplication/feature/battle/BattleMainScreen.kt
@@ -180,13 +180,10 @@ fun BattleMainBody(
         PartyRunMatchButton(
             modifier = Modifier.padding(bottom = 70.dp),
             onClick = {
-                matchViewModel.openMatchDialog()
-                matchViewModel.beginBattleMatchingProcess(
-                    RunningDistance(
-                        distance = 1000
-                    )
-                )
-            }
+                if (matchUiState.isMatchingBtnEnabled) { // enabled로 할 경우 버튼이 사라지는 현상을 방지하기 위해 조건부로 처리
+                    matchingAction(matchViewModel)
+                }
+            },
         ) {
             Text(
                 text = stringResource(id = R.string.battle_matching_start),
@@ -194,4 +191,14 @@ fun BattleMainBody(
             )
         }
     }
+}
+
+private fun matchingAction(matchViewModel: MatchViewModel) {
+    matchViewModel.setMatchingBtnEnabled(isEnabled = false)
+    matchViewModel.openMatchDialog()
+    matchViewModel.beginBattleMatchingProcess(
+        RunningDistance(
+            distance = 1000
+        )
+    )
 }

--- a/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/MatchDialogScreen.kt
+++ b/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/MatchDialogScreen.kt
@@ -32,7 +32,7 @@ fun MatchDialog(
     matchViewModel: MatchViewModel = viewModel(),
 ) {
     val context = LocalContext.current
-    val matchState by matchViewModel.matchUiState.collectAsStateWithLifecycle()
+    val matchUiState by matchViewModel.matchUiState.collectAsStateWithLifecycle()
     val exoPlayer = remember { context.buildExoPlayer(getVideoUri()) }
     val isBuffering = remember { mutableStateOf(true) } // 로딩 상태를 관리하기 위한 MutableState
 
@@ -56,13 +56,14 @@ fun MatchDialog(
         }
     }
 
-    when (matchState.matchProgress.name) {
+    when (matchUiState.matchProgress.name) {
         MatchProgress.WAITING.name ->
             MatchWaitingDialog(
                 setShowDialog = setShowDialog,
                 disconnectMatching = {
                     matchViewModel.cancelMatchWaitingEvent()
                     matchViewModel.disconnectMatchEventSource()
+                    matchViewModel.setMatchingBtnEnabled(isEnabled = true)
                 },
                 exoPlayer = exoPlayer,
                 isBuffering = isBuffering
@@ -79,7 +80,7 @@ fun MatchDialog(
             )
         MatchProgress.RESULT.name ->
             MatchResultDialog(
-                matchUiState = matchState
+                matchUiState = matchUiState
             )
         MatchProgress.CANCEL.name ->
             MatchCancelDialog(

--- a/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/MatchUiState.kt
+++ b/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/MatchUiState.kt
@@ -26,6 +26,7 @@ enum class MatchResultStatus {
 data class MatchUiState(
     val isOpen: Boolean = false,
     val isAllRunnersAccepted: Boolean = false,
+    val isMatchingBtnEnabled: Boolean = true,
     val runnerIds: RunnerIds = RunnerIds(emptyList()),
     val runnerInfoData: RunnerInfoData = RunnerInfoData(emptyList()),
     val matchProgress: MatchProgress = MatchProgress.WAITING,

--- a/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/MatchViewModel.kt
+++ b/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/MatchViewModel.kt
@@ -84,6 +84,14 @@ class MatchViewModel @Inject constructor(
         _matchUiState.value = MatchUiState()
     }
 
+    fun setMatchingBtnEnabled(isEnabled: Boolean) {
+        _matchUiState.update { state ->
+            state.copy(
+                isMatchingBtnEnabled = isEnabled
+            )
+        }
+    }
+
     fun clearSnackbarMessage() {
         _snackbarMessage.value = ""
     }


### PR DESCRIPTION
## Description
사용자가 매칭 잡기를 중복으로 눌렀을 경우, 상대방이 수락을 누르더라도 정상적으로 매칭 완료가 되지 않는 이슈 발생

매칭버튼의 enabled 상태를 추적해 버튼의 클릭 가능 여부를 판단하려 했지만, enabled가 false일 때 버턴이 사라지는 현상이 있어,

enabled 속성으로 제어하지 않고 onClick에서 조건부로 판단할 수 있게 수정.