### PR TITLE
#PAR-307 : 매칭 수락/거절 여부를 판단하는 Dialog에서 다른 곳을 클릭했을 때 닫히지 않도록 수정

### DIFF
--- a/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/MatchDialogScreen.kt
+++ b/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/MatchDialogScreen.kt
@@ -68,9 +68,9 @@ fun MatchDialog(
                 exoPlayer = exoPlayer,
                 isBuffering = isBuffering
             )
+
         MatchProgress.DECISION.name ->
             MatchDecisionDialog(
-                setShowDialog = setShowDialog,
                 onAccept = {
                     matchViewModel.onUserDecision(true)
                 },
@@ -78,10 +78,12 @@ fun MatchDialog(
                     matchViewModel.onUserDecision(false)
                 }
             )
+
         MatchProgress.RESULT.name ->
             MatchResultDialog(
                 matchUiState = matchUiState
             )
+
         MatchProgress.CANCEL.name ->
             MatchCancelDialog(
                 setShowDialog = setShowDialog
@@ -90,7 +92,8 @@ fun MatchDialog(
 }
 
 private fun getVideoUri(): Uri {
-    val videoUri = "https://partyrun-battle-preparation-video.s3.ap-northeast-2.amazonaws.com/develop/battle_preparation_video.mp4"
+    val videoUri =
+        "https://partyrun-battle-preparation-video.s3.ap-northeast-2.amazonaws.com/develop/battle_preparation_video.mp4"
     return Uri.parse(videoUri)
 }
 

--- a/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/ui/MatchDecisionDialog.kt
+++ b/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/ui/MatchDecisionDialog.kt
@@ -28,14 +28,11 @@ import online.partyrun.partyrunapplication.feature.match.R
 
 @Composable
 fun MatchDecisionDialog(
-    setShowDialog: (Boolean) -> Unit,
     onAccept: () -> Unit,
     onDecline: () -> Unit
 ) {
     PartyRunMatchDialog(
-        onDismissRequest = {
-            setShowDialog(false)
-        },
+        onDismissRequest = { },
         modifier = Modifier
             .width(300.dp)
             .height(320.dp)


### PR DESCRIPTION
## Description
기존 매칭 수락/거절 여부를 결정하는 MatchDecisionDialog에서 onDismissRequest부분에 setShowDialog를 설정
이로 인해 Dialog 바깥 부분을 클릭 했을 시 자동으로 setShowDialog 메소드가 호출되어 Dialog가 닫힌다.

이 부분은 수락/거절 만으로 로직 처리가 되어야 하기에, 이러한 부분을 수정해주어야 한다.
따라서, 각 과정의 onDismissRequest와 setShowDialog를 제거한다.

## Part
package online.partyrun.partyrunapplication.feature.match -> MatchWaitingDialog 부분 
package online.partyrun.partyrunapplication.feature.match.ui -> MatchWaitingDialog 부분 


## Implementation
### 변경 전

https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/f5929b80-3e29-4bd4-aa5e-3581c601807d


### 변경 후 

https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/90d39bc1-87a3-46b4-8cb2-0dcd692418b5

