### PR TITLE
#PAR-305 : 대결을 뛴 러너들의 GPS 좌표를 통해 구글맵에 경로 표시 

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -21,9 +21,11 @@ jobs:
       env:
         BASE_URL: ${{ secrets.BASE_URL }}
         FIREBASE_GOOGLE_CLIENT_ID: ${{ secrets.FIREBASE_GOOGLE_CLIENT_ID }}
+        MAPS_API_KEY: ${{ secrets.MAPS_API_KEY }}
       run: |
         echo BASE_URL=\"$BASE_URL\" >> ./local.properties
         echo FIREBASE_GOOGLE_CLIENT_ID=\"$FIREBASE_GOOGLE_CLIENT_ID\" >> ./local.properties
+        echo MAPS_API_KEY=\"$MAPS_API_KEY\" >> ./local.properties
 
     - name: Create google-services.json
       env:

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,9 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.PartyRunApplication"
         tools:targetApi="31">
+        <meta-data
+            android:name="com.google.android.geo.API_KEY"
+            android:value="${MAPS_API_KEY}" />
         <activity
             android:name=".AuthActivity"
             android:exported="true"

--- a/app/src/main/java/online/partyrun/partyrunapplication/ui/PartyRunMain.kt
+++ b/app/src/main/java/online/partyrun/partyrunapplication/ui/PartyRunMain.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/running_result/BattleRunnerRecord.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/running_result/BattleRunnerRecord.kt
@@ -1,0 +1,14 @@
+package online.partyrun.partyrunapplication.core.model.running_result
+
+/**
+ * 해당 러너가 뛴 각 기록에 대한 세부 정보
+ * @param time: 해당 GPS가 찍힌 시간
+ * @param distance: 해당 GPS까지의 달린 총 거리
+ */
+data class BattleRunnerRecord(
+    val altitude: Double,
+    val latitude: Double,
+    val longitude: Double,
+    val time: String,
+    val distance: Double
+)

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/running_result/BattleRunnerStatus.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/running_result/BattleRunnerStatus.kt
@@ -4,7 +4,8 @@ data class BattleRunnerStatus(
     val endTime: String = "",
     val id: String = "", // 해당 Runner ID
     val name: String = "",
+    val elapsedTime: String = "", // 총 달린 시간
     val profile: String = "",
     val rank: Int = 0,
-    val elapsedTime: String = "" // 총 달린 시간
+    val records: List<BattleRunnerRecord> = listOf() // records 필드 추가
 )

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/BattleRunnerRecordResponse.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/BattleRunnerRecordResponse.kt
@@ -1,0 +1,33 @@
+package online.partyrun.partyrunapplication.core.network.model.response
+
+import com.google.gson.annotations.SerializedName
+import online.partyrun.partyrunapplication.core.model.running_result.BattleRunnerRecord
+import online.partyrun.partyrunapplication.core.model.util.DateTimeUtils.localDateTimeFormatter
+import online.partyrun.partyrunapplication.core.network.model.util.formatTime
+import java.time.LocalDateTime
+
+data class BattleRunnerRecordResponse(
+    @SerializedName("altitude")
+    val altitude: Double?,
+    @SerializedName("latitude")
+    val latitude: Double?,
+    @SerializedName("longitude")
+    val longitude: Double?,
+    @SerializedName("time")
+    val time: String?,
+    @SerializedName("distance")
+    val distance: Double?
+)
+
+fun BattleRunnerRecordResponse.toDomainModel(): BattleRunnerRecord {
+
+    val parsedTime =
+        this.time?.let { LocalDateTime.parse(it, localDateTimeFormatter) }
+    return BattleRunnerRecord(
+        altitude = this.altitude ?: 0.0,
+        latitude = this.latitude ?: 0.0,
+        longitude = this.longitude ?: 0.0,
+        time = parsedTime?.let { formatTime(it) } ?: "", // "xx:xx" 형식화
+        distance = this.distance ?: 0.0
+    )
+}

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/BattleRunnerStatusResponse.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/BattleRunnerStatusResponse.kt
@@ -8,32 +8,48 @@ import online.partyrun.partyrunapplication.core.network.model.util.formatTime
 import java.time.LocalDateTime
 
 data class BattleRunnerStatusResponse(
-    @SerializedName("endTime")
-    val endTime: String?,
     @SerializedName("id")
     val id: String?,
     @SerializedName("rank")
-    val rank: Int?
+    val rank: Int?,
+    @SerializedName("endTime")
+    val endTime: String?,
+    @SerializedName("records")
+    val records: List<BattleRunnerRecordResponse>
 )
 
 /**
  * BattleResultResponse로부터 startTime을 인자로 받아 elapsedTime 계산
  */
