### PR TITLE
fix : ApiResponseCallAdapterFactory ParameterizedType 체크

### DIFF
--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/api_call_adapter/ApiResponseCallAdapterFactory.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/api_call_adapter/ApiResponseCallAdapterFactory.kt
@@ -26,14 +26,24 @@ class ApiResponseCallAdapterFactory private constructor() : CallAdapter.Factory(
             return null
         }
 
-        val callType = getParameterUpperBound(0, returnType as ParameterizedType)
+        // returnType이 ParameterizedType인지 확인
+        if (returnType !is ParameterizedType) {
+            return null
+        }
+        val callType = getParameterUpperBound(0, returnType)
+
         if (getRawType(callType) != ApiResponse::class.java) {
             return null
         }
 
-        val resultType = getParameterUpperBound(0, callType as ParameterizedType)
+        // callType이 ParameterizedType인지 확인
+        if (callType !is ParameterizedType) {
+            return null
+        }
+        val resultType = getParameterUpperBound(0, callType)
         return ApiResponseCallAdapter(resultType)
     }
+
 
     companion object {
         fun create(): ApiResponseCallAdapterFactory = ApiResponseCallAdapterFactory()


### PR DESCRIPTION
## Description
ParameterizedType -> 제네릭을 가진 타입
ex, List<String>이나 Map<Key, Value>처럼 제네릭 타입을 가진 경우

ApiService interface 메서드의 리턴 타입을 보고 적절한 CallAdapter 리턴하는 ApiResponseCallAdapterFactory에서는
제네릭 타입을 요구한다.
callType은 ApiResponse의 제네릭 타입을 확인한다. 즉 리턴 타입이 ApiResponse<T>의 형태인지 확인하는 것인데,
예를 들어, ApiResponse<List<String>>의 경우 List<String>도 ParameterizedType이기에 이것 또한 제네릭 타입인지 확인해야 한다.
이러한 타입 확인은 안전한 형변환과 올바른 타입의 객체 생성을 위해서 필요하고, 기존 이 검사가 없었을 때는, 난독화가 적용된 Release 모드에서는 잘못된 타입에 대한 연산을 시도하게 되어 ClassCastException과 같은 런타임 오류가 발생하게 된다.
따라서, 이러한 타입 검사를 통해 올바른 제네릭 타입을 처리하고,  잘못된 타입에 대한 연산을 방지한다.

## Part
package online.partyrun.partyrunapplication.core.network.api_call_adapter
ApiResponseCallAdapterFactory 클래스
