### PR TITLE
feat : MyPage Profile Image aspectRatio, matchHeightConstraintsFirst 적용

### DIFF
--- a/core/designsystem/src/main/java/online/partyrun/partyrunapplication/core/designsystem/component/RenderAsyncImage.kt
+++ b/core/designsystem/src/main/java/online/partyrun/partyrunapplication/core/designsystem/component/RenderAsyncImage.kt
@@ -3,6 +3,7 @@ package online.partyrun.partyrunapplication.core.designsystem.component
 import androidx.compose.foundation.Image
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import coil.compose.AsyncImagePainter
 import coil.compose.rememberAsyncImagePainter
@@ -34,6 +35,7 @@ fun RenderAsyncImage(
 
 @Composable
 fun RenderAsyncUrlImage(
+    modifier: Modifier = Modifier,
     imageUrl: String, // URL 문자열.
     contentDescription: String?,
 ) {
@@ -49,6 +51,7 @@ fun RenderAsyncUrlImage(
         CircularProgressIndicator()
     }
     Image(
+        modifier = modifier,
         painter = painter,
         contentDescription = contentDescription
     )

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageScreen.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageScreen.kt
@@ -3,6 +3,7 @@ package online.partyrun.partyrunapplication.feature.my_page
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
@@ -261,6 +262,7 @@ private fun ProfileImage(
         contentAlignment = Alignment.Center,
         modifier = Modifier
             .size(80.dp)
+            .aspectRatio(1f, matchHeightConstraintsFirst = true)
             .clip(CircleShape)
             .zIndex(1f)
     ) {


### PR DESCRIPTION
## Description
 .aspectRatio(1f, matchHeightConstraintsFirst = true)
-> UI 요소의 가로세로비(aspect ratio)를 1:1로 설정
-> matchHeightConstraintsFirst가 true로 설정 -> 제약 조건 내에서 먼저 높이를 맞춘 후 그에 맞게 너비 설정 