### PR TITLE
#PAR-343 : 싱글모드 일시정지, 재시작, 종료 로직 구현 

### DIFF
--- a/core/common/src/main/java/online/partyrun/partyrunapplication/core/common/Constants.kt
+++ b/core/common/src/main/java/online/partyrun/partyrunapplication/core/common/Constants.kt
@@ -2,6 +2,7 @@ package online.partyrun.partyrunapplication.core.common
 
 object Constants {
     const val FIREBASE_GOOGLE_CLIENT_ID = BuildConfig.FIREBASE_GOOGLE_CLIENT_ID
+
     // App 모듈의 Build.gradle.kts -> BuildType에 따른 BASE_URL 분기 처리
     const val BASE_URL = BuildConfig.BASE_URL
 
@@ -11,5 +12,7 @@ object Constants {
 
     const val ACTION_START_RUNNING = "StartRunning"
     const val ACTION_STOP_RUNNING = "StopRunning"
+    const val ACTION_PAUSE_RUNNING = "PauseRunning"
+    const val ACTION_RESUME_RUNNING = "ResumeRunning"
     const val BATTLE_ID_KEY = "BATTLE_ID_KEY"
 }

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/running/SingleRunningScreen.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/running/SingleRunningScreen.kt
@@ -39,6 +39,7 @@ import online.partyrun.partyrunapplication.feature.running.running.component.Run
 import online.partyrun.partyrunapplication.feature.running.running.component.SingleRunnerMarker
 import online.partyrun.partyrunapplication.feature.running.running.component.TrackDistanceDistanceBox
 import online.partyrun.partyrunapplication.feature.running.running.component.trackRatio
+import online.partyrun.partyrunapplication.feature.running.single.RunningServiceState
 import online.partyrun.partyrunapplication.feature.running.single.SingleContentUiState
 import online.partyrun.partyrunapplication.feature.running.single.SingleContentViewModel
 
@@ -116,12 +117,53 @@ fun SingleRunningScreen(
                     title = stringResource(id = R.string.progress_time)
                 )
                 Spacer(modifier = Modifier.size(5.dp))
-                PartyRunImageButton(
-                    modifier = Modifier.size(80.dp),
-                    image = R.drawable.stop,
-                ) {
-                    openRunningExitDialog.value = true
-                }
+                RunControlPanel(
+                    pausedState = singleContentUiState.runningServiceState,
+                    pauseAction = {
+                        singleContentViewModel.pauseSingleRunningService()
+                    },
+                    resumeAction = {
+                        singleContentViewModel.resumeSingleRunningService()
+                    },
+                    stopAction = {
+                        openRunningExitDialog.value = true
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RunControlPanel(
+    pausedState: RunningServiceState,
+    pauseAction: () -> Unit,
+    resumeAction: () -> Unit,
+    stopAction: () -> Unit,
+) {
+    if (pausedState != RunningServiceState.PAUSED) {
+        PartyRunImageButton(
+            modifier = Modifier.size(80.dp),
+            image = R.drawable.pause,
+        ) {
+            pauseAction()
+        }
+    } else {
+        Row(
+            horizontalArrangement = Arrangement.SpaceEvenly,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            PartyRunImageButton(
+                modifier = Modifier.size(80.dp),
+                image = R.drawable.restart,
+            ) {
+                resumeAction()
+            }
+            PartyRunImageButton(
+                modifier = Modifier.size(80.dp),
+                image = R.drawable.stop,
+            ) {
+                stopAction()
             }
         }
     }

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentUiState.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentUiState.kt
@@ -2,6 +2,10 @@ package online.partyrun.partyrunapplication.feature.running.single
 
 import online.partyrun.partyrunapplication.core.model.single.SingleRunnerDisplayStatus
 
+enum class RunningServiceState {
+    STARTED, PAUSED, RESUMED, STOPPED
+}
+
 data class SingleContentUiState(
     // 목표 거리에 도달했는지 여부 판단
     val isFinished: Boolean = false,
@@ -9,8 +13,8 @@ data class SingleContentUiState(
     val selectedDistance: Int = 0,
     // 사용자가 선택한 목표 시간
     val selectedTime: Int = 0,
-    // 러닝 서비스 시작
-    val startRunningService: Boolean = false,
+    // 러닝 서비스 상태 추적
+    val runningServiceState: RunningServiceState = RunningServiceState.PAUSED,
     // 현재 보여줘야 할 스크린
     val screenState: SingleScreenState = SingleScreenState.Ready,
     // 유저 이름


### PR DESCRIPTION
## Description
싱글모드 시에 일시정지, 재시작, 종료 로직을 구현한다.
초기 버튼 패널에는 일시정지만 있고, 일시정지를 클릭했을 때 재시작과 종료 버튼 패널로 전환되는 방식이다.

* 사용자 편의성을 위해 다음과 같은 기능을 추가 구현
자동으로 사용자 디바이스 움직임을 감지하여 작동을 일시정지하거나 재시작하는 서비스와, 사용자의 의도에 따라 종료하는 로직

1. 사용자가 뛰다가 잠시 쉬거나 멈추게 되면, 앱이 자동으로 그것을 감지하여 일시정지 상태로 전환 -> 사용자가 직접 앱을 건드리지 않아도 되므로 달리기에만 집중 가능
2. 일시정지 상태에서 사용자의 움직임이 감지되면 자동으로 재시작 
3. 만약 사용자가 멈추었는데 앱이 계속 거리를 측정한다면, 의미없는 데이터이므로. 자동 일시정지 기능을 통해 데이터의 정확성 향상

안드로이드 Sensor로부터 받는 속도 데이터를 기반으로 특정 임계값(THRESHOLD) 이하일 때를 감지 ->
이 임계값 이하의 속도가 연속으로 감지될 경우 (여기서는 3회 이상-정책에 따라 수정 예정), 서비스는 자동으로 일시정지 상태로 전환
사용자의 움직임이 재개되면, 서비스는 자동으로 재시작
이러한 자동 상태 변경 로직은 브로드캐스트와 리시버를 통해 통신

## Implementation
### 일시정지, 재시작, 종료 상황

https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/bc0ed834-6933-4b4e-8d40-f3fc244d11a0


### 실제 디바이스에서 움직임을 감지하여 자동으로 일시정지, 재시작을 하는 상황

https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/0764acbd-d79b-4c94-a708-d816e0476d5f

