### PR TITLE
refactor : 싱글 모드 기능 개발 전 기존 구현부에 대한 재사용성을 위한 리팩토링 수행

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,7 +45,7 @@
         </activity>
 
         <service
-            android:name=".feature.running.battle.RunningService"
+            android:name=".feature.running.service.BattleRunningService"
             android:foregroundServiceType="location" />
     </application>
 

--- a/feature/battle/build.gradle.kts
+++ b/feature/battle/build.gradle.kts
@@ -21,4 +21,5 @@ dependencies {
 
     implementation(libs.google.location)
     implementation(project(":feature:match"))
+    implementation(project(":feature:running"))
 }

--- a/feature/battle/src/main/java/online/partyrun/partyrunapplication/feature/battle/BattleScreen.kt
+++ b/feature/battle/src/main/java/online/partyrun/partyrunapplication/feature/battle/BattleScreen.kt
@@ -40,6 +40,7 @@ import online.partyrun.partyrunapplication.core.ui.KmInfoCard
 import online.partyrun.partyrunapplication.feature.match.MatchDialog
 import online.partyrun.partyrunapplication.feature.match.MatchUiState
 import online.partyrun.partyrunapplication.feature.match.MatchViewModel
+import online.partyrun.partyrunapplication.feature.running.permission.CheckMultiplePermissions
 
 private var lastClickTime = 0L
 private const val DEBOUNCE_DURATION = 100  // 0.1 seconds

--- a/feature/battle/src/main/res/values/strings.xml
+++ b/feature/battle/src/main/res/values/strings.xml
@@ -5,16 +5,5 @@
     <string name="battle_head_line_2">매칭을 잡아보세요!</string>
     <string name="track_img_desc">트랙 이미지</string>
 
-    <string name="permission_confirm">권한 설정</string>
-    <string name="permission_cancel">취소</string>
-
-    <string name="notification_permission_title">[필수] 알림 설정</string>
-    <string name="notification_permission_description">스마트폰이 닫힌 상태에서도 러닝 중 지속적인 알림을 받을 수 있도록 알림 액세스를 허용해주세요.</string>
-    <string name="notification_permission_additional_instruction">[설정] -> [알림]에서 권한을 설정해주세요.</string>
-
-    <string name="location_permission_title">[필수] 위치 정보</string>
-    <string name="location_permission_description">정확한 GPS 신호를 통한 러닝 추적을 위해 위치 정보 액세스를 허용해주세요.</string>
-    <string name="location_permission_additional_instruction">[설정] -> [권한] -> [위치]에서 권한을 설정해주세요.</string>
-
 </resources>
 

--- a/feature/running/build.gradle.kts
+++ b/feature/running/build.gradle.kts
@@ -20,5 +20,7 @@ dependencies {
     // google Location
     implementation(libs.google.location)
 
+    implementation(libs.google.accompanist.permission)
+
     implementation(project(":core:network"))
 }

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentScreen.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentScreen.kt
@@ -37,9 +37,10 @@ import online.partyrun.partyrunapplication.core.designsystem.component.PartyRunG
 import online.partyrun.partyrunapplication.core.designsystem.component.PartyRunOutlinedButton
 import online.partyrun.partyrunapplication.core.ui.CountdownDialog
 import online.partyrun.partyrunapplication.feature.running.R
