### PR TITLE
#PAR-341 : 싱글 모드에서 목표 거리 도달 시 결과를 보여주는 프로세스 구현 

### DIFF
--- a/app/src/main/java/online/partyrun/partyrunapplication/navigation/MainNavHost.kt
+++ b/app/src/main/java/online/partyrun/partyrunapplication/navigation/MainNavHost.kt
@@ -110,10 +110,10 @@ fun SetUpMainNavGraph(
         )
 
         singleRunningRoute(
-            navigateToSingle = {
-                navController.navigate(MainNavRoutes.Single.route) {
+            navigateToSingleResult = {
+                navController.navigate(MainNavRoutes.SingleResult.route) {
                     popUpTo(MainNavRoutes.Single.route) {
-                        inclusive = true
+                        inclusive = false
                     }
                 }
             },

--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/SingleRepository.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/SingleRepository.kt
@@ -2,6 +2,7 @@ package online.partyrun.partyrunapplication.core.data.repository
 
 import kotlinx.coroutines.flow.Flow
 import online.partyrun.partyrunapplication.core.model.running.GpsData
+import online.partyrun.partyrunapplication.core.model.running_result.single.SingleResult
 
 interface SingleRepository {
     val gpsDataList: Flow<List<GpsData>>
@@ -10,5 +11,6 @@ interface SingleRepository {
     fun initialize()
     suspend fun addGpsData(gpsData: GpsData)
     suspend fun getGpsData(): List<GpsData>
+    suspend fun getGpsDataTest(): SingleResult
     suspend fun setDistance(totalDistance: Int)
 }

--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/SingleRepositoryImpl.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/SingleRepositoryImpl.kt
@@ -2,7 +2,22 @@ package online.partyrun.partyrunapplication.core.data.repository
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import online.partyrun.partyrunapplication.core.model.running.GpsData
+import online.partyrun.partyrunapplication.core.model.running_result.single.SingleResult
+import online.partyrun.partyrunapplication.core.model.running_result.single.SingleRunnerRecord
+import online.partyrun.partyrunapplication.core.model.running_result.single.SingleRunnerStatus
+import online.partyrun.partyrunapplication.core.model.util.DateTimeUtils
+import online.partyrun.partyrunapplication.core.network.model.response.toDomainModel
+import online.partyrun.partyrunapplication.core.network.model.util.calculateElapsedTimeToDomainModel
+import online.partyrun.partyrunapplication.core.network.model.util.calculateSecondsElapsedTimeToDomainModel
+import online.partyrun.partyrunapplication.core.network.model.util.formatDate
+import online.partyrun.partyrunapplication.core.network.model.util.formatDistanceInKm
+import online.partyrun.partyrunapplication.core.network.model.util.formatDistanceWithComma
+import online.partyrun.partyrunapplication.core.network.model.util.formatEndTime
+import online.partyrun.partyrunapplication.core.network.model.util.formatTime
+import java.time.LocalDateTime
 import javax.inject.Inject
 
 class SingleRepositoryImpl @Inject constructor() : SingleRepository {
@@ -24,6 +39,46 @@ class SingleRepositoryImpl @Inject constructor() : SingleRepository {
 
     override suspend fun getGpsData(): List<GpsData> {
         return _gpsDataList.value
+    }
+
+    /**
+     * 싱글 UI 테스트를 위한 임시 메소드
+     */
+    override suspend fun getGpsDataTest(): SingleResult {
+        val endTimeLocalDateType = _gpsDataList.value.lastOrNull()?.time
+        val startTimeLocalDateType = _gpsDataList.value.firstOrNull()?.time
+
+        return SingleResult(
+            singleRunnerStatus = SingleRunnerStatus(
+                endTime = formatEndTime(endTimeLocalDateType),
+                elapsedTime = calculateElapsedTimeToDomainModel(
+                    startTimeLocalDateType,
+                    endTimeLocalDateType
+                ),
+                secondsElapsedTime = calculateSecondsElapsedTimeToDomainModel(
+                    startTimeLocalDateType,
+                    endTimeLocalDateType
+                ),
+                records = _gpsDataList.value.mapIndexed { index, gpsData ->
+                    SingleRunnerRecord(
+                        altitude = gpsData.altitude,
+                        latitude = gpsData.latitude,
+                        longitude = gpsData.longitude,
+                        time = gpsData.time,
+                        distance = (index + 1) * 50.0  // 인덱스는 0부터 시작하므로, index + 1을 하여 1부터 시작하도록
+                    )
+                }
+            ),
+            startTime = startTimeLocalDateType?.let { formatTime(it) },
+            targetDistance = this._totalDistance.value,
+            targetDistanceFormatted = this._totalDistance.value.let {
+                formatDistanceWithComma(it)
+            },
+            targetDistanceInKm = this._totalDistance.value.let {
+                formatDistanceInKm(it)
+            },
+            singleDate = startTimeLocalDateType?.let { formatDate(it) } ?: ""
+        )
     }
 
     override suspend fun setDistance(totalDistance: Int) {

--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/SingleRepositoryImpl.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/SingleRepositoryImpl.kt
@@ -2,14 +2,10 @@ package online.partyrun.partyrunapplication.core.data.repository
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.firstOrNull
 import online.partyrun.partyrunapplication.core.model.running.GpsData
 import online.partyrun.partyrunapplication.core.model.running_result.single.SingleResult
 import online.partyrun.partyrunapplication.core.model.running_result.single.SingleRunnerRecord
 import online.partyrun.partyrunapplication.core.model.running_result.single.SingleRunnerStatus
-import online.partyrun.partyrunapplication.core.model.util.DateTimeUtils
-import online.partyrun.partyrunapplication.core.network.model.response.toDomainModel
 import online.partyrun.partyrunapplication.core.network.model.util.calculateElapsedTimeToDomainModel
 import online.partyrun.partyrunapplication.core.network.model.util.calculateSecondsElapsedTimeToDomainModel
 import online.partyrun.partyrunapplication.core.network.model.util.formatDate
@@ -17,7 +13,6 @@ import online.partyrun.partyrunapplication.core.network.model.util.formatDistanc
 import online.partyrun.partyrunapplication.core.network.model.util.formatDistanceWithComma
 import online.partyrun.partyrunapplication.core.network.model.util.formatEndTime
 import online.partyrun.partyrunapplication.core.network.model.util.formatTime
-import java.time.LocalDateTime
 import javax.inject.Inject
 
 class SingleRepositoryImpl @Inject constructor() : SingleRepository {

--- a/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/running_result/GetStoredSingleResultUseCase.kt
+++ b/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/running_result/GetStoredSingleResultUseCase.kt
@@ -1,0 +1,13 @@
+package online.partyrun.partyrunapplication.core.domain.running_result
+
+import online.partyrun.partyrunapplication.core.data.repository.SingleRepository
+import online.partyrun.partyrunapplication.core.model.running_result.single.toUiModel
+import online.partyrun.partyrunapplication.core.model.running_result.ui.SingleResultUiModel
+import javax.inject.Inject
+
+class GetStoredSingleResultUseCase @Inject constructor(
+    private val singleRepository: SingleRepository
+) {
+    suspend operator fun invoke(): SingleResultUiModel =
+        singleRepository.getGpsDataTest().toUiModel()
+}

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/running_result/battle/BattleRunnerRecord.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/running_result/battle/BattleRunnerRecord.kt
@@ -1,5 +1,6 @@
 package online.partyrun.partyrunapplication.core.model.running_result.battle
 
+import online.partyrun.partyrunapplication.core.model.running_result.common.RunnerRecord
 import online.partyrun.partyrunapplication.core.model.running_result.ui.RunnerRecordUiModel
 import java.time.LocalDateTime
 
@@ -9,12 +10,12 @@ import java.time.LocalDateTime
  * @param distance: 해당 GPS까지의 달린 총 거리
  */
 data class BattleRunnerRecord(
-    val altitude: Double,
-    val latitude: Double,
-    val longitude: Double,
-    val time: LocalDateTime,
-    val distance: Double
-)
+    override val altitude: Double,
+    override val latitude: Double,
+    override val longitude: Double,
+    override val time: LocalDateTime,
+    override val distance: Double
+) : RunnerRecord
 
 fun BattleRunnerRecord.toUiModel(): RunnerRecordUiModel {
     return RunnerRecordUiModel(

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/running_result/battle/BattleRunnerStatus.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/running_result/battle/BattleRunnerStatus.kt
@@ -1,21 +1,23 @@
 package online.partyrun.partyrunapplication.core.model.running_result.battle
 
+import online.partyrun.partyrunapplication.core.model.running_result.common.RunnerStatus
 import online.partyrun.partyrunapplication.core.model.running_result.ui.RunnerStatusUiModel
-import online.partyrun.partyrunapplication.core.model.util.formatDurationToTimeString
-import online.partyrun.partyrunapplication.core.model.util.formatPace
-import java.time.Duration
-import kotlin.math.roundToInt
+import online.partyrun.partyrunapplication.core.model.util.calculateAltitudeOverTime
+import online.partyrun.partyrunapplication.core.model.util.calculateAverageAltitude
+import online.partyrun.partyrunapplication.core.model.util.calculateAveragePace
+import online.partyrun.partyrunapplication.core.model.util.calculateDistanceOverTime
+import online.partyrun.partyrunapplication.core.model.util.calculatePacePerMinute
 
 data class BattleRunnerStatus(
-    val endTime: String = "",
     val id: String = "", // 해당 Runner ID
     val name: String = "",
-    val elapsedTime: String = "", // 총 달린 시간
-    val secondsElapsedTime: Long = 0,
     val profile: String = "",
     val rank: Int = 0,
-    val records: List<BattleRunnerRecord> = listOf() // records 필드 추가
-)
+    override val endTime: String = "",
+    override val secondsElapsedTime: Long = 0,
+    override val elapsedTime: String = "", // 총 달린 시간
+    override val records: List<BattleRunnerRecord> = listOf() // records 필드 추가
+) : RunnerStatus
 
 fun BattleRunnerStatus.toUiModel(): RunnerStatusUiModel {
     return RunnerStatusUiModel(
@@ -33,60 +35,4 @@ fun BattleRunnerStatus.toUiModel(): RunnerStatusUiModel {
         distanceOverTime = calculateDistanceOverTime(this.records),
         altitudeOvertime = calculateAltitudeOverTime(this.records)
     )
-}
-
-fun calculateAveragePace(runnerStatus: BattleRunnerStatus): String {
-    val seconds = runnerStatus.secondsElapsedTime.toDouble()
-    val lastRecordDistance = runnerStatus.records.lastOrNull()?.distance ?: 0.0
-    val distanceInKm = lastRecordDistance / 1000.0
-
-    val pace = if (distanceInKm > 0) seconds / distanceInKm else 0.0
-
-    return formatPace(pace)
-}
-
-fun calculateAverageAltitude(runnerStatus: BattleRunnerStatus): Double {
-    return if (runnerStatus.records.isNotEmpty()) {
-        (runnerStatus.records.sumOf { it.altitude } / runnerStatus.records.size)
-            .roundToInt().toDouble()
-    } else {
-        0.0
-    }
-}
-
-fun calculatePacePerMinute(records: List<BattleRunnerRecord>): List<Pair<String, Double>> {
-    val startTime = records.first().time
-    return records.drop(1).mapNotNull { record ->
-        val timeElapsed = Duration.between(startTime, record.time)
-        val currentDistanceInKm = record.distance / 1000.0
-
-        if (!timeElapsed.isZero && currentDistanceInKm != 0.0) {
-            val rawPaceInSeconds = timeElapsed.toSeconds().toDouble() / currentDistanceInKm
-            val minutesPart = (rawPaceInSeconds / 60).toInt()
-            val secondsPart = (rawPaceInSeconds % 60).toInt()
-
-            val formattedPace = "$minutesPart.${secondsPart}"
-            Pair(formatDurationToTimeString(timeElapsed), formattedPace.toDouble())
-        } else {
-            null
-        }
-    }
-}
-
-fun calculateDistanceOverTime(records: List<BattleRunnerRecord>): List<Pair<String, Double>> {
-    val startTime = records.first().time
-
-    return records.map { record ->
-        val timeElapsed = Duration.between(startTime, record.time)
-        Pair(formatDurationToTimeString(timeElapsed), record.distance)
-    }
-}
-
-fun calculateAltitudeOverTime(records: List<BattleRunnerRecord>): List<Pair<String, Double>> {
-    val startTime = records.first().time
-
-    return records.map { record ->
-        val timeElapsed = Duration.between(startTime, record.time)
-        Pair(formatDurationToTimeString(timeElapsed), record.altitude.roundToInt().toDouble())
-    }
 }

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/running_result/common/RunnerRecord.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/running_result/common/RunnerRecord.kt
@@ -1,0 +1,11 @@
+package online.partyrun.partyrunapplication.core.model.running_result.common
+
+import java.time.LocalDateTime
+
+interface RunnerRecord {
+    val altitude: Double
+    val latitude: Double
+    val longitude: Double
+    val time: LocalDateTime
+    val distance: Double
+}

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/running_result/common/RunnerStatus.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/running_result/common/RunnerStatus.kt
@@ -1,0 +1,8 @@
+package online.partyrun.partyrunapplication.core.model.running_result.common
+
+interface RunnerStatus {
+    val endTime: String
+    val elapsedTime: String
+    val secondsElapsedTime: Long
+    val records: List<RunnerRecord>
+}

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/running_result/single/SingleResult.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/running_result/single/SingleResult.kt
@@ -1,0 +1,23 @@
+package online.partyrun.partyrunapplication.core.model.running_result.single
+
+import online.partyrun.partyrunapplication.core.model.running_result.ui.SingleResultUiModel
+
+data class SingleResult(
+    val singleRunnerStatus: SingleRunnerStatus = SingleRunnerStatus(),
+    val startTime: String? = "", // "xx:xx" 형식화
+    val targetDistance: Int? = 0,
+    val targetDistanceFormatted: String = "", // 쉼표로 형식화
+    val targetDistanceInKm: String = "", // km 단위로 형식화
+    val singleDate: String = "" // "x월 x일" 형식화
+)
+
+fun SingleResult.toUiModel(): SingleResultUiModel {
+    return SingleResultUiModel(
+        singleRunnerStatus = this.singleRunnerStatus.toUiModel(),
+        startTime = this.startTime,
+        targetDistance = this.targetDistance,
+        targetDistanceFormatted = this.targetDistanceFormatted,
+        targetDistanceInKm = this.targetDistanceInKm,
+        singleDate = this.singleDate,
+    )
+}

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/running_result/single/SingleRunnerRecord.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/running_result/single/SingleRunnerRecord.kt
@@ -1,0 +1,27 @@
+package online.partyrun.partyrunapplication.core.model.running_result.single
+
+import online.partyrun.partyrunapplication.core.model.running_result.ui.RunnerRecordUiModel
+import java.time.LocalDateTime
+
+/**
+ * 해당 러너가 뛴 각 기록에 대한 세부 정보
+ * @param time: 해당 GPS가 찍힌 시간
+ * @param distance: 해당 GPS까지의 달린 총 거리
+ */
+data class SingleRunnerRecord(
+    val altitude: Double,
+    val latitude: Double,
+    val longitude: Double,
+    val time: LocalDateTime,
+    val distance: Double
+)
+
+fun SingleRunnerRecord.toUiModel(): RunnerRecordUiModel {
+    return RunnerRecordUiModel(
+        altitude = this.altitude,
+        latitude = this.latitude,
+        longitude = this.longitude,
+        time = this.time,
+        distance = this.distance
+    )
+}

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/running_result/single/SingleRunnerRecord.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/running_result/single/SingleRunnerRecord.kt
@@ -1,5 +1,6 @@
 package online.partyrun.partyrunapplication.core.model.running_result.single
 
+import online.partyrun.partyrunapplication.core.model.running_result.common.RunnerRecord
 import online.partyrun.partyrunapplication.core.model.running_result.ui.RunnerRecordUiModel
 import java.time.LocalDateTime
 
@@ -9,12 +10,12 @@ import java.time.LocalDateTime
  * @param distance: 해당 GPS까지의 달린 총 거리
  */
 data class SingleRunnerRecord(
-    val altitude: Double,
-    val latitude: Double,
-    val longitude: Double,
-    val time: LocalDateTime,
-    val distance: Double
-)
+    override val altitude: Double,
+    override val latitude: Double,
+    override val longitude: Double,
+    override val time: LocalDateTime,
+    override val distance: Double
+) : RunnerRecord
 
 fun SingleRunnerRecord.toUiModel(): RunnerRecordUiModel {
     return RunnerRecordUiModel(

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/running_result/single/SingleRunnerStatus.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/running_result/single/SingleRunnerStatus.kt
@@ -1,17 +1,19 @@
 package online.partyrun.partyrunapplication.core.model.running_result.single
 
+import online.partyrun.partyrunapplication.core.model.running_result.common.RunnerStatus
 import online.partyrun.partyrunapplication.core.model.running_result.ui.RunnerStatusUiModel
-import online.partyrun.partyrunapplication.core.model.util.formatDurationToTimeString
-import online.partyrun.partyrunapplication.core.model.util.formatPace
-import java.time.Duration
-import kotlin.math.roundToInt
+import online.partyrun.partyrunapplication.core.model.util.calculateAltitudeOverTime
+import online.partyrun.partyrunapplication.core.model.util.calculateAverageAltitude
+import online.partyrun.partyrunapplication.core.model.util.calculateAveragePace
+import online.partyrun.partyrunapplication.core.model.util.calculateDistanceOverTime
+import online.partyrun.partyrunapplication.core.model.util.calculatePacePerMinute
 
 data class SingleRunnerStatus(
-    val endTime: String = "",
-    val elapsedTime: String = "", // 총 달린 시간
-    val secondsElapsedTime: Long = 0,
-    val records: List<SingleRunnerRecord> = listOf() // records 필드 추가
-)
+    override val endTime: String = "",
+    override val elapsedTime: String = "", // 총 달린 시간
+    override val secondsElapsedTime: Long = 0,
+    override val records: List<SingleRunnerRecord> = listOf() // records 필드 추가
+) : RunnerStatus
 
 fun SingleRunnerStatus.toUiModel(): RunnerStatusUiModel {
     return RunnerStatusUiModel(
@@ -21,70 +23,8 @@ fun SingleRunnerStatus.toUiModel(): RunnerStatusUiModel {
         records = this.records.map { it.toUiModel() },
         averagePace = calculateAveragePace(this),
         averageAltitude = calculateAverageAltitude(this),
-        pacePerMinute = calculatePacePerMinute(
-            this.records
-        ),
-        distanceOverTime = calculateDistanceOverTime(
-            this.records
-        ),
-        altitudeOvertime = calculateAltitudeOverTime(
-            this.records
-        )
+        pacePerMinute = calculatePacePerMinute(this.records),
+        distanceOverTime = calculateDistanceOverTime(this.records),
+        altitudeOvertime = calculateAltitudeOverTime(this.records)
     )
-}
-
-fun calculateAveragePace(runnerStatus: SingleRunnerStatus): String {
-    val seconds = runnerStatus.secondsElapsedTime.toDouble()
-    val lastRecordDistance = runnerStatus.records.lastOrNull()?.distance ?: 0.0
-    val distanceInKm = lastRecordDistance / 1000.0
-
-    val pace = if (distanceInKm > 0) seconds / distanceInKm else 0.0
-
-    return formatPace(pace)
-}
-
-fun calculateAverageAltitude(runnerStatus: SingleRunnerStatus): Double {
-    return if (runnerStatus.records.isNotEmpty()) {
-        (runnerStatus.records.sumOf { it.altitude } / runnerStatus.records.size)
-            .roundToInt().toDouble()
-    } else {
-        0.0
-    }
-}
-
-fun calculatePacePerMinute(records: List<SingleRunnerRecord>): List<Pair<String, Double>> {
-    val startTime = records.first().time
-    return records.drop(1).mapNotNull { record ->
-        val timeElapsed = Duration.between(startTime, record.time)
-        val currentDistanceInKm = record.distance / 1000.0
-
-        if (!timeElapsed.isZero && currentDistanceInKm != 0.0) {
-            val rawPaceInSeconds = timeElapsed.toSeconds().toDouble() / currentDistanceInKm
-            val minutesPart = (rawPaceInSeconds / 60).toInt()
-            val secondsPart = (rawPaceInSeconds % 60).toInt()
-
-            val formattedPace = "$minutesPart.${secondsPart}"
-            Pair(formatDurationToTimeString(timeElapsed), formattedPace.toDouble())
-        } else {
-            null
-        }
-    }
-}
-
-fun calculateDistanceOverTime(records: List<SingleRunnerRecord>): List<Pair<String, Double>> {
-    val startTime = records.first().time
-
-    return records.map { record ->
-        val timeElapsed = Duration.between(startTime, record.time)
-        Pair(formatDurationToTimeString(timeElapsed), record.distance)
-    }
-}
-
-fun calculateAltitudeOverTime(records: List<SingleRunnerRecord>): List<Pair<String, Double>> {
-    val startTime = records.first().time
-
-    return records.map { record ->
-        val timeElapsed = Duration.between(startTime, record.time)
-        Pair(formatDurationToTimeString(timeElapsed), record.altitude.roundToInt().toDouble())
-    }
 }

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/running_result/single/SingleRunnerStatus.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/running_result/single/SingleRunnerStatus.kt
@@ -1,0 +1,90 @@
+package online.partyrun.partyrunapplication.core.model.running_result.single
+
+import online.partyrun.partyrunapplication.core.model.running_result.ui.RunnerStatusUiModel
+import online.partyrun.partyrunapplication.core.model.util.formatDurationToTimeString
+import online.partyrun.partyrunapplication.core.model.util.formatPace
+import java.time.Duration
+import kotlin.math.roundToInt
+
+data class SingleRunnerStatus(
+    val endTime: String = "",
+    val elapsedTime: String = "", // 총 달린 시간
+    val secondsElapsedTime: Long = 0,
+    val records: List<SingleRunnerRecord> = listOf() // records 필드 추가
+)
+
+fun SingleRunnerStatus.toUiModel(): RunnerStatusUiModel {
+    return RunnerStatusUiModel(
+        endTime = this.endTime,
+        elapsedTime = this.elapsedTime,
+        secondsElapsedTime = this.secondsElapsedTime,
+        records = this.records.map { it.toUiModel() },
+        averagePace = calculateAveragePace(this),
+        averageAltitude = calculateAverageAltitude(this),
+        pacePerMinute = calculatePacePerMinute(
+            this.records
+        ),
+        distanceOverTime = calculateDistanceOverTime(
+            this.records
+        ),
+        altitudeOvertime = calculateAltitudeOverTime(
+            this.records
+        )
+    )
+}
+
+fun calculateAveragePace(runnerStatus: SingleRunnerStatus): String {
+    val seconds = runnerStatus.secondsElapsedTime.toDouble()
+    val lastRecordDistance = runnerStatus.records.lastOrNull()?.distance ?: 0.0
+    val distanceInKm = lastRecordDistance / 1000.0
+
+    val pace = if (distanceInKm > 0) seconds / distanceInKm else 0.0
+
+    return formatPace(pace)
+}
+
+fun calculateAverageAltitude(runnerStatus: SingleRunnerStatus): Double {
+    return if (runnerStatus.records.isNotEmpty()) {
+        (runnerStatus.records.sumOf { it.altitude } / runnerStatus.records.size)
+            .roundToInt().toDouble()
+    } else {
+        0.0
+    }
+}
+
+fun calculatePacePerMinute(records: List<SingleRunnerRecord>): List<Pair<String, Double>> {
+    val startTime = records.first().time
+    return records.drop(1).mapNotNull { record ->
+        val timeElapsed = Duration.between(startTime, record.time)
+        val currentDistanceInKm = record.distance / 1000.0
+
+        if (!timeElapsed.isZero && currentDistanceInKm != 0.0) {
+            val rawPaceInSeconds = timeElapsed.toSeconds().toDouble() / currentDistanceInKm
+            val minutesPart = (rawPaceInSeconds / 60).toInt()
+            val secondsPart = (rawPaceInSeconds % 60).toInt()
+
+            val formattedPace = "$minutesPart.${secondsPart}"
+            Pair(formatDurationToTimeString(timeElapsed), formattedPace.toDouble())
+        } else {
+            null
+        }
+    }
+}
+
+fun calculateDistanceOverTime(records: List<SingleRunnerRecord>): List<Pair<String, Double>> {
+    val startTime = records.first().time
+
+    return records.map { record ->
+        val timeElapsed = Duration.between(startTime, record.time)
+        Pair(formatDurationToTimeString(timeElapsed), record.distance)
+    }
+}
+
+fun calculateAltitudeOverTime(records: List<SingleRunnerRecord>): List<Pair<String, Double>> {
+    val startTime = records.first().time
+
+    return records.map { record ->
+        val timeElapsed = Duration.between(startTime, record.time)
+        Pair(formatDurationToTimeString(timeElapsed), record.altitude.roundToInt().toDouble())
+    }
+}

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/running_result/ui/SingleResultUiModel.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/running_result/ui/SingleResultUiModel.kt
@@ -1,0 +1,10 @@
+package online.partyrun.partyrunapplication.core.model.running_result.ui
+
+data class SingleResultUiModel(
+    val singleRunnerStatus: RunnerStatusUiModel = RunnerStatusUiModel(),
+    val startTime: String? = "", // "xx:xx" 형식화
+    val targetDistance: Int? = 0,
+    val targetDistanceFormatted: String = "", // 쉼표로 형식화
+    val targetDistanceInKm: String = "", // km 단위로 형식화
+    val singleDate: String = "" // "x월 x일" 형식화
+)

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/util/RunningRecordCalculation.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/util/RunningRecordCalculation.kt
@@ -1,6 +1,9 @@
 package online.partyrun.partyrunapplication.core.model.util
 
+import online.partyrun.partyrunapplication.core.model.running_result.common.RunnerRecord
+import online.partyrun.partyrunapplication.core.model.running_result.common.RunnerStatus
 import java.time.Duration
+import kotlin.math.roundToInt
 
 fun formatPace(pace: Double): String {
     val minutesPart = (pace / 60).toInt()
@@ -16,4 +19,61 @@ fun formatDurationToTimeString(duration: Duration): String {
     val seconds = duration.seconds % 60
 
     return String.format("%02d:%02d:%02d", hours, minutes, seconds)
+}
+
+
+fun calculateAveragePace(runnerStatus: RunnerStatus): String {
+    val seconds = runnerStatus.secondsElapsedTime.toDouble()
+    val lastRecordDistance = runnerStatus.records.lastOrNull()?.distance ?: 0.0
+    val distanceInKm = lastRecordDistance / 1000.0
+
+    val pace = if (distanceInKm > 0) seconds / distanceInKm else 0.0
+
+    return formatPace(pace)
+}
+
+fun calculateAverageAltitude(runnerStatus: RunnerStatus): Double {
+    return if (runnerStatus.records.isNotEmpty()) {
+        (runnerStatus.records.sumOf { it.altitude } / runnerStatus.records.size)
+            .roundToInt().toDouble()
+    } else {
+        0.0
+    }
+}
+
+fun calculatePacePerMinute(records: List<RunnerRecord>): List<Pair<String, Double>> {
+    val startTime = records.first().time
+    return records.drop(1).mapNotNull { record ->
+        val timeElapsed = Duration.between(startTime, record.time)
+        val currentDistanceInKm = record.distance / 1000.0
+
+        if (!timeElapsed.isZero && currentDistanceInKm != 0.0) {
+            val rawPaceInSeconds = timeElapsed.toSeconds().toDouble() / currentDistanceInKm
+            val minutesPart = (rawPaceInSeconds / 60).toInt()
+            val secondsPart = (rawPaceInSeconds % 60).toInt()
+
+            val formattedPace = "$minutesPart.${secondsPart}"
+            Pair(formatDurationToTimeString(timeElapsed), formattedPace.toDouble())
+        } else {
+            null
+        }
+    }
+}
+
+fun calculateDistanceOverTime(records: List<RunnerRecord>): List<Pair<String, Double>> {
+    val startTime = records.first().time
+
+    return records.map { record ->
+        val timeElapsed = Duration.between(startTime, record.time)
+        Pair(formatDurationToTimeString(timeElapsed), record.distance)
+    }
+}
+
+fun calculateAltitudeOverTime(records: List<RunnerRecord>): List<Pair<String, Double>> {
+    val startTime = records.first().time
+
+    return records.map { record ->
+        val timeElapsed = Duration.between(startTime, record.time)
+        Pair(formatDurationToTimeString(timeElapsed), record.altitude.roundToInt().toDouble())
+    }
 }

--- a/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/main/MainNavRoutes.kt
+++ b/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/main/MainNavRoutes.kt
@@ -13,6 +13,7 @@ sealed class MainNavRoutes(val route: String) {
     object BattleRunning : MainNavRoutes("battle_running")
     object SingleRunning : MainNavRoutes("single_running")
     object BattleResult : MainNavRoutes("battle_result")
+    object SingleResult : MainNavRoutes("single_result")
     object Settings : MainNavRoutes("settings")
 
 }

--- a/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/running/RunningNavigation.kt
+++ b/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/running/RunningNavigation.kt
@@ -30,7 +30,7 @@ fun NavGraphBuilder.battleRunningRoute(
 }
 
 fun NavGraphBuilder.singleRunningRoute(
-    navigateToSingle: () -> Unit,
+    navigateToSingleResult: () -> Unit,
     onShowSnackbar: (String) -> Unit,
     ) {
     composable(
@@ -51,7 +51,7 @@ fun NavGraphBuilder.singleRunningRoute(
         SingleContentScreen(
             targetDistance = distance,
             targetTime = time,
-            navigateToSingle = navigateToSingle,
+            navigateToSingleResult = navigateToSingleResult,
             onShowSnackbar = onShowSnackbar
         )
     }

--- a/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/running_result/RunningResultNavigation.kt
+++ b/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/running_result/RunningResultNavigation.kt
@@ -4,12 +4,18 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import online.partyrun.partyrunapplication.core.navigation.main.MainNavRoutes
 import online.partyrun.partyrunapplication.feature.running_result.battle.BattleResultScreen
+import online.partyrun.partyrunapplication.feature.running_result.single.SingleResultScreen
 
 fun NavGraphBuilder.runningResultRoute(
     navigateToTopLevel: () -> Unit
 ) {
     composable(route = MainNavRoutes.BattleResult.route) {
         BattleResultScreen(
+            navigateToTopLevel = navigateToTopLevel
+        )
+    }
+    composable(route = MainNavRoutes.SingleResult.route) {
+        SingleResultScreen(
             navigateToTopLevel = navigateToTopLevel
         )
     }

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/BattleRunnerStatusResponse.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/BattleRunnerStatusResponse.kt
@@ -2,10 +2,10 @@ package online.partyrun.partyrunapplication.core.network.model.response
 
 import com.google.gson.annotations.SerializedName
 import online.partyrun.partyrunapplication.core.model.running_result.battle.BattleRunnerStatus
-import online.partyrun.partyrunapplication.core.model.util.DateTimeUtils.localDateTimeFormatter
-import online.partyrun.partyrunapplication.core.network.model.util.calculateElapsedTime
-import online.partyrun.partyrunapplication.core.network.model.util.calculateSecondsElapsedTime
-import online.partyrun.partyrunapplication.core.network.model.util.formatTime
+import online.partyrun.partyrunapplication.core.network.model.util.calculateElapsedTimeToDomainModel
+import online.partyrun.partyrunapplication.core.network.model.util.calculateSecondsElapsedTimeToDomainModel
+import online.partyrun.partyrunapplication.core.network.model.util.formatEndTime
+import online.partyrun.partyrunapplication.core.network.model.util.parseEndTime
 import java.time.LocalDateTime
 
 data class BattleRunnerStatusResponse(
@@ -33,34 +33,4 @@ fun BattleRunnerStatusResponse.toDomainModel(startTime: LocalDateTime?): BattleR
         secondsElapsedTime = calculateSecondsElapsedTimeToDomainModel(startTime, parsedEndTime),
         records = this.records.map { it.toDomainModel() } // 각 record를 도메인 모델로 변환
     )
-}
-
-private fun calculateElapsedTimeToDomainModel(
-    startTime: LocalDateTime?,
-    parsedEndTime: LocalDateTime?
-) = if (startTime != null && parsedEndTime != null) {
-    calculateElapsedTime(startTime, parsedEndTime)
-} else {
-    "00:00"
-}
-
-private fun calculateSecondsElapsedTimeToDomainModel(
-    startTime: LocalDateTime?,
-    parsedEndTime: LocalDateTime?
-) = if (startTime != null && parsedEndTime != null) {
-    calculateSecondsElapsedTime(startTime, parsedEndTime)
-} else {
-    0
-}
-
-private fun parseEndTime(endTime: String?): LocalDateTime? {
-    /**
-     *  LocalDateTime.parse() :
-     *  문자열 형태로 표현된 날짜와 시간 정보를 LocalDateTime 객체로 변환 수행
-     */
-    return endTime?.let { LocalDateTime.parse(it, localDateTimeFormatter) }
-}
-
-private fun formatEndTime(parsedEndTime: LocalDateTime?): String {
-    return parsedEndTime?.let { formatTime(it) } ?: "00:00"
 }

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/SingleResultResponse.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/SingleResultResponse.kt
@@ -1,0 +1,41 @@
+package online.partyrun.partyrunapplication.core.network.model.response
+
+import com.google.gson.annotations.SerializedName
+import online.partyrun.partyrunapplication.core.model.running_result.single.SingleResult
+import online.partyrun.partyrunapplication.core.model.running_result.single.SingleRunnerStatus
+import online.partyrun.partyrunapplication.core.model.util.DateTimeUtils.localDateTimeFormatter
+import online.partyrun.partyrunapplication.core.network.model.util.formatDate
+import online.partyrun.partyrunapplication.core.network.model.util.formatDistanceInKm
+import online.partyrun.partyrunapplication.core.network.model.util.formatDistanceWithComma
+import online.partyrun.partyrunapplication.core.network.model.util.formatTime
+import java.time.LocalDateTime
+
+data class SingleResultResponse(
+    @SerializedName("runner")
+    val singleRunnerStatus: SingleRunnerStatusResponse?,
+    @SerializedName("startTime")
+    val startTime: String?,
+    @SerializedName("targetDistance")
+    val targetDistance: Int?
+)
+
+fun SingleResultResponse.toDomainModel(): SingleResult {
+    val parsedStartTime = this.startTime?.let {
+        LocalDateTime.parse(
+            it,
+            localDateTimeFormatter
+        )
+    }
+
+    return SingleResult(
+        singleRunnerStatus = this.singleRunnerStatus?.toDomainModel(parsedStartTime)
+            ?: SingleRunnerStatus(),
+        startTime = parsedStartTime?.let { formatTime(it) } ?: "", // "xx:xx" 형식화
+        targetDistance = this.targetDistance ?: 0,
+        targetDistanceFormatted = this.targetDistance?.let { formatDistanceWithComma(it) }
+            ?: "", // 쉼표로 형식화
+        targetDistanceInKm = this.targetDistance?.let { formatDistanceInKm(it) }
+            ?: "",  // km 단위로 형식화
+        singleDate = parsedStartTime?.let { formatDate(it) } ?: "" // "x월 x일" 형식화
+    )
+}

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/SingleRunnerRecordResponse.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/SingleRunnerRecordResponse.kt
@@ -1,0 +1,31 @@
+package online.partyrun.partyrunapplication.core.network.model.response
+
+import com.google.gson.annotations.SerializedName
+import online.partyrun.partyrunapplication.core.model.running_result.single.SingleRunnerRecord
+import online.partyrun.partyrunapplication.core.model.util.DateTimeUtils.localDateTimeFormatter
+import java.time.LocalDateTime
+
+data class SingleRunnerRecordResponse(
+    @SerializedName("altitude")
+    val altitude: Double?,
+    @SerializedName("latitude")
+    val latitude: Double?,
+    @SerializedName("longitude")
+    val longitude: Double?,
+    @SerializedName("time")
+    val time: String?,
+    @SerializedName("distance")
+    val distance: Double?
+)
+
+fun SingleRunnerRecordResponse.toDomainModel(): SingleRunnerRecord {
+    val parsedTime =
+        this.time?.let { LocalDateTime.parse(it, localDateTimeFormatter) } ?: LocalDateTime.MIN
+    return SingleRunnerRecord(
+        altitude = this.altitude ?: 0.0,
+        latitude = this.latitude ?: 0.0,
+        longitude = this.longitude ?: 0.0,
+        time = parsedTime,
+        distance = this.distance ?: 0.0
+    )
+}

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/SingleRunnerStatusResponse.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/SingleRunnerStatusResponse.kt
@@ -1,0 +1,27 @@
+package online.partyrun.partyrunapplication.core.network.model.response
+
+import com.google.gson.annotations.SerializedName
+import online.partyrun.partyrunapplication.core.model.running_result.single.SingleRunnerStatus
+import online.partyrun.partyrunapplication.core.network.model.util.calculateElapsedTimeToDomainModel
+import online.partyrun.partyrunapplication.core.network.model.util.calculateSecondsElapsedTimeToDomainModel
+import online.partyrun.partyrunapplication.core.network.model.util.formatEndTime
+import online.partyrun.partyrunapplication.core.network.model.util.parseEndTime
+import java.time.LocalDateTime
+
+data class SingleRunnerStatusResponse(
+    @SerializedName("endTime")
+    val endTime: String?,
+    @SerializedName("records")
+    val records: List<SingleRunnerRecordResponse>
+)
+
+fun SingleRunnerStatusResponse.toDomainModel(startTime: LocalDateTime?): SingleRunnerStatus {
+    val parsedEndTime = parseEndTime(this.endTime)
+
+    return SingleRunnerStatus(
+        endTime = formatEndTime(parsedEndTime),
+        elapsedTime = calculateElapsedTimeToDomainModel(startTime, parsedEndTime),
+        secondsElapsedTime = calculateSecondsElapsedTimeToDomainModel(startTime, parsedEndTime),
+        records = this.records.map { it.toDomainModel() } // 각 record를 도메인 모델로 변환
+    )
+}

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/util/FormatLocalDateTime.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/util/FormatLocalDateTime.kt
@@ -1,5 +1,6 @@
 package online.partyrun.partyrunapplication.core.network.model.util
 
+import online.partyrun.partyrunapplication.core.model.util.DateTimeUtils
 import java.text.NumberFormat
 import java.time.Duration
 import java.time.LocalDateTime
@@ -16,6 +17,24 @@ fun formatTime(time: LocalDateTime): String {
     } else {
         time.format(DateTimeFormatter.ofPattern("mm:ss"))
     }
+}
+
+fun calculateElapsedTimeToDomainModel(
+    startTime: LocalDateTime?,
+    parsedEndTime: LocalDateTime?
+) = if (startTime != null && parsedEndTime != null) {
+    calculateElapsedTime(startTime, parsedEndTime)
+} else {
+    "00:00"
+}
+
+fun calculateSecondsElapsedTimeToDomainModel(
+    startTime: LocalDateTime?,
+    parsedEndTime: LocalDateTime?
+) = if (startTime != null && parsedEndTime != null) {
+    calculateSecondsElapsedTime(startTime, parsedEndTime)
+} else {
+    0
 }
 
 /**
@@ -51,4 +70,16 @@ fun formatDistanceWithComma(distance: Int): String {
 
 fun formatDistanceInKm(distance: Int): String {
     return (distance / 1000).toString().plus("km")
+}
+
+fun parseEndTime(endTime: String?): LocalDateTime? {
+    /**
+     *  LocalDateTime.parse() :
+     *  문자열 형태로 표현된 날짜와 시간 정보를 LocalDateTime 객체로 변환 수행
+     */
+    return endTime?.let { LocalDateTime.parse(it, DateTimeUtils.localDateTimeFormatter) }
+}
+
+fun formatEndTime(parsedEndTime: LocalDateTime?): String {
+    return parsedEndTime?.let { formatTime(it) } ?: "00:00"
 }

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentScreen.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentScreen.kt
@@ -34,7 +34,7 @@ fun SingleContentScreen(
     targetDistance: Int?,
     targetTime: Int?,
     singleContentViewModel: SingleContentViewModel = hiltViewModel(),
-    navigateToSingle: () -> Unit,
+    navigateToSingleResult: () -> Unit = {},
     onShowSnackbar: (String) -> Unit
 ) {
     val singleContentUiState by singleContentViewModel.singleContentUiState.collectAsStateWithLifecycle()
@@ -44,7 +44,7 @@ fun SingleContentScreen(
     Content(
         targetDistance = targetDistance,
         targetTime = targetTime,
-        navigateToSingle = navigateToSingle,
+        navigateToSingleResult = navigateToSingleResult,
         singleContentViewModel = singleContentViewModel,
         singleContentUiState = singleContentUiState,
         openRunningExitDialog = openRunningExitDialog,
@@ -57,7 +57,7 @@ fun SingleContentScreen(
 fun Content(
     targetDistance: Int?,
     targetTime: Int?,
-    navigateToSingle: () -> Unit,
+    navigateToSingleResult: () -> Unit,
     singleContentViewModel: SingleContentViewModel,
     singleContentUiState: SingleContentUiState,
     openRunningExitDialog: MutableState<Boolean>,
@@ -99,7 +99,7 @@ fun Content(
     if (singleContentUiState.isFinished) {
         LaunchedEffect(Unit) {
             delay(4000)
-            navigateToSingle()
+            navigateToSingleResult()
         }
     }
 

--- a/feature/running_result/src/main/java/online/partyrun/partyrunapplication/feature/running_result/single/SingleResultScreen.kt
+++ b/feature/running_result/src/main/java/online/partyrun/partyrunapplication/feature/running_result/single/SingleResultScreen.kt
@@ -1,0 +1,195 @@
+package online.partyrun.partyrunapplication.feature.running_result.single
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import online.partyrun.partyrunapplication.core.model.running_result.ui.SingleResultUiModel
+import online.partyrun.partyrunapplication.feature.running_result.R
+import online.partyrun.partyrunapplication.feature.running_result.ui.ChartScreen
+import online.partyrun.partyrunapplication.feature.running_result.ui.FixedBottomNavigationSheet
+import online.partyrun.partyrunapplication.feature.running_result.ui.MapWidget
+import online.partyrun.partyrunapplication.feature.running_result.ui.ResultLoadFailedBody
+import online.partyrun.partyrunapplication.feature.running_result.ui.ResultLoadingBody
+import online.partyrun.partyrunapplication.feature.running_result.ui.SummaryInfo
+
+@Composable
+fun SingleResultScreen(
+    modifier: Modifier = Modifier,
+    singleResultViewModel: SingleResultViewModel = hiltViewModel(),
+    navigateToTopLevel: () -> Unit
+) {
+    val singleResultUiState by singleResultViewModel.singleResultUiState.collectAsStateWithLifecycle()
+
+    Content(
+        modifier = modifier,
+        singleResultUiState = singleResultUiState,
+        singleResultViewModel = singleResultViewModel,
+        navigateToTopLevel = navigateToTopLevel
+    )
+}
+
+@Composable
+private fun Content(
+    modifier: Modifier = Modifier,
+    singleResultUiState: SingleResultUiState,
+    singleResultViewModel: SingleResultViewModel,
+    navigateToTopLevel: () -> Unit
+) {
+    Box(modifier = modifier) {
+        when (singleResultUiState) {
+            is SingleResultUiState.Loading -> ResultLoadingBody()
+            is SingleResultUiState.Success ->
+                SingleResultBody(
+                    singleResult = singleResultUiState.singleResult,
+                    navigateToTopLevel = navigateToTopLevel
+                )
+
+            is SingleResultUiState.LoadFailed ->
+                ResultLoadFailedBody {
+                    singleResultViewModel.getSingleResult()
+                }
+        }
+    }
+}
+
+@Composable
+private fun SingleResultBody(
+    singleResult: SingleResultUiModel,
+    navigateToTopLevel: () -> Unit
+) {
+    Box(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+        ) {
+            // 구글 맵
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(400.dp) // 지도의 높이는 400dp
+            ) {
+                MapWidget(
+                    targetDistance = singleResult.targetDistance,
+                    targetDistanceFormatted = singleResult.targetDistanceFormatted,
+                    records = singleResult.singleRunnerStatus.records
+                )
+            }
+            // 프레임 컴포넌트
+            Column(
+                modifier = Modifier
+                    .padding(top = 280.dp) // 라운딩 모서리를 위해 지도를 살짝만 가려야 하므로 padding은 280dp
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState())
+                        .padding(top = 5.dp)
+                        .background(
+                            color = MaterialTheme.colorScheme.background,
+                            shape = RoundedCornerShape(
+                                topStartPercent = 15,
+                                topEndPercent = 15
+                            ) // 라운딩 모서리
+                        )
+                ) {
+                    // 메인 정보 디스플레이
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 25.dp, horizontal = 20.dp)
+                            .shadow(elevation = 5.dp, shape = RoundedCornerShape(15.dp))
+                            .background(
+                                color = MaterialTheme.colorScheme.surface,
+                                shape = RoundedCornerShape(
+                                    topStartPercent = 15,
+                                    topEndPercent = 15
+                                ) // 라운딩 모서리
+                            )
+                    ) {
+                        Column(
+                            modifier = Modifier.padding(top = 10.dp)
+                        ) {
+                            SingleTitleAndDateDisplay(singleResult)
+                        }
+
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(top = 10.dp, start = 20.dp, end = 20.dp, bottom = 20.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            SummaryInfo(singleResult.singleRunnerStatus)
+                        }
+
+                        // 분석 차트
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(400.dp)
+                                .padding(20.dp),
+                        ) {
+                            Text(text = stringResource(id = R.string.analysis_chart))
+                            ChartScreen(runnerStatus = singleResult.singleRunnerStatus)
+                        }
+                    }
+                    Spacer(modifier = Modifier.size(60.dp)) // 바텀 컴포넌트보다 위에서 보이도록 스페이스 설정
+                }
+            }
+        }
+
+        // 스크린 위치에 상관없이 항상 바텀에 고정으로 보이는 컴포넌트
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.BottomCenter),
+            color = MaterialTheme.colorScheme.background,
+            shadowElevation = 5.dp
+        ) {
+            FixedBottomNavigationSheet(navigateToTopLevel)
+        }
+    }
+}
+
+@Composable
+private fun SingleTitleAndDateDisplay(singleResult: SingleResultUiModel) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 20.dp, start = 20.dp, end = 20.dp, bottom = 10.dp)
+    ) {
+        Text(text = singleResult.singleDate)
+        Spacer(modifier = Modifier.height(5.dp))
+        Text(
+            text = "${stringResource(id = R.string.single_title)} ${singleResult.targetDistanceInKm}",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onPrimary
+        )
+    }
+}

--- a/feature/running_result/src/main/java/online/partyrun/partyrunapplication/feature/running_result/single/SingleResultUiState.kt
+++ b/feature/running_result/src/main/java/online/partyrun/partyrunapplication/feature/running_result/single/SingleResultUiState.kt
@@ -1,0 +1,13 @@
+package online.partyrun.partyrunapplication.feature.running_result.single
+
+import online.partyrun.partyrunapplication.core.model.running_result.ui.SingleResultUiModel
+
+sealed class SingleResultUiState {
+    object Loading : SingleResultUiState()
+
+    data class Success(
+        val singleResult: SingleResultUiModel = SingleResultUiModel()
+    ) : SingleResultUiState()
+
+    object LoadFailed : SingleResultUiState()
+}

--- a/feature/running_result/src/main/java/online/partyrun/partyrunapplication/feature/running_result/single/SingleResultViewModel.kt
+++ b/feature/running_result/src/main/java/online/partyrun/partyrunapplication/feature/running_result/single/SingleResultViewModel.kt
@@ -1,0 +1,40 @@
+package online.partyrun.partyrunapplication.feature.running_result.single
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import online.partyrun.partyrunapplication.core.domain.running_result.GetStoredSingleResultUseCase
+import timber.log.Timber
+import javax.inject.Inject
+
+@HiltViewModel
+class SingleResultViewModel @Inject constructor(
+    private val getStoredSingleResultUseCase: GetStoredSingleResultUseCase
+) : ViewModel() {
+    private val _singleResultUiState =
+        MutableStateFlow<SingleResultUiState>(SingleResultUiState.Loading)
+    val singleResultUiState = _singleResultUiState.asStateFlow()
+
+    init {
+        getSingleResult()
+    }
+
+    fun getSingleResult() {
+        viewModelScope.launch {
+            try {
+                _singleResultUiState.value = SingleResultUiState.Success(
+                    singleResult = getStoredSingleResultUseCase()
+                )
+            } catch (e: Exception) {
+                Timber.tag("getSingleResult 에러").e(e)
+                _singleResultUiState.value =
+                    SingleResultUiState.LoadFailed
+            }
+        }
+    }
+
+}
+

--- a/feature/running_result/src/main/res/values/strings.xml
+++ b/feature/running_result/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="battle_title">대결모드</string>
+    <string name="single_title">싱글모드</string>
     <string name="avg_pace">평균 페이스</string>
     <string name="time">시간</string>
     <string name="avg_altitude">평균 고도</string>

--- a/feature/single/src/main/java/online/partyrun/partyrunapplication/feature/single/SingleScreen.kt
+++ b/feature/single/src/main/java/online/partyrun/partyrunapplication/feature/single/SingleScreen.kt
@@ -176,7 +176,7 @@ private fun SingleContent(
             modifier = Modifier
                 .fillMaxSize()
                 .weight(1f)
-                .padding(10.dp)
+                .padding(30.dp)
         ) {
             Column(
                 modifier = Modifier


### PR DESCRIPTION
## Description
싱글 모드에서는 사용자가 직접 목표 거리를 설정한다.
싱글 모드를 시작하고 Running Screen에 돌입한 이유부터의 종료 조건은 목표 거리에 도달하거나, 중간에 종료시키거나 2가지이다.
중간에 종료시킬 경우, 현 단계에서는 기록을 저장하지 않는다.
목표 거리에 도달할 경우, 결과를 보여줘야 하기에 SingleResultScreen으로 전환되고, 대결 모드와 마찬가지로 관련 기록 분석 데이터를 보여준다.

다만, 현재 API 명세가 없어 서버와 연동이 안된 상태이므로 SingleResultScreen에서 보여주는 데이터는 임시 더미 데이터를 통한 UI 환경으로 제공한다.


## Implementation

https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/cec3c381-8acc-4657-8513-35a3b4454d2e