-fun BattleRunnerStatusResponse.toDomainModel(startTime: LocalDateTime?) : BattleRunnerStatus {
+fun BattleRunnerStatusResponse.toDomainModel(startTime: LocalDateTime?): BattleRunnerStatus {
+    val parsedEndTime = parseEndTime(this.endTime)
+
+    return BattleRunnerStatus(
+        endTime = formatEndTime(parsedEndTime),
+        id = this.id ?: "Unknown",
+        rank = this.rank ?: -1,
+        elapsedTime = calculateElapsedTimeToDomainModel(startTime, parsedEndTime),
+        records = this.records.map { it.toDomainModel() } // 각 record를 도메인 모델로 변환
+    )
+}
+
+private fun calculateElapsedTimeToDomainModel(
+    startTime: LocalDateTime?,
+    parsedEndTime: LocalDateTime?
+) = if (startTime != null && parsedEndTime != null) {
+    calculateElapsedTime(startTime, parsedEndTime)
+} else {
+    "00:00"
+}
+
+private fun parseEndTime(endTime: String?): LocalDateTime? {
     /**
      *  LocalDateTime.parse() :
      *  문자열 형태로 표현된 날짜와 시간 정보를 LocalDateTime 객체로 변환 수행
      */
-    val parsedEndTime = this.endTime?.let { LocalDateTime.parse(it, localDateTimeFormatter) }
+    return endTime?.let { LocalDateTime.parse(it, localDateTimeFormatter) }
+}
 
-    return BattleRunnerStatus(
-        endTime = parsedEndTime?.let { formatTime(it) } ?: "00:00",
-        id = this.id ?: "Unknown",
-        rank = this.rank ?: -1,
-        elapsedTime = if (startTime != null && parsedEndTime != null) {
-            calculateElapsedTime(startTime, parsedEndTime)
-        } else {
-            "00:00"
-        }
-    )
+private fun formatEndTime(parsedEndTime: LocalDateTime?): String {
+    return parsedEndTime?.let { formatTime(it) } ?: "00:00"
 }

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentViewModel.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentViewModel.kt
@@ -221,6 +221,10 @@ class BattleContentViewModel @Inject constructor(
         }
     }
 
+    /**
+     * 위치 업데이트를 주기적으로 요청하며,
+     * 새로운 위치 정보가 도착하면 onLocationResult 콜백 메서드를 통해 처리
+     */
     @SuppressLint("MissingPermission")
     fun startLocationUpdates(
         battleId: String
@@ -231,7 +235,6 @@ class BattleContentViewModel @Inject constructor(
             locationRequest, locationCallback, Looper.getMainLooper(),
         )
     }
