### PR TITLE
fix : PlayerView를 빌드하는 과정에서 생기는 검은 로딩 화면 제거

### DIFF
--- a/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/ui/MatchWaitingDialog.kt
+++ b/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/ui/MatchWaitingDialog.kt
@@ -99,10 +99,10 @@ private fun ExoPlayerBox(
                 factory = { it.buildPlayerView(exoPlayer) },
                 modifier = Modifier
                     .fillMaxSize()
-                    .alpha(if (visible.value) 1f else 0.2f)
+                    .alpha(if (visible.value) 1f else 0f)
             ) {
                 scope.launch {
-                    delay(500L)
+                    delay(200L)
                     visible.value = true
                 }
             }


### PR DESCRIPTION
## Implementation
# 기존

https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/6ea5e025-a5e9-4a1b-aa63-c28b4fd9d166


# 변경

https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/696b53f1-3370-4650-852d-5d4af873b49e

