### PR TITLE
#PAR-312 : 사용자가 선택한 distance에 따라 Result Screen의 GoogleMap Zoom 셋팅

### DIFF
--- a/feature/running_result/src/main/java/online/partyrun/partyrunapplication/feature/running_result/RunningResultScreen.kt
+++ b/feature/running_result/src/main/java/online/partyrun/partyrunapplication/feature/running_result/RunningResultScreen.kt
@@ -133,7 +133,8 @@ private fun RunningResultBody(
                     .heightIn(400.dp) // 지도의 높이는 400dp
             ) {
                 MapWidget(
-                    targetDistance = battleResult.targetDistanceFormatted,
+                    targetDistance = battleResult.targetDistance,
+                    targetDistanceFormatted = battleResult.targetDistanceFormatted,
                     records = selectedRunner?.records
                 )
             }
@@ -227,7 +228,8 @@ private fun RunningResultBody(
 
 @Composable
 private fun MapWidget(
-    targetDistance: String,
+    targetDistance: Int?,
+    targetDistanceFormatted: String,
     records: List<BattleRunnerRecord>?,
 ) {
     val points = records?.map { LatLng(it.latitude, it.longitude) } ?: listOf()
@@ -237,9 +239,11 @@ private fun MapWidget(
      * centerLatLng 사용하여 카메라의 초기 위치 및 zoom 설정. -> 1000M면 14.5f https://ai-programmer.tistory.com/2
      * centerLatLng의 변화를 감지하여 cameraPositionState 업데이트
      */
+    val zoomValue = getZoomValueForDistance(targetDistance)
+
     val cameraPositionState: CameraPositionState = rememberCameraPositionState()
     LaunchedEffect(centerLatLng) {
-        cameraPositionState.position = CameraPosition.fromLatLngZoom(centerLatLng, 14.5f)
+        cameraPositionState.position = CameraPosition.fromLatLngZoom(centerLatLng, zoomValue)
     }
 
     GoogleMap(
@@ -264,8 +268,23 @@ private fun MapWidget(
             .clip(RoundedCornerShape(15.dp))
             .background(color = MaterialTheme.colorScheme.primary)
     ) {
-        DistanceBox(targetDistance)
+        DistanceBox(targetDistanceFormatted)
     }
+}
+
+/**
+ * targetDistance 값에 따라 zoom 값 결정
+ */
+@Composable
+private fun getZoomValueForDistance(targetDistance: Int?): Float {
+    val zoomValue = when (targetDistance) {
+        1000 -> 14.5f
+        3000 -> 13.5f
+        5000 -> 12.8f
+        10000 -> 12f
+        else -> 12f  // 기본값 혹은 예기치 않은 값에 대한 대응
+    }
+    return zoomValue
 }
 
 /**


### PR DESCRIPTION
## Description
사용자가 선택한 사용자가 선택한 distance에 따라 결과스크린의 구글맵에서 경로를 보여줘야 한다.
이때, 사용자가 달린 모든 경로를 한 눈에 보여주기 위해 Zoom 배율을 적절히 선택하는게 중요하다.
따라서, 1, 3, 5, 10 Km에 따라 적절히 대응한 float값으로 줌 값이 셋팅될 수 있도록 한다.

## Implementation
### 1km -> 14.5f
<img width="385" alt="스크린샷 2023-08-25 오후 4 26 55" src="https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/6cf257cd-2ed5-4b21-8233-2d97c36343dc">

---

### 3km -> 13.5f
<img width="377" alt="스크린샷 2023-08-25 오후 4 27 51" src="https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/00ac9f64-fd64-46b4-b47d-ffef2ef79108">

---

### 5km -> 12.8f
<img width="378" alt="스크린샷 2023-08-25 오후 4 28 53" src="https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/8cbc18a9-83c2-4aa9-b381-288792acce50">

---

### 10km -> 12f
<img width="378" alt="스크린샷 2023-08-25 오후 4 30 00" src="https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/37b3edaa-8fd3-46bd-914c-dd9ca7ccfaa1">
