### PR TITLE
feat : 러닝 결과 불러오기 실패 시 RunningResultUiState.LoadFailed 처리

### DIFF
--- a/feature/running_result/src/main/java/online/partyrun/partyrunapplication/feature/running_result/RunningResultScreen.kt
+++ b/feature/running_result/src/main/java/online/partyrun/partyrunapplication/feature/running_result/RunningResultScreen.kt
@@ -71,6 +71,7 @@ fun RunningResultScreen(
     Content(
         modifier = modifier,
         runningResultUiState = runningResultUiState,
+        runningResultViewModel = runningResultViewModel,
         navigateToTopLevel = navigateToTopLevel
     )
 }
@@ -79,6 +80,7 @@ fun RunningResultScreen(
 private fun Content(
     modifier: Modifier = Modifier,
     runningResultUiState: RunningResultUiState,
+    runningResultViewModel: RunningResultViewModel,
     navigateToTopLevel: () -> Unit,
 ) {
     Box(modifier = modifier) {
@@ -90,7 +92,10 @@ private fun Content(
                     navigateToTopLevel = navigateToTopLevel
                 )
 
-            is RunningResultUiState.LoadFailed -> LoadingBody()
+            is RunningResultUiState.LoadFailed ->
+                LoadFailedBody(
+                    runningResultViewModel = runningResultViewModel
+                )
         }
     }
 }
@@ -103,6 +108,27 @@ private fun LoadingBody() {
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         CircularProgressIndicator()
+    }
+}
+
+@Composable
+private fun LoadFailedBody(
+    runningResultViewModel: RunningResultViewModel
+) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        PartyRunGradientButton(
+            onClick = { runningResultViewModel.getBattleResult() }
+        ) {
+            Text(
+                text = stringResource(id = R.string.re_loading),
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onPrimary
+            )
+        }
     }
 }
 

--- a/feature/running_result/src/main/java/online/partyrun/partyrunapplication/feature/running_result/RunningResultViewModel.kt
+++ b/feature/running_result/src/main/java/online/partyrun/partyrunapplication/feature/running_result/RunningResultViewModel.kt
@@ -32,7 +32,7 @@ class RunningResultViewModel @Inject constructor(
         getBattleResult()
     }
 
-    private fun getBattleResult() {
+    fun getBattleResult() {
         viewModelScope.launch {
             val battleData = getBattleStatusUseCase()
             val userId = getUserIdUseCase()

--- a/feature/running_result/src/main/res/values/strings.xml
+++ b/feature/running_result/src/main/res/values/strings.xml
@@ -12,4 +12,6 @@
 
     <string name="navigate_to_top_level">돌아가기</string>
 
+    <string name="re_loading">다시 조회하기</string>
+
 </resources>


### PR DESCRIPTION
## Description
러닝이 끝나고 난 뒤, 바로 러닝 결과를 조회하는데, 이때 서버로부터 결과를 불러오지 못한다면
RunningResultUiState.LoadFailed로 상태를 변경하고, 
다시 조회하는 버튼을 통해 결과를 못보고 메인으로 돌아가는 상황이 없도록 기능을 추가한다. 