### PR TITLE
feat : RunningResult에서 '돌아가기' 버튼을 눌렀을 때 popUpTo 적용

### DIFF
--- a/app/src/main/java/online/partyrun/partyrunapplication/navigation/MainNavHost.kt
+++ b/app/src/main/java/online/partyrun/partyrunapplication/navigation/MainNavHost.kt
@@ -122,7 +122,11 @@ fun SetUpMainNavGraph(
 
         runningResultRoute(
             navigateToTopLevel = {
-                navController.navigate(MainNavRoutes.Battle.route)
+                navController.navigate(MainNavRoutes.Battle.route) {
+                    popUpTo(MainNavRoutes.Battle.route) {
+                        inclusive = true
+                    }
+                }
             }
         )
 


### PR DESCRIPTION
## Description
'돌아가기' 버튼을 눌렀을 때, navigateToTopLevel() 메소드가 수행되는데, 
기존에는 이 메소드에 navController popUpTo가 적용 되어있지 않아 BackStack에 ResultScreen이 그대로 있었음.
popUpTo를 적용해 제외해주는 과정을 거치도록 변경
 