### PR TITLE
#PAR-323 : 위치 정보를 획득 및 전달 로직을 서비스에서 담당하도록 수정

### DIFF
--- a/core/common/src/main/java/online/partyrun/partyrunapplication/core/common/Constants.kt
+++ b/core/common/src/main/java/online/partyrun/partyrunapplication/core/common/Constants.kt
@@ -9,4 +9,7 @@ object Constants {
     const val NOTIFICATION_CHANNEL_NAME = "Running_location_updates"
     const val NOTIFICATION_ID = 1050
 
+    const val ACTION_START_RUNNING = "StartRunning"
+    const val ACTION_STOP_RUNNING = "StopRunning"
+    const val BATTLE_ID_KEY = "BATTLE_ID_KEY"
 }

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentScreen.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentScreen.kt
@@ -30,6 +30,9 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.delay
+import online.partyrun.partyrunapplication.core.common.Constants.ACTION_START_RUNNING
+import online.partyrun.partyrunapplication.core.common.Constants.ACTION_STOP_RUNNING
+import online.partyrun.partyrunapplication.core.common.Constants.BATTLE_ID_KEY
 import online.partyrun.partyrunapplication.core.designsystem.component.PartyRunGradientButton
 import online.partyrun.partyrunapplication.core.designsystem.component.PartyRunOutlinedButton
 import online.partyrun.partyrunapplication.core.ui.CountdownDialog
@@ -171,22 +174,20 @@ private fun setOrDisposeBattleRunning(
     battleId: String,
     context: Context
 ) {
+    // Foreground Service 시작/중지
     if (isStarting) {
         viewModel.initBattleState() // 러너 데이터를 기반으로 BattleState를 초기화하고 시작
-        viewModel.startLocationUpdates(battleId)
+        val intent = Intent(context, RunningService::class.java).apply {
+            putExtra(BATTLE_ID_KEY, battleId)
+        }
+        intent.action = ACTION_START_RUNNING
+        context.startService(intent)
     } else {
-        viewModel.stopLocationUpdates()
+        val intent = Intent(context, RunningService::class.java)
+        intent.action = ACTION_STOP_RUNNING
+        context.stopService(intent)
     }
-    toggleRunningService(isStarting, context)
 }
