### PR TITLE
#PAR-313 : Running이 시작되기 전 카운트다운 끝나고부터 진행시간 측정

### DIFF
--- a/core/ui/src/main/java/online/partyrun/partyrunapplication/core/ui/Timer.kt
+++ b/core/ui/src/main/java/online/partyrun/partyrunapplication/core/ui/Timer.kt
@@ -37,6 +37,35 @@ fun FormatElapsedTimer(
 }
 
 @Composable
+fun FormatRunningElapsedTimer(
+    countDown: Int = 5,
+    contentStyle: TextStyle = MaterialTheme.typography.titleMedium,
+    contentColor: Color = MaterialTheme.colorScheme.primary
+) {
+    val elapsedTime = remember { mutableStateOf(0) }
+
+    LaunchedEffect(key1 = countDown) {
+        delay((countDown * 1000).toLong()) // CountDown 시간 대기
+        while (true) {
+            delay(1000L) // 1초 대기
+            elapsedTime.value++ // elapsedTime 증가
+        }
+    }
+
+    val hours = elapsedTime.value / 3600
+    val minutes = (elapsedTime.value % 3600) / 60
+    val seconds = elapsedTime.value % 60
+
+    val displayTime = formatTime(hours, minutes, seconds)
+
+    Text(
+        text = if (countDown > 0 && elapsedTime.value == 0) "00:00" else displayTime,
+        style = contentStyle,
+        color = contentColor
+    )
+}
+
+@Composable
 fun FormatRemainingTimer(totalTime: Int) {
     val remainingTime = remember { mutableStateOf(totalTime) }
 
@@ -61,7 +90,12 @@ fun FormatRemainingTimer(totalTime: Int) {
 
 fun formatTime(hours: Int, minutes: Int, seconds: Int): String {
     if (hours > 0) {
-        return "${String.format("%02d", hours)}:${String.format("%02d", minutes)}:${String.format("%02d", seconds)}"
+        return "${String.format("%02d", hours)}:${
+            String.format(
+                "%02d",
+                minutes
+            )
+        }:${String.format("%02d", seconds)}"
     }
     return "${String.format("%02d", minutes)}:${String.format("%02d", seconds)}"
 }

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/running/BattleRunningScreen.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/running/BattleRunningScreen.kt
@@ -49,7 +49,7 @@ import online.partyrun.partyrunapplication.core.designsystem.component.RenderAsy
 import online.partyrun.partyrunapplication.core.designsystem.icon.PartyRunIcons
 import online.partyrun.partyrunapplication.core.model.battle.RunnerStatus
 import online.partyrun.partyrunapplication.core.ui.BackgroundBlurImage
-import online.partyrun.partyrunapplication.core.ui.FormatElapsedTimer
+import online.partyrun.partyrunapplication.core.ui.FormatRunningElapsedTimer
 import online.partyrun.partyrunapplication.feature.running.R
 import online.partyrun.partyrunapplication.feature.running.battle.BattleContentViewModel
 import online.partyrun.partyrunapplication.feature.running.battle.BattleUiState
@@ -124,7 +124,7 @@ fun BattleRunningScreen(
                         verticalArrangement = Arrangement.Center,
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
-                        FormatElapsedTimer(
+                        FormatRunningElapsedTimer(
                             contentColor = MaterialTheme.colorScheme.onPrimary
                         )
                         Row(
@@ -252,7 +252,8 @@ fun TrackWithMultipleUsers(
                 trackWidth = trackWidth,
                 trackHeight = trackHeight
             )
-            val zIndex = if (runner.runnerId == userId) 1f else 0f // 해당 runnerId가 userId와 같으면 z-index를 1로 설정
+            val zIndex =
+                if (runner.runnerId == userId) 1f else 0f // 해당 runnerId가 userId와 같으면 z-index를 1로 설정
             Box(
                 modifier = Modifier
                     .offset(
@@ -290,7 +291,7 @@ fun TrackWithMultipleUsers(
 
 @Composable
 private fun RunnerMarker(runner: RunnerStatus) {
-    Box (
+    Box(
         contentAlignment = Alignment.Center
     ) {
         // 마커 프레임


### PR DESCRIPTION
## Description
Running이 시작되기 전 카운트다운을 통해 달리기 전 준비상태를 알린다.
그러나, 현재 이 카운트다운에서부터 뒤에 위치한 진행시간이 측정되기 때문에 진행시간이 6초부터 실제 달리기 측정이 시작되고 있다.
따라서, 카운트다운이 끝나고 난 뒤, 진행시간 측정이 시작되도록 FormatRunningElapsedTimer 추가하고 적용한다.

## Implementation
### 변경 전

https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/1329a87f-5dcf-41d6-8319-b901b204d761

---

### 변경 후

https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/2d9d2eca-260d-4b37-bd4f-cd2b6482ead6