-
     private fun setLocationCallback(battleId: String) {
         locationCallback = object : LocationCallback() {
             override fun onLocationResult(result: LocationResult) {

--- a/feature/running_result/src/main/java/online/partyrun/partyrunapplication/feature/running_result/RunningResultScreen.kt
+++ b/feature/running_result/src/main/java/online/partyrun/partyrunapplication/feature/running_result/RunningResultScreen.kt
@@ -2,6 +2,7 @@ package online.partyrun.partyrunapplication.feature.running_result
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -26,7 +27,11 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -53,6 +58,7 @@ import online.partyrun.partyrunapplication.core.designsystem.component.PartyRunG
 import online.partyrun.partyrunapplication.core.designsystem.component.RenderAsyncUrlImage
 import online.partyrun.partyrunapplication.core.designsystem.icon.PartyRunIcons
 import online.partyrun.partyrunapplication.core.model.running_result.BattleResult
+import online.partyrun.partyrunapplication.core.model.running_result.BattleRunnerRecord
 import online.partyrun.partyrunapplication.core.model.running_result.BattleRunnerStatus
 
 @Composable
@@ -74,7 +80,7 @@ fun RunningResultScreen(
 private fun Content(
     modifier: Modifier = Modifier,
     runningResultUiState: RunningResultUiState,
-    navigateToTopLevel: () -> Unit
+    navigateToTopLevel: () -> Unit,
 ) {
     Box(modifier = modifier) {
         when (runningResultUiState) {
@@ -101,12 +107,17 @@ private fun LoadingBody() {
     }
 }
 
-
 @Composable
 private fun RunningResultBody(
     battleResult: BattleResult,
     navigateToTopLevel: () -> Unit
 ) {
+    // userID에 해당하는 러너 찾기
+    val userStatus = battleResult.battleRunnerStatus.find { it.id == battleResult.userId }
+
+    // 선택된 runner의 상태 정보 관리
+    var selectedRunner by remember { mutableStateOf(userStatus) }
+
     Box(
         modifier = Modifier.fillMaxSize()
     ) {
@@ -121,7 +132,10 @@ private fun RunningResultBody(
                     .fillMaxWidth()
                     .heightIn(400.dp) // 지도의 높이는 400dp
             ) {
-                MapWidget(battleResult)
+                MapWidget(
+                    targetDistance = battleResult.targetDistanceFormatted,
+                    records = selectedRunner?.records
+                )
             }
 
             // 프레임 컴포넌트
@@ -150,7 +164,10 @@ private fun RunningResultBody(
                             .offset(y = (-40).dp)
                     ) {
                         UserProfiles(
-                            users = battleResult.battleRunnerStatus
+                            users = battleResult.battleRunnerStatus,
+                            onRunnerSelected = {
+                                selectedRunner = it
+                            } // UserProfile을 클릭할 때 해당 runner의 상태 업데이트
                         )
                     }
 
@@ -210,19 +227,19 @@ private fun RunningResultBody(
 
 @Composable
 private fun MapWidget(
-    battleResult: BattleResult
+    targetDistance: String,
+    records: List<BattleRunnerRecord>?,
 ) {
-    // battleResult의 첫 번째 battleRunnerStatus에서 records를 가져와서 LatLng 리스트로 변환
-    val points = battleResult.battleRunnerStatus.firstOrNull()?.records?.map {
-        LatLng(it.latitude, it.longitude)
-    } ?: listOf()
-
-    // 전체 좌표들 중 중간 좌표 구하기
+    val points = records?.map { LatLng(it.latitude, it.longitude) } ?: listOf()
     val centerLatLng = getCenterLatLng(points)
 
-    // centerLatLng 사용하여 카메라의 초기 위치 및 zoom 설정. -> 1000M면 14.5f https://ai-programmer.tistory.com/2
-    val cameraPositionState: CameraPositionState = rememberCameraPositionState {
-        position = CameraPosition.fromLatLngZoom(centerLatLng, 14.5f)
+    /*
+     * centerLatLng 사용하여 카메라의 초기 위치 및 zoom 설정. -> 1000M면 14.5f https://ai-programmer.tistory.com/2
+     * centerLatLng의 변화를 감지하여 cameraPositionState 업데이트
+     */
+    val cameraPositionState: CameraPositionState = rememberCameraPositionState()
+    LaunchedEffect(centerLatLng) {
+        cameraPositionState.position = CameraPosition.fromLatLngZoom(centerLatLng, 14.5f)
     }
 
     GoogleMap(
@@ -247,10 +264,13 @@ private fun MapWidget(
             .clip(RoundedCornerShape(15.dp))
             .background(color = MaterialTheme.colorScheme.primary)
     ) {
-        DistanceBox(battleResult)
+        DistanceBox(targetDistance)
     }
 }
 
+/**
+ * cameraPosition를 중앙에 위치시키기 위한 points 중앙 좌표를 구하는 작업 수행
+ */
 @Composable
 private fun getCenterLatLng(points: List<LatLng>): LatLng {
     val startLatLng = points.firstOrNull() ?: LatLng(0.0, 0.0)
@@ -349,7 +369,7 @@ private fun FixedBottomNavigationSheet(navigateToTopLevel: () -> Unit) {
 }
 
 @Composable
-private fun DistanceBox(battleResult: BattleResult) {
+private fun DistanceBox(targetDistance: String) {
     Row(
         modifier = Modifier.padding(10.dp)
     ) {
@@ -363,7 +383,7 @@ private fun DistanceBox(battleResult: BattleResult) {
             colorFilter = ColorFilter.tint(color = MaterialTheme.colorScheme.onPrimary)
         )
         Text(
-            text = battleResult.targetDistanceFormatted, // "X,xxx m"로 형식화
+            text = targetDistance, // "X,xxx m" 형식
             style = MaterialTheme.typography.titleLarge,
             color = MaterialTheme.colorScheme.onPrimary
         )
@@ -373,6 +393,7 @@ private fun DistanceBox(battleResult: BattleResult) {
 @Composable
 fun UserProfiles(
     users: List<BattleRunnerStatus>,
+    onRunnerSelected: (BattleRunnerStatus) -> Unit // 러너 프로필 클릭 시 호출될 콜백
 ) {
     LazyRow(
         modifier = Modifier.padding(all = 8.dp),
@@ -380,7 +401,8 @@ fun UserProfiles(
     ) {
         items(users) { runner ->
             UserProfile(
-                runner = runner
+                runner = runner,
+                onRunnerClick = { onRunnerSelected(runner) } // 선택된 runner 정보로 업데이트
             )
         }
     }
@@ -389,9 +411,12 @@ fun UserProfiles(
 @Composable
 fun UserProfile(
     runner: BattleRunnerStatus,
+    onRunnerClick: () -> Unit
 ) {
     Box(
-        modifier = Modifier.fillMaxWidth()
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onRunnerClick) // 사용자 프로필 클릭 시 runner 정보 업데이트
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,

--- a/feature/running_result/src/main/java/online/partyrun/partyrunapplication/feature/running_result/RunningResultViewModel.kt
+++ b/feature/running_result/src/main/java/online/partyrun/partyrunapplication/feature/running_result/RunningResultViewModel.kt
@@ -59,7 +59,10 @@ class RunningResultViewModel @Inject constructor(
             getBattleResultUseCase().collect { result ->
                 result.onSuccess { data ->
                     // 여기서 battleData의 runnerId와 battleResult의 id를 비교하여 name과 profile을 매핑
-                    val battleResultStatus = mappingRunnerInfo(data, battleData)
+                    val battleResultStatus = mappingRunnerInfo(
+                        data = data,
+                        battleData = battleData
+                    )
 
                     _runningResultUiState.value = RunningResultUiState.Success(
                         battleResult = data.copy(
@@ -76,10 +79,10 @@ class RunningResultViewModel @Inject constructor(
     }
 
     private fun mappingRunnerInfo(
-        it: BattleResult,
+        data: BattleResult,
         battleData: BattleStatus
     ): List<BattleRunnerStatus> {
-        val battleResultStatus = it.battleRunnerStatus.map { battleRunnerStatus ->
+        val battleResultStatus = data.battleRunnerStatus.map { battleRunnerStatus ->
             val runnerStatus =
                 battleData.battleInfo.find { runnerStatus -> runnerStatus.runnerId == battleRunnerStatus.id }
             battleRunnerStatus.copy(

--- a/feature/running_result/src/main/java/online/partyrun/partyrunapplication/feature/running_result/RunningResultViewModel.kt
+++ b/feature/running_result/src/main/java/online/partyrun/partyrunapplication/feature/running_result/RunningResultViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import online.partyrun.partyrunapplication.core.common.result.onFailure
 import online.partyrun.partyrunapplication.core.common.result.onSuccess
@@ -25,36 +24,18 @@ class RunningResultViewModel @Inject constructor(
     private val getBattleStatusUseCase: GetBattleStatusUseCase
 ) : ViewModel() {
 
-    private lateinit var userId: String
     private val _runningResultUiState =
         MutableStateFlow<RunningResultUiState>(RunningResultUiState.Loading)
     val runningResultUiState = _runningResultUiState.asStateFlow()
 
     init {
         getBattleResult()
-        getUserId()
-    }
-
-    private fun getUserId() {
-        viewModelScope.launch {
-            userId = getUserIdUseCase()
-            _runningResultUiState.update { state ->
-                when (state) {
-                    is RunningResultUiState.Success -> state.copy(
-                        battleResult = state.battleResult.copy(
-                            userId = userId
-                        )
-                    )
-
-                    else -> state
-                }
-            }
-        }
     }
 
     private fun getBattleResult() {
         viewModelScope.launch {
             val battleData = getBattleStatusUseCase()
+            val userId = getUserIdUseCase()
 
             getBattleResultUseCase().collect { result ->
                 result.onSuccess { data ->
@@ -66,6 +47,7 @@ class RunningResultViewModel @Inject constructor(
 
                     _runningResultUiState.value = RunningResultUiState.Success(
                         battleResult = data.copy(
+                            userId = userId,
                             battleRunnerStatus = battleResultStatus
                         )
                     )


### PR DESCRIPTION
## Description
서버로부터 대결 결과를 받아올 때 러너들의 좌표정보(records)도 받아오도록 수정.
좌표 정보로부터 구글맵에 경로를 보여준다.
또한, 특정 러너를 클릭했을 시 그 러너의 정보를 보여줄 수 있도록 한다.

## Implementation

https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/4399b929-db47-4107-98c8-50936705178c


