### PR TITLE
fix : Battle Running Service 수행방식 변경

### DIFF
--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentScreen.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentScreen.kt
@@ -112,7 +112,8 @@ fun Content(
         }
     }
 
-    CheckStartTime(battleContentUiState, battleId, battleContentViewModel)
+    CheckStartTime(battleContentUiState)
+    StartRunningService(battleContentUiState, battleId, battleContentViewModel)
 
     Column(
         modifier = Modifier
@@ -133,13 +134,21 @@ fun Content(
 
 @Composable
 private fun CheckStartTime(
+    battleContentUiState: BattleContentUiState
+) {
+    when (battleContentUiState.timeRemaining) {
+        in 1..5 -> CountdownDialog(timeRemaining = battleContentUiState.timeRemaining)
+    }
+}
+
+@Composable
+private fun StartRunningService(
     battleContentUiState: BattleContentUiState,
     battleId: String?,
     battleContentViewModel: BattleContentViewModel,
 ) {
-    when (battleContentUiState.timeRemaining) {
-        in 1..5 -> CountdownDialog(timeRemaining = battleContentUiState.timeRemaining)
-        0 -> battleId?.let {
+    if (battleContentUiState.startRunningService) {
+        battleId?.let {
             // 위치 업데이트 시작 및 정지 로직
             StartBattleRunning(battleId, battleContentViewModel)
         }

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentUiState.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentUiState.kt
@@ -9,6 +9,8 @@ data class BattleContentUiState(
     val isFinished: Boolean = false,
     // 유저 id
     val userId: String = "",
+    // 러닝 서비스 시작
+    val startRunningService: Boolean = false,
     // 사용자가 선택한 목표 거리
     val selectedDistance: Int = 1000,
     // 현재 보여줘야 할 스크린

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentViewModel.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentViewModel.kt
@@ -254,12 +254,6 @@ class BattleContentViewModel @Inject constructor(
         val countDownInterval = 1000L
         val startCount = COUNTDOWN_SECONDS
 
-        fun updateCountdownState(timeRemaining: Int) {
-            _battleContentUiState.update { state ->
-                state.copy(timeRemaining = timeRemaining)
-            }
-        }
-
         delay(initialDelay)
 
         for (remainingSeconds in startCount downTo 0) {
@@ -268,6 +262,21 @@ class BattleContentViewModel @Inject constructor(
             if (remainingSeconds > 0) {
                 delay(countDownInterval)
             }
+        }
+    }
+
+    private fun startBattleRunningService() {
+        _battleContentUiState.update { state ->
+            state.copy(startRunningService = true)
+        }
+    }
+
+    private fun updateCountdownState(timeRemaining: Int) {
+        if (timeRemaining == 3) { // 3초가 남았을 때 러닝 서비스 시작
+            startBattleRunningService()
+        }
+        _battleContentUiState.update { state ->
+            state.copy(timeRemaining = timeRemaining)
         }
     }
 

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/service/BattleRunningService.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/service/BattleRunningService.kt
@@ -22,6 +22,7 @@ class BattleRunningService : BaseRunningService() {
 
     @Inject
     lateinit var sendRecordDataUseCase: SendRecordDataUseCase
+    private var isFirstLocationUpdate = true  // 플래그 초기화
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         when (intent?.action) {
@@ -54,6 +55,12 @@ class BattleRunningService : BaseRunningService() {
     private fun setLocationCallback(battleId: String) {
         locationCallback = object : LocationCallback() {
             override fun onLocationResult(result: LocationResult) {
+                // onLocationResult의 반환 값이 이전 위치일수도 있는 첫 번째 값은 무시
+                if (isFirstLocationUpdate) {
+                    isFirstLocationUpdate = false  // 플래그 업데이트
+                    return
+                }
+
                 result.lastLocation?.let { location ->
                     if (lastSensorVelocity <= THRESHOLD) {
                         return@let


### PR DESCRIPTION
## Description
1. fusedLocationProviderClient의 lastLocation을 받아올 때 첫 좌표가 가장 마지막에 인식한 위치로 찍히는 문제
->  러너가 이동 후 다시 시작하는 경우에 이전 좌표를 첫 좌표로 받기에 이동 거리가 확 튀게 됨.
-> 플래그를 통해 첫 좌표 제외
 
2. fusedLocationProviderClient의 Callback LocationResult의 딜레이가 처음 2~3초 가량 발생
-> 이를 감안하기 위해 카운트다운 중 BattleRunningService가 선제적으로 수행될 수 있도록 수정 