### PR TITLE
#PAR-321 : SensorManager를 통해 디바이스의 정지 상태를 파악하고 유효하지 않은 GPS 데이터를 필터링한다.

### DIFF
--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/di/LocationModule.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/di/LocationModule.kt
@@ -1,6 +1,7 @@
 package online.partyrun.partyrunapplication.core.data.di
 
 import android.content.Context
+import android.hardware.SensorManager
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
 import dagger.Module
@@ -8,6 +9,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -18,6 +20,12 @@ object LocationModule {
         @ApplicationContext context: Context
     ): FusedLocationProviderClient {
         return LocationServices.getFusedLocationProviderClient(context)
+    }
+
+    @Provides
+    @Singleton
+    fun provideSensorManager(@ApplicationContext context: Context): SensorManager {
+        return context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
     }
 
 }

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/RunningService.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/RunningService.kt
@@ -110,7 +110,9 @@ class RunningService : Service() {
     }
 
     private val sensorEventListener = object : SensorEventListener {
-        override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {}
+        override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {
+            // 현재 사용하지 않는 메소드지만 반드시 오버라이드해야 하는 추상 메서드
+        }
 
         override fun onSensorChanged(event: SensorEvent?) {
             event?.let {


### PR DESCRIPTION
## Description
SensorManager와 FusedLocationProviderClient를 동시에 사용하여 GPS 오차를 보정한다.
GPS만을 사용하는 경우 실내나 빌딩 사이와 같은 일부 지역에서 GPS 좌표가 확 튀는 등 정확도가 떨어진다. 반면에 센서(가속도계, 자이로스코프 등)는 이러한 환경에서 디바이스 기반의 값을 제공하기 때문에 이 둘의 데이터를 적절히 활용해 신뢰도를 높인다.
SensorManager를 사용해 안드로이드 디바이스의 물리적인 센서(가속도계, 자이로스코프, 자기장 센서 등)에 접근하여 실시간 데이터를 얻는다. 흔들림, 회전, 기울기 등의 사용자 인터랙션을 감지가 가능하지만, 현 티켓 PR에서는 가속도계를 통해 정지해있는지, 움직이고 있는지를 파악한다.
임계값을 정해 센서가 감지하는 움직임이 일정 임계값 이하라면, 그러한 움직임을 무시하고 유효한 GPS 데이터만을 사용할 수 있도록 한다. 이를 통해 정지 상태를 더 정확하게 판별할 수 있도록 하여 신뢰도를 높인다.