-import online.partyrun.partyrunapplication.feature.running.battle.finish.FinishScreen
-import online.partyrun.partyrunapplication.feature.running.battle.ready.BattleReadyScreen
-import online.partyrun.partyrunapplication.feature.running.battle.running.BattleRunningScreen
+import online.partyrun.partyrunapplication.feature.running.finish.FinishScreen
+import online.partyrun.partyrunapplication.feature.running.ready.BattleReadyScreen
+import online.partyrun.partyrunapplication.feature.running.running.BattleRunningScreen
+import online.partyrun.partyrunapplication.feature.running.service.BattleRunningService
 
 @Composable
 fun BattleContentScreen(
@@ -177,13 +178,13 @@ private fun setOrDisposeBattleRunning(
     // Foreground Service 시작/중지
     if (isStarting) {
         viewModel.initBattleState() // 러너 데이터를 기반으로 BattleState를 초기화하고 시작
-        val intent = Intent(context, RunningService::class.java).apply {
+        val intent = Intent(context, BattleRunningService::class.java).apply {
             putExtra(BATTLE_ID_KEY, battleId)
         }
         intent.action = ACTION_START_RUNNING
         context.startService(intent)
     } else {
-        val intent = Intent(context, RunningService::class.java)
+        val intent = Intent(context, BattleRunningService::class.java)
         intent.action = ACTION_STOP_RUNNING
         context.stopService(intent)
     }

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentViewModel.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentViewModel.kt
@@ -25,7 +25,7 @@ import online.partyrun.partyrunapplication.core.domain.running.GetUserIdUseCase
 import online.partyrun.partyrunapplication.core.domain.running.SaveBattleIdUseCase
 import online.partyrun.partyrunapplication.core.model.battle.BattleStatus
 import online.partyrun.partyrunapplication.core.model.running.BattleEvent
-import online.partyrun.partyrunapplication.feature.running.battle.util.distanceToCoordinatesMapper
+import online.partyrun.partyrunapplication.feature.running.util.distanceToCoordinatesMapper
 import timber.log.Timber
 import java.net.ConnectException
 import java.time.LocalDateTime

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/finish/FinishScreen.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/finish/FinishScreen.kt
@@ -1,4 +1,4 @@
-package online.partyrun.partyrunapplication.feature.running.battle.finish
+package online.partyrun.partyrunapplication.feature.running.finish
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/permission/CheckMultiplePermissions.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/permission/CheckMultiplePermissions.kt
@@ -1,4 +1,4 @@
-package online.partyrun.partyrunapplication.feature.battle
+package online.partyrun.partyrunapplication.feature.running.permission
 
 import android.Manifest
 import android.content.Context
@@ -9,7 +9,11 @@ import android.provider.Settings
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.ui.platform.LocalContext
-import com.google.accompanist.permissions.*
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.MultiplePermissionsState
+import com.google.accompanist.permissions.PermissionStatus
+import com.google.accompanist.permissions.shouldShowRationale
+import online.partyrun.partyrunapplication.feature.running.R
 
 @OptIn(ExperimentalPermissionsApi::class)
 @Composable

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/permission/PermissionDialog.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/permission/PermissionDialog.kt
@@ -1,4 +1,4 @@
-package online.partyrun.partyrunapplication.feature.battle
+package online.partyrun.partyrunapplication.feature.running.permission
 
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AlertDialog
@@ -11,6 +11,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import online.partyrun.partyrunapplication.core.designsystem.component.PartyRunGradientButton
 import online.partyrun.partyrunapplication.core.designsystem.component.PartyRunOutlinedButton
+import online.partyrun.partyrunapplication.feature.running.R
 
 @Composable
 fun PermissionDialog(

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/ready/BattleReadyScreen.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/ready/BattleReadyScreen.kt
@@ -1,4 +1,4 @@
-package online.partyrun.partyrunapplication.feature.running.battle.ready
+package online.partyrun.partyrunapplication.feature.running.ready
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/running/BattleRunningScreen.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/running/BattleRunningScreen.kt
@@ -1,4 +1,4 @@
-package online.partyrun.partyrunapplication.feature.running.battle.running
+package online.partyrun.partyrunapplication.feature.running.running
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/service/BattleRunningService.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/service/BattleRunningService.kt
@@ -1,4 +1,4 @@
-package online.partyrun.partyrunapplication.feature.running.battle
+package online.partyrun.partyrunapplication.feature.running.service
 
 import android.annotation.SuppressLint
 import android.app.Notification
@@ -40,7 +40,7 @@ import kotlin.math.ceil
 import kotlin.math.sqrt
 
 @AndroidEntryPoint
-class RunningService : Service() {
+class BattleRunningService : Service() {
     companion object {
         const val LOCATION_UPDATE_INTERVAL_SECONDS = 1L
         private const val THRESHOLD = 0.05

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/util/DistanceToCoordinatesMapper.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/util/DistanceToCoordinatesMapper.kt
@@ -1,4 +1,4 @@
-package online.partyrun.partyrunapplication.feature.running.battle.util
+package online.partyrun.partyrunapplication.feature.running.util
 
 /**
  * 비율 기반 거리 매핑 함수

--- a/feature/running/src/main/res/values/strings.xml
+++ b/feature/running/src/main/res/values/strings.xml
@@ -25,4 +25,17 @@
     <string name="running_service_title">파티런</string>
     <string name="running_service_content">현재 러닝 진행 중입니다.</string>
 
+
+    <string name="permission_confirm">권한 설정</string>
+    <string name="permission_cancel">취소</string>
+
+    <string name="notification_permission_title">[필수] 알림 설정</string>
+    <string name="notification_permission_description">스마트폰이 닫힌 상태에서도 러닝 중 지속적인 알림을 받을 수 있도록 알림 액세스를 허용해주세요.</string>
+    <string name="notification_permission_additional_instruction">[설정] -> [알림]에서 권한을 설정해주세요.</string>
+
+    <string name="location_permission_title">[필수] 위치 정보</string>
+    <string name="location_permission_description">정확한 GPS 신호를 통한 러닝 추적을 위해 위치 정보 액세스를 허용해주세요.</string>
+    <string name="location_permission_additional_instruction">[설정] -> [권한] -> [위치]에서 권한을 설정해주세요.</string>
+
+
 </resources>


### PR DESCRIPTION
## Description
기존에는 대결 모드만 구현했기에 러닝에 필요한 기능들이 Battle에만 몰려있던 구조였다.
싱글 모드 구현을 시작하기 전에 이러한 한 곳에 몰려있던 파일들을 목적에 맞게 디렉토리화하여 분리하고
Permission 같은 경우, 싱글에서도 확인해야 하므로, battle과 single 모두 접근 가능한 feature/running Module로 로직을 이전한다.

