### PR TITLE
#PAR-306 : MatchingButton Debounce 적용

### DIFF
--- a/feature/battle/src/main/java/online/partyrun/partyrunapplication/feature/battle/BattleMainScreen.kt
+++ b/feature/battle/src/main/java/online/partyrun/partyrunapplication/feature/battle/BattleMainScreen.kt
@@ -33,6 +33,9 @@ import online.partyrun.partyrunapplication.feature.match.MatchDialog
 import online.partyrun.partyrunapplication.feature.match.MatchUiState
 import online.partyrun.partyrunapplication.feature.match.MatchViewModel
 
+private var lastClickTime = 0L
+private const val DEBOUNCE_DURATION = 100  // 0.1 seconds
+
 @Composable
 fun BattleMainScreen(
     modifier: Modifier = Modifier,
@@ -180,10 +183,14 @@ fun BattleMainBody(
         PartyRunMatchButton(
             modifier = Modifier.padding(bottom = 70.dp),
             onClick = {
-                if (matchUiState.isMatchingBtnEnabled) { // enabled로 할 경우 버튼이 사라지는 현상을 방지하기 위해 조건부로 처리
+                /**
+                 * matchUiState.isMatchingBtnEnabled를 조건부로 처리 ->
+                 * enabled로 할 경우 버튼이 사라지는 현상 방지
+                 */
+                if (isDebounced(System.currentTimeMillis()) && matchUiState.isMatchingBtnEnabled) {
                     matchingAction(matchViewModel)
                 }
-            },
+            }
         ) {
             Text(
                 text = stringResource(id = R.string.battle_matching_start),
@@ -202,3 +209,12 @@ private fun matchingAction(matchViewModel: MatchViewModel) {
         )
     )
 }
+
+fun isDebounced(currentTime: Long): Boolean {
+    if (currentTime - lastClickTime > DEBOUNCE_DURATION) {
+        lastClickTime = currentTime
+        return true
+    }
+    return false
+}
+


### PR DESCRIPTION
## Description
매칭 버튼이 2번 클릭이 되지 않도록 한번 클릭이 되면 버튼의 enabled 상태로 바꾸게 해놨지만,
트랙패드와 같이 민감하게 터치가 가능한 경우, 0.002초 사이에 2번 클릭이 되어 매칭 대기열에 Connect Event가 2번 일어나는 문제가 발생
이에, debounce기법을 적용하여 연속 클릭을 제한하는 시간을 설정 → 이 시간 동안의 추가 클릭은 무시하도록 변경

## Part
BattleMainScreen의 PartyRunMatchButton을 클릭 했을 시, 두 번 클릭하면
SSE Event가
Connection -> Matched(다른 러너가 매칭을 잡았을 때) -> Connection(2번 클릭으로 인한 잔여 대기열 등록)
다음과 같이 오기 때문에 2번째 Connection에서 onFailure(null)가 발생

## Implementation

### 의도적으로 매칭 버튼을 빠르게 반복적으로 눌러도 정상적으로 동작하도록 수정 
https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/49e460d3-1939-4567-859f-752764f9d1a8

