### PR TITLE
#PAR-324 : 약관동의 시 개별적인 항목에 대한 선택 추가

### DIFF
--- a/core/ui/src/main/java/online/partyrun/partyrunapplication/core/ui/SurfaceRoundedRect.kt
+++ b/core/ui/src/main/java/online/partyrun/partyrunapplication/core/ui/SurfaceRoundedRect.kt
@@ -24,7 +24,7 @@ import online.partyrun.partyrunapplication.core.designsystem.icon.PartyRunIcons.
 import online.partyrun.partyrunapplication.core.designsystem.icon.PartyRunIcons.UnChecked
 
 @Composable
-fun AgreementBox(
+fun SurfaceRoundedRect(
     modifier: Modifier = Modifier,
     border: BorderStroke = BorderStroke(1.dp, MaterialTheme.colorScheme.onBackground),
     color: Color = MaterialTheme.colorScheme.background,
@@ -50,7 +50,7 @@ fun AgreementBox(
 fun LeadingIconAgreementText(
     modifier: Modifier = Modifier,
     toggleButtonChecked: Boolean,
-    toggleOnCheckedChange: (Boolean) -> Unit,
+    toggleOnCheckedChange: () -> Unit,
     content: @Composable () -> Unit
 ) {
     Row(
@@ -61,7 +61,7 @@ fun LeadingIconAgreementText(
         PartyRunIconToggleButton(
             checked = toggleButtonChecked,
             onCheckedChange = {
-                toggleOnCheckedChange(it)
+                toggleOnCheckedChange()
             },
             modifier = Modifier
                 .width(32.dp)

--- a/core/ui/src/main/java/online/partyrun/partyrunapplication/core/ui/SurfaceRoundedRect.kt
+++ b/core/ui/src/main/java/online/partyrun/partyrunapplication/core/ui/SurfaceRoundedRect.kt
@@ -39,7 +39,7 @@ fun SurfaceRoundedRect(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(top = 10.dp, start = 20.dp, bottom = 10.dp)
+                .padding(vertical = 10.dp)
         ) {
             content()
         }

--- a/feature/splash/src/main/java/online/partyrun/partyrunapplication/feature/splash/agreement/AgreementScreen.kt
+++ b/feature/splash/src/main/java/online/partyrun/partyrunapplication/feature/splash/agreement/AgreementScreen.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import online.partyrun.partyrunapplication.core.designsystem.component.PartyRunAnimatedButton
-import online.partyrun.partyrunapplication.core.ui.AgreementBox
+import online.partyrun.partyrunapplication.core.ui.SurfaceRoundedRect
 import online.partyrun.partyrunapplication.core.ui.HeadLine
 import online.partyrun.partyrunapplication.core.ui.LeadingIconAgreementText
 import online.partyrun.partyrunapplication.feature.splash.R
@@ -63,7 +63,7 @@ fun AgreementScreen(
                     .padding(start = 20.dp, bottom = 10.dp),
                 toggleButtonChecked = state.isAllChecked,
                 toggleOnCheckedChange = {
-                    agreementViewModel.onCheckedChangeAllAgreement(it)
+                    agreementViewModel.onCheckedChangeAllAgreement()
                 }
             ) {
                 Text(
@@ -74,20 +74,28 @@ fun AgreementScreen(
                 )
             }
 
-            AgreementBox(
+            SurfaceRoundedRect(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(120.dp)
-                    .padding(start = 20.dp, end = 20.dp),
+                    .padding(horizontal = 10.dp),
                 border = BorderStroke(1.dp, MaterialTheme.colorScheme.onBackground),
                 color = MaterialTheme.colorScheme.background
             ) {
                 TermsRow(
+                    conditionChecked = state.isTermsOfServiceChecked,
+                    setToggleButtonChecked = {
+                        agreementViewModel.setTermsOfServiceChecked()
+                    },
                     textId = R.string.terms_of_services_subject,
                 ) {
                     navigationToTermsOfService()
                 }
                 TermsRow(
+                    conditionChecked = state.isPrivacyPolicyChecked,
+                    setToggleButtonChecked = {
+                        agreementViewModel.setPrivacyPolicyChecked()
+                    },
                     textId = R.string.privacy_policy_subject,
                 ) {
                     navigationToPrivacyPolicy()
@@ -121,16 +129,33 @@ fun AgreementScreen(
 }
 
 @Composable
-fun TermsRow(textId: Int, onClick: () -> Unit) {
+fun TermsRow(
+    conditionChecked: Boolean,
+    setToggleButtonChecked: () -> Unit,
+    textId: Int,
+    navigateToDetailScreen: () -> Unit
+) {
     Row(
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
-        Text(
-            text = stringResource(id = textId),
-        )
-        TextButton(onClick = onClick) {
+        LeadingIconAgreementText(
+            modifier = Modifier,
+            toggleButtonChecked = conditionChecked,
+            toggleOnCheckedChange = {
+                setToggleButtonChecked()
+            }
+        ) {
+            Text(
+                modifier = Modifier.padding(bottom = 3.dp),
+                text = stringResource(id = textId),
+            )
+        }
+        TextButton(
+            modifier = Modifier.padding(end = 10.dp, bottom = 3.dp),
+            onClick = navigateToDetailScreen
+        ) {
             Text(
                 text = stringResource(id = R.string.read_detail)
             )

--- a/feature/splash/src/main/java/online/partyrun/partyrunapplication/feature/splash/agreement/AgreementScreen.kt
+++ b/feature/splash/src/main/java/online/partyrun/partyrunapplication/feature/splash/agreement/AgreementScreen.kt
@@ -141,7 +141,7 @@ fun TermsRow(
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
         LeadingIconAgreementText(
-            modifier = Modifier,
+            modifier = Modifier.padding(start = 10.dp),
             toggleButtonChecked = conditionChecked,
             toggleOnCheckedChange = {
                 setToggleButtonChecked()
@@ -153,7 +153,7 @@ fun TermsRow(
             )
         }
         TextButton(
-            modifier = Modifier.padding(end = 10.dp, bottom = 3.dp),
+            modifier = Modifier.padding(end = 5.dp, bottom = 3.dp),
             onClick = navigateToDetailScreen
         ) {
             Text(

--- a/feature/splash/src/main/java/online/partyrun/partyrunapplication/feature/splash/agreement/AgreementViewModel.kt
+++ b/feature/splash/src/main/java/online/partyrun/partyrunapplication/feature/splash/agreement/AgreementViewModel.kt
@@ -15,6 +15,7 @@ import javax.inject.Inject
 class AgreementViewModel @Inject constructor(
     private val saveAgreementUseCase: SaveAgreementStateUseCase
 ) : ViewModel() {
+
     private val _agreementUiState = MutableStateFlow(AgreementUiState())
     val agreementUiState: StateFlow<AgreementUiState> = _agreementUiState.asStateFlow()
 
@@ -22,9 +23,36 @@ class AgreementViewModel @Inject constructor(
         saveAgreementUseCase(isChecked)
     }
 
-    fun onCheckedChangeAllAgreement(isChecked: Boolean) {
+    fun onCheckedChangeAllAgreement() {
+        val newStateValue =
+            !(_agreementUiState.value.isTermsOfServiceChecked && _agreementUiState.value.isPrivacyPolicyChecked)
         _agreementUiState.update { state ->
-            state.copy(isAllChecked = isChecked)
+            state.copy(
+                isTermsOfServiceChecked = newStateValue,
+                isPrivacyPolicyChecked = newStateValue
+            )
+        }
+        updateAllConditions()
+    }
+
+    fun setTermsOfServiceChecked() {
+        toggleAndNotify { it.copy(isTermsOfServiceChecked = !it.isTermsOfServiceChecked) }
+    }
+
+    fun setPrivacyPolicyChecked() {
+        toggleAndNotify { it.copy(isPrivacyPolicyChecked = !it.isPrivacyPolicyChecked) }
+    }
+
+    private fun toggleAndNotify(updater: (AgreementUiState) -> AgreementUiState) {
+        _agreementUiState.update(updater)
+        updateAllConditions()
+    }
+
+    private fun updateAllConditions() {
+        val isAllChecked =
+            _agreementUiState.value.isTermsOfServiceChecked && _agreementUiState.value.isPrivacyPolicyChecked
+        _agreementUiState.update { state ->
+            state.copy(isAllChecked = isAllChecked)
         }
     }
 }


### PR DESCRIPTION
## Description
현재 약관동의 시 2가지 선택 항목이 모두 [필수]여서 전체 동의를 통해 다음 단계로 넘어가도록 구성되어있다.
그러나, 약관동의는 개별적으로 선택하는 버튼이 필요하기에 각 항목에 대한 개별 선택 기능을 추가한다.

## Implementation


https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/629725fc-ee47-4aed-bf10-7645a8ea6c72

