### PR TITLE
#PAR-334 : 싱글모드를 시작하기 위한 메인 스크린과 퍼미션 확인

### DIFF
--- a/app/src/main/java/online/partyrun/partyrunapplication/navigation/MainNavHost.kt
+++ b/app/src/main/java/online/partyrun/partyrunapplication/navigation/MainNavHost.kt
@@ -54,7 +54,9 @@ fun SetUpMainNavGraph(
             onShowSnackbar = onShowSnackbar
         )
 
-        singleRoute()
+        singleRoute(
+            onShowSnackbar = onShowSnackbar
+        )
 
         challengeRoute()
 

--- a/core/designsystem/src/main/java/online/partyrun/partyrunapplication/core/designsystem/icon/PartyRunIcons.kt
+++ b/core/designsystem/src/main/java/online/partyrun/partyrunapplication/core/designsystem/icon/PartyRunIcons.kt
@@ -22,6 +22,7 @@ object PartyRunIcons {
     val Menu = R.drawable.ic_round_menu_24
     val Close = R.drawable.ic_round_close_24
     val Add = R.drawable.ic_round_add_24
+    val Remove = R.drawable.ic_round_remove_24
     val CheckCircle = R.drawable.ic_round_check_circle_outline_24
     val AddCircle = R.drawable.ic_round_add_circle_outline_24
     val RemoveCircle = R.drawable.ic_round_remove_circle_outline_24

--- a/core/designsystem/src/main/res/drawable/ic_round_remove_24.xml
+++ b/core/designsystem/src/main/res/drawable/ic_round_remove_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M18,13H6c-0.55,0 -1,-0.45 -1,-1s0.45,-1 1,-1h12c0.55,0 1,0.45 1,1s-0.45,1 -1,1z"/>
+</vector>

--- a/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/single/SingleNavigation.kt
+++ b/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/single/SingleNavigation.kt
@@ -5,8 +5,12 @@ import androidx.navigation.compose.composable
 import online.partyrun.partyrunapplication.core.navigation.main.MainNavRoutes
 import online.partyrun.partyrunapplication.feature.single.SingleScreen
 
-fun NavGraphBuilder.singleRoute() {
+fun NavGraphBuilder.singleRoute(
+    onShowSnackbar: (String) -> Unit,
+) {
     composable(route = MainNavRoutes.Single.route) {
-        SingleScreen()
+        SingleScreen(
+            onShowSnackbar = onShowSnackbar
+        )
     }
 }

--- a/feature/single/build.gradle.kts
+++ b/feature/single/build.gradle.kts
@@ -13,4 +13,7 @@ dependencies {
     // Timber
     implementation (libs.timber)
 
+    implementation(libs.google.accompanist.permission)
+
+    implementation(project(":feature:running"))
 }

--- a/feature/single/src/main/java/online/partyrun/partyrunapplication/feature/single/SingleScreen.kt
+++ b/feature/single/src/main/java/online/partyrun/partyrunapplication/feature/single/SingleScreen.kt
@@ -234,9 +234,9 @@ private fun TargetDistanceSetting(
     val displayTargetDistance =
         String.format("%04.2f", (targetDistance.toFloat() / 1000f) * 100f / 100)
     TargetSettingRow(
-        title = "목표 거리",
+        title = stringResource(id = R.string.target_distance),
         displayValue = displayTargetDistance,
-        unit = "KM",
+        unit = stringResource(id = R.string.target_distance_unit),
         onIncrement = { singleViewModel.incrementTargetDistance() },
         onDecrement = { singleViewModel.decrementTargetDistance() }
     )
@@ -249,14 +249,13 @@ private fun TargetTimeSetting(singleViewModel: SingleViewModel, targetTime: Int)
     val displayTargetTime = String.format("%02d.%02d", hours, minutes)
 
     TargetSettingRow(
-        title = "목표 시간",
+        title = stringResource(id = R.string.target_time),
         displayValue = displayTargetTime,
-        unit = "분",
+        unit = stringResource(id = R.string.target_time_unit),
         onIncrement = { singleViewModel.incrementTargetTime() },
         onDecrement = { singleViewModel.decrementTargetTime() }
     )
 }
-
 
 @Composable
 private fun TargetSettingRow(

--- a/feature/single/src/main/java/online/partyrun/partyrunapplication/feature/single/SingleScreen.kt
+++ b/feature/single/src/main/java/online/partyrun/partyrunapplication/feature/single/SingleScreen.kt
@@ -1,32 +1,278 @@
 package online.partyrun.partyrunapplication.feature.single
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import online.partyrun.partyrunapplication.core.ui.PreparingImage
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import online.partyrun.partyrunapplication.core.designsystem.component.PartyRunCircularIconButton
+import online.partyrun.partyrunapplication.core.designsystem.component.PartyRunGradientButton
+import online.partyrun.partyrunapplication.core.designsystem.component.SurfaceRoundedRect
+import online.partyrun.partyrunapplication.core.designsystem.icon.PartyRunIcons
+import online.partyrun.partyrunapplication.core.ui.HeadLine
 
 @Composable
-fun SingleScreen() {
-    Box(
-        modifier = Modifier.fillMaxSize()
+fun SingleScreen(
+    modifier: Modifier = Modifier,
+    singleViewModel: SingleViewModel = hiltViewModel(),
+    onShowSnackbar: (String) -> Unit
+) {
+    val singleUiState by singleViewModel.singleUiState.collectAsStateWithLifecycle()
+    val singleSnackbarMessage by singleViewModel.snackbarMessage.collectAsStateWithLifecycle()
+    val targetDistance by singleViewModel.targetDistance.collectAsStateWithLifecycle()
+    val targetTime by singleViewModel.targetTime.collectAsStateWithLifecycle()
+
+    Content(
+        modifier = modifier,
+        singleUiState = singleUiState,
+        singleViewModel = singleViewModel,
+        targetDistance = targetDistance,
+        targetTime = targetTime,
+        singleSnackbarMessage = singleSnackbarMessage,
+        onShowSnackbar = onShowSnackbar
+    )
+}
+
+@Composable
+fun Content(
+    modifier: Modifier = Modifier,
+    singleUiState: SingleUiState,
+    singleViewModel: SingleViewModel,
+    targetDistance: Int,
+    targetTime: Int,
+    singleSnackbarMessage: String,
+    onShowSnackbar: (String) -> Unit
+) {
+
+    LaunchedEffect(singleSnackbarMessage) {
+        if (singleSnackbarMessage.isNotEmpty()) {
+            onShowSnackbar(singleSnackbarMessage)
+            singleViewModel.clearSnackbarMessage()
+        }
+    }
+
+    Box(modifier = modifier) {
+        when (singleUiState) {
+            is SingleUiState.Loading -> LoadingBody()
+            is SingleUiState.Success -> SingleMainBody(
+                singleViewModel = singleViewModel,
+                targetDistance = targetDistance,
+                targetTime = targetTime
+            )
+
+            is SingleUiState.LoadFailed -> LoadingBody()
+        }
+    }
+}
+
+@Composable
+private fun LoadingBody() {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        PreparingImage {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+fun SingleMainBody(
+    singleViewModel: SingleViewModel,
+    targetDistance: Int,
+    targetTime: Int
+) {
+    SingleContent(
+        singleViewModel = singleViewModel,
+        targetDistance = targetDistance,
+        targetTime = targetTime
+    )
+}
+
+@Composable
+private fun SingleContent(
+    singleViewModel: SingleViewModel,
+    targetDistance: Int,
+    targetTime: Int
+) {
+
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        HeadLine(
+            modifier = Modifier
+        ) {
             Text(
-                text = stringResource(id = R.string.single_preparing_service_comment_1),
-                style = MaterialTheme.typography.headlineLarge,
+                text = stringResource(id = R.string.single_headline_1),
+                style = MaterialTheme.typography.titleLarge,
                 color = MaterialTheme.colorScheme.onPrimary
             )
             Text(
-                modifier = Modifier.padding(40.dp),
-                text = stringResource(id = R.string.single_preparing_service_comment_2),
-                style = MaterialTheme.typography.titleMedium,
+                text = stringResource(id = R.string.single_headline_2),
+                style = MaterialTheme.typography.titleLarge,
                 color = MaterialTheme.colorScheme.onPrimary
+            )
+        }
+        Spacer(modifier = Modifier.size(10.dp))
+        SurfaceRoundedRect(
+            modifier = Modifier
+                .fillMaxSize()
+                .weight(1f)
+                .padding(10.dp)
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 20.dp),
+                verticalArrangement = Arrangement.SpaceAround
+            ) {
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    TargetDistanceSetting(
+                        singleViewModel = singleViewModel,
+                        targetDistance = targetDistance
+                    )
+                }
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    TargetTimeSetting(
+                        singleViewModel = singleViewModel,
+                        targetTime = targetTime
+                    )
+                }
+            }
+        }
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            PartyRunGradientButton(
+                modifier = Modifier
+                    .size(80.dp)
+                    .clip(CircleShape),
+                onClick = { /*TODO*/ }
+            ) {
+                Text(
+                    text = stringResource(R.string.single_start)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TargetDistanceSetting(
+    singleViewModel: SingleViewModel,
+    targetDistance: Int
+) {
+    val displayTargetDistance =
+        String.format("%04.2f", (targetDistance.toFloat() / 1000f) * 100f / 100)
+    TargetSettingRow(
+        title = "목표 거리",
+        displayValue = displayTargetDistance,
+        unit = "KM",
+        onIncrement = { singleViewModel.incrementTargetDistance() },
+        onDecrement = { singleViewModel.decrementTargetDistance() }
+    )
+}
+
+@Composable
+private fun TargetTimeSetting(singleViewModel: SingleViewModel, targetTime: Int) {
+    val hours = targetTime / 60
+    val minutes = targetTime % 60
+    val displayTargetTime = String.format("%02d.%02d", hours, minutes)
+
+    TargetSettingRow(
+        title = "목표 시간",
+        displayValue = displayTargetTime,
+        unit = "분",
+        onIncrement = { singleViewModel.incrementTargetTime() },
+        onDecrement = { singleViewModel.decrementTargetTime() }
+    )
+}
+
+@Composable
+private fun TargetSettingRow(
+    modifier: Modifier = Modifier,
+    title: String,
+    displayValue: String,
+    unit: String,
+    onIncrement: () -> Unit,
+    onDecrement: () -> Unit
+) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleLarge,
+        color = MaterialTheme.colorScheme.primary
+    )
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        PartyRunCircularIconButton(
+            modifier = Modifier.size(45.dp),
+            onClick = onDecrement,
+        ) {
+            Icon(
+                painterResource(id = PartyRunIcons.Remove),
+                contentDescription = null
+            )
+        }
+        Row(
+            modifier = Modifier
+        ) {
+            Text(
+                text = displayValue,
+                style = MaterialTheme.typography.displayMedium,
+                color = MaterialTheme.colorScheme.primary
+            )
+            Spacer(modifier = Modifier.width(5.dp))
+            Text(
+                modifier = Modifier
+                    .align(Alignment.Bottom)
+                    .padding(bottom = 10.dp),
+                text = unit,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.primary
+            )
+        }
+        PartyRunCircularIconButton(
+            modifier = Modifier.size(45.dp),
+            onClick = onIncrement,
+        ) {
+            Icon(
+                painterResource(id = PartyRunIcons.Add),
+                contentDescription = null
             )
         }
     }

--- a/feature/single/src/main/java/online/partyrun/partyrunapplication/feature/single/SingleUiState.kt
+++ b/feature/single/src/main/java/online/partyrun/partyrunapplication/feature/single/SingleUiState.kt
@@ -1,0 +1,7 @@
+package online.partyrun.partyrunapplication.feature.single
+
+sealed class SingleUiState {
+    object Loading : SingleUiState()
+    object Success : SingleUiState()
+    object LoadFailed : SingleUiState()
+}

--- a/feature/single/src/main/java/online/partyrun/partyrunapplication/feature/single/SingleViewModel.kt
+++ b/feature/single/src/main/java/online/partyrun/partyrunapplication/feature/single/SingleViewModel.kt
@@ -2,11 +2,48 @@ package online.partyrun.partyrunapplication.feature.single
 
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
 
 @HiltViewModel
 class SingleViewModel @Inject constructor(
 
-): ViewModel() {
+) : ViewModel() {
+    private val _singleUiState = MutableStateFlow<SingleUiState>(SingleUiState.Success)
+    val singleUiState: StateFlow<SingleUiState> = _singleUiState
+
+    private val _targetDistance = MutableStateFlow(5000)
+    val targetDistance: StateFlow<Int> = _targetDistance
+
+    private val _targetTime = MutableStateFlow(15)
+    val targetTime: StateFlow<Int> = _targetTime
+
+    private val _snackbarMessage = MutableStateFlow("")
+    val snackbarMessage: StateFlow<String> = _snackbarMessage
+
+    fun clearSnackbarMessage() {
+        _snackbarMessage.value = ""
+    }
+
+    fun incrementTargetDistance() {
+        _targetDistance.value += 250
+    }
+
+    fun decrementTargetDistance() {
+        if (_targetDistance.value >= 250) {
+            _targetDistance.value -= 250
+        }
+    }
+
+    fun incrementTargetTime() {
+        _targetTime.value += 5
+    }
+
+    fun decrementTargetTime() {
+        if (_targetTime.value > 5) {
+            _targetTime.value -= 5
+        }
+    }
 
 }

--- a/feature/single/src/main/res/values/strings.xml
+++ b/feature/single/src/main/res/values/strings.xml
@@ -7,4 +7,9 @@
     <string name="single_headline_1">함께 뛸 그림자 러너의 목표를 설정하고</string>
     <string name="single_headline_2">대결에서 승리하세요!</string>
 
+    <string name="target_distance">목표 거리</string>
+    <string name="target_time">목표 시간</string>
+    <string name="target_distance_unit">KM</string>
+    <string name="target_time_unit">분</string>
+
 </resources>

--- a/feature/single/src/main/res/values/strings.xml
+++ b/feature/single/src/main/res/values/strings.xml
@@ -3,4 +3,8 @@
     <string name="single_preparing_service_comment_1">싱글 서비스 준비 중</string>
     <string name="single_preparing_service_comment_2">이전에 뛴 나의 기록과 실시간으로 함께 달리는 서비스를 제공할 예정이에요.</string>
 
+    <string name="single_start">시작</string>
+    <string name="single_headline_1">함께 뛸 그림자 러너의 목표를 설정하고</string>
+    <string name="single_headline_2">대결에서 승리하세요!</string>
+
 </resources>


### PR DESCRIPTION
## Description
싱글 모드 구현을 위한 메인 스크린과 기능들을 구성한다.
* ( 현재 싱글 모드에 대한 디자인이 나오지 않았기에, 기본 DesignSystem 설정대로 UI를 구성한다.
추후 디자인이 나오면 수정 예정 )

1. 목표 거리 설정
2. 목표 시간 설정
3. 러닝을 위한 퍼미션 확인 및 획득

혼자서 달리기를 진행하기 전에, 대결 모드와 마찬가지로 달릴 거리를 설정해야 하고
시작하기 버튼을 누르면 퍼미션 확인 후 싱글 모드가 시작된다.

## Implementation

https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/6d57a023-ed5b-4704-8982-7c0355e71515

