### PR TITLE
#PAR-311 : 사용자가 선택한 distance를 Running Feature까지 전달해 State에 반영

### DIFF
--- a/app/src/main/java/online/partyrun/partyrunapplication/navigation/MainNavHost.kt
+++ b/app/src/main/java/online/partyrun/partyrunapplication/navigation/MainNavHost.kt
@@ -44,8 +44,8 @@ fun SetUpMainNavGraph(
         startDestination = startDestination,
     ) {
         battleRoute(
-            navigateToBattleRunning = {
-                navController.navigate(MainNavRoutes.BattleRunning.route) {
+            navigateToBattleRunningWithDistance = { distance ->
+                navController.navigate("${MainNavRoutes.BattleRunning.route}?distance=$distance") {
                     popUpTo(MainNavRoutes.Battle.route) {
                         inclusive = true
                     }
@@ -66,7 +66,7 @@ fun SetUpMainNavGraph(
             navigateBack = {
                 navController.popBackStack()
             },
-            navigationToProfile ={
+            navigationToProfile = {
                 navController.navigate(MainNavRoutes.Profile.route)
             },
             onShowSnackbar = onShowSnackbar

--- a/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/battle/BattleNavigation.kt
+++ b/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/battle/BattleNavigation.kt
@@ -6,12 +6,12 @@ import online.partyrun.partyrunapplication.core.navigation.main.MainNavRoutes
 import online.partyrun.partyrunapplication.feature.battle.BattleMainScreen
 
 fun NavGraphBuilder.battleRoute(
-    navigateToBattleRunning: () -> Unit,
+    navigateToBattleRunningWithDistance: (Int) -> Unit,
     onShowSnackbar: (String) -> Unit,
 ) {
     composable(route = MainNavRoutes.Battle.route) {
         BattleMainScreen(
-            navigateToBattleRunning = navigateToBattleRunning,
+            navigateToBattleRunningWithDistance = navigateToBattleRunningWithDistance,
             onShowSnackbar = onShowSnackbar
         )
     }

--- a/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/battle_running/BattleRunningNavigation.kt
+++ b/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/battle_running/BattleRunningNavigation.kt
@@ -1,7 +1,9 @@
 package online.partyrun.partyrunapplication.core.navigation.battle_running
 
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavType
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
 import online.partyrun.partyrunapplication.core.navigation.main.MainNavRoutes
 import online.partyrun.partyrunapplication.feature.running.battle.BattleContentScreen
 
@@ -10,10 +12,16 @@ fun NavGraphBuilder.battleRunningRoute(
     navigationToRunningResult: () -> Unit,
     onShowSnackbar: (String) -> Unit
 ) {
+
     composable(
-        route = MainNavRoutes.BattleRunning.route,
-    ) {
+        route = "${MainNavRoutes.BattleRunning.route}?distance={distance}",
+        arguments = listOf(navArgument("distance") {
+            type = NavType.IntType
+            defaultValue = 1000 // 기본 값을 1km로 설정
+        })
+    ) { backStackEntry ->
         BattleContentScreen(
+            targetDistance = backStackEntry.arguments?.getInt("distance"),
             navigateToBattleOnWebSocketError = navigateToBattleOnWebSocketError,
             navigationToRunningResult = navigationToRunningResult,
             onShowSnackbar = onShowSnackbar

--- a/feature/battle/src/main/java/online/partyrun/partyrunapplication/feature/battle/BattleMainScreen.kt
+++ b/feature/battle/src/main/java/online/partyrun/partyrunapplication/feature/battle/BattleMainScreen.kt
@@ -41,7 +41,7 @@ fun BattleMainScreen(
     modifier: Modifier = Modifier,
     battleMainViewModel: BattleMainViewModel = hiltViewModel(),
     matchViewModel: MatchViewModel = hiltViewModel(),
-    navigateToBattleRunning: () -> Unit,
+    navigateToBattleRunningWithDistance: (Int) -> Unit,
     onShowSnackbar: (String) -> Unit,
 ) {
     val battleMainUiState by battleMainViewModel.battleMainUiState.collectAsState()
@@ -54,7 +54,7 @@ fun BattleMainScreen(
         battleMainUiState = battleMainUiState,
         battleMainViewModel = battleMainViewModel,
         matchViewModel = matchViewModel,
-        navigateToBattleRunning = navigateToBattleRunning,
+        navigateToBattleRunningWithDistance = navigateToBattleRunningWithDistance,
         matchUiState = matchUiState,
         battleMainSnackbarMessage = battleMainSnackbarMessage,
         matchSnackbarMessage = matchSnackbarMessage,
@@ -68,14 +68,15 @@ fun Content(
     battleMainUiState: BattleMainUiState,
     battleMainViewModel: BattleMainViewModel,
     matchViewModel: MatchViewModel,
-    navigateToBattleRunning: () -> Unit,
+    navigateToBattleRunningWithDistance: (Int) -> Unit,
     matchUiState: MatchUiState,
     battleMainSnackbarMessage: String,
     matchSnackbarMessage: String,
     onShowSnackbar: (String) -> Unit,
 ) {
     if (matchUiState.isAllRunnersAccepted) {
-        navigateToBattleRunning()
+        val currentKmState by battleMainViewModel.kmState.collectAsState()
+        navigateToBattleRunningWithDistance(currentKmState.toDistance())
         matchViewModel.closeMatchDialog() // 다이얼로그를 닫고 초기화 수행
     }
 

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentScreen.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentScreen.kt
@@ -38,6 +38,7 @@ import online.partyrun.partyrunapplication.feature.running.battle.running.Battle
 
 @Composable
 fun BattleContentScreen(
+    targetDistance: Int?,
     navigateToBattleOnWebSocketError: () -> Unit = {},
     navigationToRunningResult: () -> Unit = {},
     battleContentViewModel: BattleContentViewModel = hiltViewModel(),
@@ -49,6 +50,7 @@ fun BattleContentScreen(
     val openRunningExitDialog = remember { mutableStateOf(false) }
 
     Content(
+        targetDistance = targetDistance,
         navigateToBattleOnWebSocketError = navigateToBattleOnWebSocketError,
         navigationToRunningResult = navigationToRunningResult,
         battleContentViewModel = battleContentViewModel,
@@ -62,6 +64,7 @@ fun BattleContentScreen(
 
 @Composable
 fun Content(
+    targetDistance: Int?,
     navigateToBattleOnWebSocketError: () -> Unit = {},
     navigationToRunningResult: () -> Unit = {},
     battleContentViewModel: BattleContentViewModel,
@@ -71,6 +74,13 @@ fun Content(
     battleContentSnackbarMessage: String,
     onShowSnackbar: (String) -> Unit
 ) {
+    // 사용자가 선택한 거리를 전달받아서 BattleUiState에 업데이트
+    LaunchedEffect(targetDistance) {
+        targetDistance?.let { distance ->
+            battleContentViewModel.updateSelectedDistance(distance)
+        }
+    }
+
     // 대결 중 BackPressed 수행 시 처리할 핸들러
     RunningBackNavigationHandler(
         battleContentViewModel = battleContentViewModel,

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentViewModel.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentViewModel.kt
@@ -95,6 +95,9 @@ class BattleContentViewModel @Inject constructor(
         _snackbarMessage.value = ""
     }
 
+    fun updateSelectedDistance(distance: Int) {
+        _battleUiState.value = _battleUiState.value.copy(selectedDistance = distance)
+    }
 
     private fun getUserId() = viewModelScope.launch {
         userId = getUserIdUseCase()
@@ -235,6 +238,7 @@ class BattleContentViewModel @Inject constructor(
             locationRequest, locationCallback, Looper.getMainLooper(),
         )
     }
+
     private fun setLocationCallback(battleId: String) {
         locationCallback = object : LocationCallback() {
             override fun onLocationResult(result: LocationResult) {


### PR DESCRIPTION
## Description
사용자가 대결 모드 Screen에서 선택한 목표 거리(=targetDistance)를 Running Feature로 전달하여,
Running Feature에서 이 targetDistance를 기준으로 목표 거리 UI Box를 보여주고 비율 기반 거리 매핑 함수인 distanceToCoordinatesMapper에도 적용해 이 targetDistance에 맞게 매핑이 이루어질 수 있도록 한다.

## Implementation
###  예시는 5km (2배속 설정)

https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/d8ae2546-c106-4739-a4f4-59e4b2eba3ea