-
-// Foreground Service 시작/중지
-private fun toggleRunningService(isStarting: Boolean, context: Context) {
-    val intent = Intent(context, RunningService::class.java)
-    intent.action = if (isStarting) "StartRunning" else "StopRunning"
-    context.startService(intent)
-}
-
 
 @Composable
 fun RunningBackNavigationHandler(

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/RunningService.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/RunningService.kt
@@ -1,19 +1,49 @@
 package online.partyrun.partyrunapplication.feature.running.battle
 
+import android.annotation.SuppressLint
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.Service
 import android.content.Intent
+import android.location.Location
 import android.os.IBinder
+import android.os.Looper
 import androidx.core.app.NotificationCompat
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.LocationCallback
+import com.google.android.gms.location.LocationRequest
+import com.google.android.gms.location.LocationResult
+import com.google.android.gms.location.Priority
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 import online.partyrun.partyrunapplication.core.common.Constants
+import online.partyrun.partyrunapplication.core.common.Constants.ACTION_START_RUNNING
+import online.partyrun.partyrunapplication.core.common.Constants.ACTION_STOP_RUNNING
+import online.partyrun.partyrunapplication.core.common.Constants.BATTLE_ID_KEY
 import online.partyrun.partyrunapplication.core.common.Constants.NOTIFICATION_ID
+import online.partyrun.partyrunapplication.core.domain.running.SendRecordDataUseCase
+import online.partyrun.partyrunapplication.core.model.running.GpsData
+import online.partyrun.partyrunapplication.core.model.running.RecordData
+import online.partyrun.partyrunapplication.feature.running.R
+import java.time.LocalDateTime
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 @AndroidEntryPoint
 class RunningService : Service() {
+    companion object {
+        const val LOCATION_UPDATE_INTERVAL_SECONDS = 1L
+    }
+
+    @Inject
+    lateinit var fusedLocationProviderClient: FusedLocationProviderClient
+
+    @Inject
+    lateinit var sendRecordDataUseCase: SendRecordDataUseCase
 
     @Inject
     lateinit var notificationManager: NotificationManager
@@ -21,28 +51,78 @@ class RunningService : Service() {
     @Inject
     lateinit var notification: NotificationCompat.Builder
 
+    private val job = Job()
+    private val serviceScope = CoroutineScope(Dispatchers.IO + job)
+
+    private lateinit var locationRequest: LocationRequest
+    private lateinit var locationCallback: LocationCallback
+
+    private val recordData = mutableListOf<GpsData>() // 1초마다 업데이트한 GPS 데이터를 쌓기 위함
+
     override fun onCreate() {
         super.onCreate()
+        initLocationRequest()
+    }
 
+    private fun initLocationRequest() {
+        val priority = Priority.PRIORITY_HIGH_ACCURACY
+        locationRequest = LocationRequest.Builder(
+            priority,
+            TimeUnit.SECONDS.toMillis(LOCATION_UPDATE_INTERVAL_SECONDS)
+        ).build()
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         when (intent?.action) {
-            "StartRunning" -> {
-                startForeground(NOTIFICATION_ID, createNotification())
-            }
-
-            "StopRunning" -> {
-                stopForeground(STOP_FOREGROUND_REMOVE)
-                stopSelf()
-            }
+            ACTION_START_RUNNING -> startRunningService(intent)
+            ACTION_STOP_RUNNING -> stopRunningService()
         }
-
         return START_NOT_STICKY
     }
 
-    override fun onBind(intent: Intent?): IBinder? {
-        return null
+    @SuppressLint("MissingPermission")
+    private fun startRunningService(intent: Intent) {
+        val battleId = intent.getStringExtra(BATTLE_ID_KEY) ?: return
+
+        startForeground(NOTIFICATION_ID, createNotification())
+        setLocationCallback(battleId)
+
+        fusedLocationProviderClient.requestLocationUpdates(
+            locationRequest, locationCallback, Looper.getMainLooper()
+        )
+    }
+
+    private fun stopRunningService() {
+        stopLocationUpdates()
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        stopSelf()
+    }
+
+    private fun setLocationCallback(battleId: String) {
+        locationCallback = object : LocationCallback() {
+            override fun onLocationResult(result: LocationResult) {
+                result.lastLocation?.let { location ->
+                    addGpsDataToRecordData(location)
+                    if (recordData.size >= 3) {
+                        serviceScope.launch {
+                            sendRecordDataUseCase(battleId, RecordData(recordData))
+                            recordData.clear() // clear the location update list
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun addGpsDataToRecordData(location: Location) {
+        recordData.add(
+            GpsData(
+                latitude = location.latitude,
+                longitude = location.longitude,
+                altitude = location.altitude,
+                time = LocalDateTime.now()
+            )
+        )
     }
 
     private fun createNotification(): Notification {
@@ -53,12 +133,9 @@ class RunningService : Service() {
         )
         notificationManager.createNotificationChannel(channel)
 
-        val title = "파티런"
-        val content = "현재 러닝 진행 중입니다."
-
         val builder = notification
-            .setContentTitle(title)
-            .setContentText(content)
+            .setContentTitle(getString(R.string.running_service_title))
+            .setContentText(getString(R.string.running_service_content))
             .setPriority(NotificationCompat.PRIORITY_HIGH)
             .setCategory(NotificationCompat.CATEGORY_MESSAGE)
             .setAutoCancel(true)
@@ -66,4 +143,19 @@ class RunningService : Service() {
         return builder.build()
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        stopLocationUpdates()
+    }
+
+    private fun stopLocationUpdates() {
+        locationCallback.let {
+            fusedLocationProviderClient.removeLocationUpdates(it)
+        }
+        job.cancel()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? {
+        return null
+    }
 }

--- a/feature/running/src/main/res/values/strings.xml
+++ b/feature/running/src/main/res/values/strings.xml
@@ -22,4 +22,7 @@
     <string name="exit_dialog_confirm">예</string>
     <string name="exit_dialog_cancel">아니오</string>
 
+    <string name="running_service_title">파티런</string>
+    <string name="running_service_content">현재 러닝 진행 중입니다.</string>
+
 </resources>


### PR DESCRIPTION
## Description
기존에는 위치 정보 획득 및 전송 프로세스 로직을 ViewModel에서 처리한다. 그러나, ViewModel은 화면 LifeCycle에 종속적이기에 
백그라운드 모드에서도 지속적으로 위치 정보를 얻기 위해 Service가 위치 정보 획득 및 전송 과정을 총괄하도록 변경한다.
위치 정보는 fusedLocationProviderClient를 통해 얻어오기에 Service에서 @Inject를 통해 Client를 주입받아 받아 위치 정보를 획득한다.
따라서, Running Service에서 위치 정보를 획득 후 UseCase를 통해 값을 전달한다.