### PR TITLE
refactor : Battle 관련 파일들 rename 작업 수행 

### DIFF
--- a/app/src/main/java/online/partyrun/partyrunapplication/MainActivity.kt
+++ b/app/src/main/java/online/partyrun/partyrunapplication/MainActivity.kt
@@ -17,13 +17,13 @@ import kotlinx.coroutines.launch
 import online.partyrun.partyrunapplication.ui.PartyRunMain
 import online.partyrun.partyrunapplication.core.common.extension.setIntentActivity
 import online.partyrun.partyrunapplication.core.designsystem.theme.PartyRunApplicationTheme
-import online.partyrun.partyrunapplication.feature.battle.BattleMainViewModel
+import online.partyrun.partyrunapplication.feature.battle.BattleViewModel
 import timber.log.Timber
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
-    private val battleViewModel: BattleMainViewModel by viewModels()
+    private val battleViewModel: BattleViewModel by viewModels()
 
     /**
      * 사용자로부터 권한을 요청하고 그 결과를 받아 처리하기 위한 코드

--- a/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/battle/BattleNavigation.kt
+++ b/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/battle/BattleNavigation.kt
@@ -3,14 +3,14 @@ package online.partyrun.partyrunapplication.core.navigation.battle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import online.partyrun.partyrunapplication.core.navigation.main.MainNavRoutes
-import online.partyrun.partyrunapplication.feature.battle.BattleMainScreen
+import online.partyrun.partyrunapplication.feature.battle.BattleScreen
 
 fun NavGraphBuilder.battleRoute(
     navigateToBattleRunningWithDistance: (Int) -> Unit,
     onShowSnackbar: (String) -> Unit,
 ) {
     composable(route = MainNavRoutes.Battle.route) {
-        BattleMainScreen(
+        BattleScreen(
             navigateToBattleRunningWithDistance = navigateToBattleRunningWithDistance,
             onShowSnackbar = onShowSnackbar
         )

--- a/feature/battle/src/main/java/online/partyrun/partyrunapplication/feature/battle/BattleScreen.kt
+++ b/feature/battle/src/main/java/online/partyrun/partyrunapplication/feature/battle/BattleScreen.kt
@@ -45,26 +45,26 @@ private var lastClickTime = 0L
 private const val DEBOUNCE_DURATION = 100  // 0.1 seconds
 
 @Composable
-fun BattleMainScreen(
+fun BattleScreen(
     modifier: Modifier = Modifier,
-    battleMainViewModel: BattleMainViewModel = hiltViewModel(),
+    battleViewModel: BattleViewModel = hiltViewModel(),
     matchViewModel: MatchViewModel = hiltViewModel(),
     navigateToBattleRunningWithDistance: (Int) -> Unit,
     onShowSnackbar: (String) -> Unit,
 ) {
-    val battleMainUiState by battleMainViewModel.battleMainUiState.collectAsState()
+    val battleUiState by battleViewModel.battleUiState.collectAsState()
     val matchUiState by matchViewModel.matchUiState.collectAsState()
-    val battleMainSnackbarMessage by battleMainViewModel.snackbarMessage.collectAsStateWithLifecycle()
+    val battleSnackbarMessage by battleViewModel.snackbarMessage.collectAsStateWithLifecycle()
     val matchSnackbarMessage by matchViewModel.snackbarMessage.collectAsStateWithLifecycle()
 
     Content(
         modifier = modifier,
-        battleMainUiState = battleMainUiState,
-        battleMainViewModel = battleMainViewModel,
+        battleUiState = battleUiState,
+        battleViewModel = battleViewModel,
         matchViewModel = matchViewModel,
         navigateToBattleRunningWithDistance = navigateToBattleRunningWithDistance,
         matchUiState = matchUiState,
-        battleMainSnackbarMessage = battleMainSnackbarMessage,
+        battleSnackbarMessage = battleSnackbarMessage,
         matchSnackbarMessage = matchSnackbarMessage,
         onShowSnackbar = onShowSnackbar
     )
@@ -73,25 +73,25 @@ fun BattleMainScreen(
 @Composable
 fun Content(
     modifier: Modifier = Modifier,
-    battleMainUiState: BattleMainUiState,
-    battleMainViewModel: BattleMainViewModel,
+    battleUiState: BattleUiState,
+    battleViewModel: BattleViewModel,
     matchViewModel: MatchViewModel,
     navigateToBattleRunningWithDistance: (Int) -> Unit,
     matchUiState: MatchUiState,
-    battleMainSnackbarMessage: String,
+    battleSnackbarMessage: String,
     matchSnackbarMessage: String,
     onShowSnackbar: (String) -> Unit,
 ) {
     if (matchUiState.isAllRunnersAccepted) {
-        val currentKmState by battleMainViewModel.kmState.collectAsState()
+        val currentKmState by battleViewModel.kmState.collectAsState()
         navigateToBattleRunningWithDistance(currentKmState.toDistance())
         matchViewModel.closeMatchDialog() // 다이얼로그를 닫고 초기화 수행
     }
 
-    LaunchedEffect(battleMainSnackbarMessage) {
-        if (battleMainSnackbarMessage.isNotEmpty()) {
-            onShowSnackbar(battleMainSnackbarMessage)
-            battleMainViewModel.clearSnackbarMessage()
+    LaunchedEffect(battleSnackbarMessage) {
+        if (battleSnackbarMessage.isNotEmpty()) {
+            onShowSnackbar(battleSnackbarMessage)
+            battleViewModel.clearSnackbarMessage()
         }
     }
 
@@ -103,15 +103,15 @@ fun Content(
     }
 
     Box(modifier = modifier) {
-        when (battleMainUiState) {
-            is BattleMainUiState.Loading -> LoadingBody()
-            is BattleMainUiState.Success -> BattleMainBody(
-                battleMainViewModel = battleMainViewModel,
+        when (battleUiState) {
+            is BattleUiState.Loading -> LoadingBody()
+            is BattleUiState.Success -> BattleMainBody(
+                battleViewModel = battleViewModel,
                 matchViewModel = matchViewModel,
                 matchUiState = matchUiState
             )
 
-            is BattleMainUiState.LoadFailed -> LoadingBody()
+            is BattleUiState.LoadFailed -> LoadingBody()
         }
     }
 }
@@ -130,7 +130,7 @@ private fun LoadingBody() {
 @OptIn(ExperimentalPermissionsApi::class)
 @Composable
 fun BattleMainBody(
-    battleMainViewModel: BattleMainViewModel,
+    battleViewModel: BattleViewModel,
     matchViewModel: MatchViewModel,
     matchUiState: MatchUiState
 ) {
@@ -157,7 +157,7 @@ fun BattleMainBody(
 
     BackgroundLayer()
     MainContent(
-        battleMainViewModel,
+        battleViewModel,
         matchUiState,
         matchViewModel,
         permissionState,
@@ -168,7 +168,7 @@ fun BattleMainBody(
 @OptIn(ExperimentalPermissionsApi::class)
 @Composable
 private fun MainContent(
-    battleMainViewModel: BattleMainViewModel,
+    battleViewModel: BattleViewModel,
     matchUiState: MatchUiState,
     matchViewModel: MatchViewModel,
     permissionState: MultiplePermissionsState,
@@ -196,13 +196,13 @@ private fun MainContent(
                 .fillMaxWidth()
                 .weight(1f),
             onLeftClick = {
-                battleMainViewModel.onLeftKmChangeButtonClick()
+                battleViewModel.onLeftKmChangeButtonClick()
             },
             onRightClick = {
-                battleMainViewModel.onRightKmChangeButtonClick()
+                battleViewModel.onRightKmChangeButtonClick()
             }
         ) {
-            TrackImage(battleMainViewModel)
+            TrackImage(battleViewModel)
         }
         Spacer(modifier = Modifier.weight(0.1f))
         PartyRunMatchButton(
@@ -214,7 +214,7 @@ private fun MainContent(
                  * enabled로 할 경우 버튼이 사라지는 현상 방지
                  */
                 if (permissionState.allPermissionsGranted && isDebounced(System.currentTimeMillis()) && matchUiState.isMatchingBtnEnabled) {
-                    matchingAction(matchViewModel, battleMainViewModel.kmState.value)
+                    matchingAction(matchViewModel, battleViewModel.kmState.value)
                 } else {
                     matchViewModel.closeMatchDialog()
                     showPermissionDialog.value = true
@@ -247,8 +247,8 @@ private fun BackgroundLayer() {
 }
 
 @Composable
-private fun TrackImage(battleMainViewModel: BattleMainViewModel) {
-    val currentKmState by battleMainViewModel.kmState.collectAsStateWithLifecycle()
+private fun TrackImage(battleViewModel: BattleViewModel) {
+    val currentKmState by battleViewModel.kmState.collectAsStateWithLifecycle()
 
     val imageRes = when (currentKmState) {
         KmState.KM_1 -> R.drawable.track_1km

--- a/feature/battle/src/main/java/online/partyrun/partyrunapplication/feature/battle/BattleUiState.kt
+++ b/feature/battle/src/main/java/online/partyrun/partyrunapplication/feature/battle/BattleUiState.kt
@@ -12,11 +12,11 @@ fun KmState.toDistance(): Int = when (this) {
 }
 
 
-sealed class BattleMainUiState {
-    object Loading : BattleMainUiState()
+sealed class BattleUiState {
+    object Loading : BattleUiState()
 
-    object Success : BattleMainUiState()
+    object Success : BattleUiState()
 
-    object LoadFailed : BattleMainUiState()
+    object LoadFailed : BattleUiState()
 
 }

--- a/feature/battle/src/main/java/online/partyrun/partyrunapplication/feature/battle/BattleViewModel.kt
+++ b/feature/battle/src/main/java/online/partyrun/partyrunapplication/feature/battle/BattleViewModel.kt
@@ -14,12 +14,12 @@ import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
-class BattleMainViewModel @Inject constructor(
+class BattleViewModel @Inject constructor(
     private val terminateOngoingBattleUseCase: TerminateOngoingBattleUseCase
 ) : ViewModel() {
 
-    private val _battleMainUiState = MutableStateFlow<BattleMainUiState>(BattleMainUiState.Success)
-    val battleMainUiState = _battleMainUiState.asStateFlow()
+    private val _battleUiState = MutableStateFlow<BattleUiState>(BattleUiState.Success)
+    val battleUiState = _battleUiState.asStateFlow()
 
     private val _kmState = MutableStateFlow(KmState.KM_1)
     val kmState: StateFlow<KmState> = _kmState.asStateFlow()
@@ -55,10 +55,10 @@ class BattleMainViewModel @Inject constructor(
     fun terminateOngoingBattle() = viewModelScope.launch {
         terminateOngoingBattleUseCase().collect { result ->
             result.onSuccess {
-                Timber.tag("BattleMainViewModel").d("현재 진행 중인 배틀이 있다면 종료 요청 성공")
+                Timber.tag("BattleViewModel").d("현재 진행 중인 배틀이 있다면 종료 요청 성공")
             }.onFailure { errorMessage, code ->
                 _snackbarMessage.value = "기존 대결을 종료할 수 없습니다."
-                Timber.tag("BattleMainViewModel").e("$code $errorMessage")
+                Timber.tag("BattleViewModel").e("$code $errorMessage")
             }
         }
     }

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentScreen.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentScreen.kt
@@ -49,7 +49,7 @@ fun BattleContentScreen(
     battleContentViewModel: BattleContentViewModel = hiltViewModel(),
     onShowSnackbar: (String) -> Unit
 ) {
-    val battleUiState by battleContentViewModel.battleUiState.collectAsStateWithLifecycle()
+    val battleContentUiState by battleContentViewModel.battleContentUiState.collectAsStateWithLifecycle()
     val battleId by battleContentViewModel.battleId.collectAsStateWithLifecycle()
     val battleContentSnackbarMessage by battleContentViewModel.snackbarMessage.collectAsStateWithLifecycle()
     val openRunningExitDialog = remember { mutableStateOf(false) }
@@ -59,7 +59,7 @@ fun BattleContentScreen(
         navigateToBattleOnWebSocketError = navigateToBattleOnWebSocketError,
         navigationToRunningResult = navigationToRunningResult,
         battleContentViewModel = battleContentViewModel,
-        battleUiState = battleUiState,
+        battleContentUiState = battleContentUiState,
         battleId = battleId,
         openRunningExitDialog = openRunningExitDialog,
         battleContentSnackbarMessage = battleContentSnackbarMessage,
@@ -73,7 +73,7 @@ fun Content(
     navigateToBattleOnWebSocketError: () -> Unit = {},
     navigationToRunningResult: () -> Unit = {},
     battleContentViewModel: BattleContentViewModel,
-    battleUiState: BattleUiState,
+    battleContentUiState: BattleContentUiState,
     battleId: String?,
     openRunningExitDialog: MutableState<Boolean>,
     battleContentSnackbarMessage: String,
@@ -104,7 +104,7 @@ fun Content(
     /**
      * 목표 거리에 도달했다면, 4초 대기 후 결과 스크린으로 이동
      */
-    if (battleUiState.isFinished) {
+    if (battleContentUiState.isFinished) {
         LaunchedEffect(Unit) {
             delay(4000)
             navigationToRunningResult()
@@ -118,17 +118,17 @@ fun Content(
         }
     }
 
-    CheckStartTime(battleUiState, battleId, battleContentViewModel)
+    CheckStartTime(battleContentUiState, battleId, battleContentViewModel)
 
     Column(
         modifier = Modifier
             .fillMaxSize()
     ) {
-        when (battleUiState.screenState) {
-            is BattleScreenState.Ready -> BattleReadyScreen(isConnecting = battleUiState.isConnecting)
+        when (battleContentUiState.screenState) {
+            is BattleScreenState.Ready -> BattleReadyScreen(isConnecting = battleContentUiState.isConnecting)
             is BattleScreenState.Running ->
                 BattleRunningScreen(
-                    battleUiState = battleUiState,
+                    battleContentUiState = battleContentUiState,
                     openRunningExitDialog = openRunningExitDialog
                 )
 
@@ -139,12 +139,12 @@ fun Content(
 
 @Composable
 private fun CheckStartTime(
-    battleUiState: BattleUiState,
+    battleContentUiState: BattleContentUiState,
     battleId: String?,
     battleContentViewModel: BattleContentViewModel,
 ) {
-    when (battleUiState.timeRemaining) {
-        in 1..5 -> CountdownDialog(timeRemaining = battleUiState.timeRemaining)
+    when (battleContentUiState.timeRemaining) {
+        in 1..5 -> CountdownDialog(timeRemaining = battleContentUiState.timeRemaining)
         0 -> battleId?.let {
             // 위치 업데이트 시작 및 정지 로직
             StartBattleRunning(battleId, battleContentViewModel)

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentUiState.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentUiState.kt
@@ -2,7 +2,7 @@ package online.partyrun.partyrunapplication.feature.running.battle
 
 import online.partyrun.partyrunapplication.core.model.battle.BattleStatus
 
-data class BattleUiState(
+data class BattleContentUiState(
     // 웹소켓 연결 과정을 진행하고 있는지 여부 판단
     val isConnecting: Boolean = true,
     // 목표 거리에 도달했는지 여부 판단

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentViewModel.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentViewModel.kt
@@ -49,8 +49,8 @@ class BattleContentViewModel @Inject constructor(
     private lateinit var userId: String
     private var isFirstBattleStreamCall = true // onEach 분기를 위한 boolean
 
-    private val _battleUiState = MutableStateFlow(BattleUiState())
-    val battleUiState: StateFlow<BattleUiState> = _battleUiState
+    private val _battleContentUiState = MutableStateFlow(BattleContentUiState())
+    val battleContentUiState: StateFlow<BattleContentUiState> = _battleContentUiState
 
     private val _battleId = MutableStateFlow<String?>(null)
     val battleId: StateFlow<String?> = _battleId
@@ -70,12 +70,12 @@ class BattleContentViewModel @Inject constructor(
     }
 
     fun updateSelectedDistance(distance: Int) {
-        _battleUiState.value = _battleUiState.value.copy(selectedDistance = distance)
+        _battleContentUiState.value = _battleContentUiState.value.copy(selectedDistance = distance)
     }
 
     private fun getUserId() = viewModelScope.launch {
         userId = getUserIdUseCase()
-        _battleUiState.update { state ->
+        _battleContentUiState.update { state ->
             state.copy(
                 userId = userId
             )
@@ -113,7 +113,7 @@ class BattleContentViewModel @Inject constructor(
 
     private fun onWebSocketConnected() {
         if (isFirstBattleStreamCall) {
-            _battleUiState.update { state ->
+            _battleContentUiState.update { state ->
                 state.copy(
                     isConnecting = false // false = 연결 완료
                 )
@@ -147,7 +147,7 @@ class BattleContentViewModel @Inject constructor(
     }
 
     private fun onStartBattleStream() {
-        _battleUiState.update { state ->
+        _battleContentUiState.update { state ->
             state.copy(
                 isConnecting = true
             )
@@ -158,7 +158,7 @@ class BattleContentViewModel @Inject constructor(
         t: Throwable,
         navigateToBattleOnWebSocketError: () -> Unit
     ) {
-        _battleUiState.update { state ->
+        _battleContentUiState.update { state ->
             state.copy(showConnectionError = t is ConnectException)
         }
         if (t is ConnectException) {
@@ -167,7 +167,7 @@ class BattleContentViewModel @Inject constructor(
     }
 
     private fun updateBattleStateWithRunnerResult(result: BattleEvent.BattleRunning) {
-        val currentBattleState = _battleUiState.value.battleState.battleInfo.toMutableList()
+        val currentBattleState = _battleContentUiState.value.battleState.battleInfo.toMutableList()
         val existingRunnerState = currentBattleState.find { it.runnerId == result.runnerId }
 
         val updatedRunnerState = existingRunnerState?.copy(
@@ -191,7 +191,7 @@ class BattleContentViewModel @Inject constructor(
         }
 
         // 업데이트된 상태로 저장
-        _battleUiState.update { state ->
+        _battleContentUiState.update { state ->
             state.copy(
                 battleState = BattleStatus(battleInfo = rankedRunners)
             )
@@ -211,7 +211,7 @@ class BattleContentViewModel @Inject constructor(
             val battleData = getBattleStatusUseCase()
 
             // 생성된 RunnerState 객체들로 BattleState 객체 생성
-            _battleUiState.update { state ->
+            _battleContentUiState.update { state ->
                 state.copy(
                     battleState = battleData
                 )
@@ -231,7 +231,7 @@ class BattleContentViewModel @Inject constructor(
     }
 
     private fun changeScreenToRunning() {
-        _battleUiState.update { state ->
+        _battleContentUiState.update { state ->
             state.copy(
                 screenState = BattleScreenState.Running
             )
@@ -252,7 +252,7 @@ class BattleContentViewModel @Inject constructor(
     private suspend fun countDown() {
         for (i in COUNTDOWN_SECONDS downTo 0) {
             delay(1000)
-            _battleUiState.update { state ->
+            _battleContentUiState.update { state ->
                 state.copy(
                     timeRemaining = i
                 )
@@ -267,7 +267,7 @@ class BattleContentViewModel @Inject constructor(
 
     private fun handleBattleFinished(runnerId: String) {
         if (runnerId == userId) {  // 내 아이디와 비교하는 작업 수행
-            _battleUiState.update { state ->
+            _battleContentUiState.update { state ->
                 state.copy(
                     isFinished = true,
                     screenState = BattleScreenState.Finish
@@ -297,7 +297,7 @@ class BattleContentViewModel @Inject constructor(
 
     fun getRunnerDistance(): String {
         val runnerStatus =
-            _battleUiState.value.battleState.battleInfo.find { it.runnerId == userId }
+            _battleContentUiState.value.battleState.battleInfo.find { it.runnerId == userId }
         val distance = runnerStatus?.distance?.toInt() ?: 0
         return "${distance}m"
     }

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/running/BattleRunningScreen.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/running/BattleRunningScreen.kt
@@ -58,16 +58,16 @@ import online.partyrun.partyrunapplication.core.ui.BackgroundBlurImage
 import online.partyrun.partyrunapplication.core.ui.FormatRunningElapsedTimer
 import online.partyrun.partyrunapplication.feature.running.R
 import online.partyrun.partyrunapplication.feature.running.battle.BattleContentViewModel
-import online.partyrun.partyrunapplication.feature.running.battle.BattleUiState
+import online.partyrun.partyrunapplication.feature.running.battle.BattleContentUiState
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BattleRunningScreen(
-    battleUiState: BattleUiState,
+    battleContentUiState: BattleContentUiState,
     openRunningExitDialog: MutableState<Boolean>,
     battleContentViewModel: BattleContentViewModel = hiltViewModel()
 ) {
-    val battleState = battleUiState.battleState // 배틀 상태 state
+    val battleState = battleContentUiState.battleState // 배틀 상태 state
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -99,7 +99,7 @@ fun BattleRunningScreen(
                     .height(50.dp)
             ) {
                 TrackDistanceDistanceBox(
-                    totalTrackDistance = battleUiState.selectedDistance
+                    totalTrackDistance = battleContentUiState.selectedDistance
                 )
             }
             Spacer(modifier = Modifier.size(15.dp))
@@ -111,8 +111,8 @@ fun BattleRunningScreen(
                 ) {
                     TrackWithMultipleUsers(
                         battleContentViewModel = battleContentViewModel,
-                        totalTrackDistance = battleUiState.selectedDistance,
-                        userId = battleUiState.userId,
+                        totalTrackDistance = battleContentUiState.selectedDistance,
+                        userId = battleContentUiState.userId,
                         runners = battleState.battleInfo
                     )
                 }


### PR DESCRIPTION
## Description

코드베이스의 가독성과 유지보수를 위해 Battle 관련 파일 명칭을 통일한다.
BattleMain__ 으로 칭했던 Battle의 기본 스크린을 Battle___로 단순표현한다.

BattleContent___ 으로 칭했던 Running Feature Module내 명칭을 BattleContent____로 유지하되, 
내부 변수, 함수, 모델명에도 Content를 붙여 통일성을 부여한다.
