### PR TITLE
feat : 싱글 모드에 대한 BottomNavBarItems isLaunched -> true로 변경

### DIFF
--- a/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/main/BottomNavBarItems.kt
+++ b/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/main/BottomNavBarItems.kt
@@ -24,7 +24,7 @@ object BottomNavBarItems {
             image = SingleIcon,
             selectedImage = SelectedSingleIcon,
             route = MainNavRoutes.Single.route,
-            isLaunched = false
+            isLaunched = true
         ),
         BottomBarItem(
             title = R.string.challenge_title,


### PR DESCRIPTION
## Description
싱글 모드 기능이 일부 가능해짐에 따라 BottomNavBarItems에서 Single 파트에 대한 isLaunched 필드값 변경

## Implementation
### 변경 전
<img width="355" alt="스크린샷 2023-09-07 오후 3 39 36" src="https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/507d8dec-d033-48b3-b16c-084dd47c71f1">

### 변경 후 
<img width="372" alt="스크린샷 2023-09-07 오후 3 39 20" src="https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/4236ac06-6003-4a43-90f1-21aace831c30">
