### PR TITLE
#PAR-347 : 싱글모드 중 사용자가 일시정지를 누른 경우와, 달리는 중 움직임이 없어 일시정지가 된 경우 로직 분리

### DIFF
--- a/core/common/src/main/java/online/partyrun/partyrunapplication/core/common/Constants.kt
+++ b/core/common/src/main/java/online/partyrun/partyrunapplication/core/common/Constants.kt
@@ -14,5 +14,7 @@ object Constants {
     const val ACTION_STOP_RUNNING = "StopRunning"
     const val ACTION_PAUSE_RUNNING = "PauseRunning"
     const val ACTION_RESUME_RUNNING = "ResumeRunning"
+    const val EXTRA_IS_USER_PAUSED = "isUserPaused"
+
     const val BATTLE_ID_KEY = "BATTLE_ID_KEY"
 }

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/running/SingleRunningScreen.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/running/SingleRunningScreen.kt
@@ -120,7 +120,7 @@ fun SingleRunningScreen(
                 RunControlPanel(
                     pausedState = singleContentUiState.runningServiceState,
                     pauseAction = {
-                        singleContentViewModel.pauseSingleRunningService()
+                        singleContentViewModel.pauseSingleRunningService(isUserPaused = true)
                     },
                     resumeAction = {
                         singleContentViewModel.resumeSingleRunningService()

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/service/SingleRunningService.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/service/SingleRunningService.kt
@@ -12,6 +12,7 @@ import online.partyrun.partyrunapplication.core.common.Constants
 import online.partyrun.partyrunapplication.core.data.repository.SingleRepository
 import online.partyrun.partyrunapplication.core.model.running.GpsData
 import online.partyrun.partyrunapplication.feature.running.single.RunningServiceState
+import timber.log.Timber
 import java.time.LocalDateTime
 import javax.inject.Inject
 import kotlin.math.roundToInt
@@ -27,29 +28,45 @@ class SingleRunningService : BaseRunningService() {
     private var isFirstLocationUpdate = true  // 플래그 초기화
     private lateinit var runningServiceState: RunningServiceState // 상태 변수를 통해 현재 서비스 상태 추적
     private var belowThresholdCount: Int = 0  // 임계값 카운트를 통해 일시정지, 재시작을 구현하기 위함
+    private var isUserPaused: Boolean = false // 사용자가 직접 일시정지를 누른 것인지 파악
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        isUserPaused = intent?.getBooleanExtra("isUserPaused", false) ?: false
+        handleIntentAction(intent)
+        return START_NOT_STICKY
+    }
+
+    private fun handleIntentAction(intent: Intent?) {
         when (intent?.action) {
             Constants.ACTION_START_RUNNING -> startRunningService()
             Constants.ACTION_PAUSE_RUNNING -> pauseRunningService()
             Constants.ACTION_RESUME_RUNNING -> resumeRunningService()
             Constants.ACTION_STOP_RUNNING -> stopRunningService()
         }
-        return START_NOT_STICKY
     }
 
     @SuppressLint("MissingPermission")
     fun startRunningService() {
         runningServiceState = RunningServiceState.STARTED
         belowThresholdCount = 0  // 시작 시 카운트 초기화
-
         registerSensors()
         setLocationCallback()
         startForeground(Constants.NOTIFICATION_ID, createNotification())
-
         fusedLocationProviderClient.requestLocationUpdates(
             locationRequest, locationCallback, Looper.getMainLooper()
         )
+    }
+
+    private fun pauseRunningService() {
+        runningServiceState = RunningServiceState.PAUSED
+        sendBroadcast(Intent(RunningServiceState.PAUSED.name)) // View로 전달
+    }
+
+    private fun resumeRunningService() {
+        runningServiceState = RunningServiceState.RESUMED
+        isUserPaused = false
+        belowThresholdCount = 0  // 재시작 시 카운트 초기화
+        sendBroadcast(Intent(RunningServiceState.RESUMED.name)) // View로 전달
     }
 
     override fun stopRunningService() {
@@ -68,45 +85,40 @@ class SingleRunningService : BaseRunningService() {
                     isFirstLocationUpdate = false  // 플래그 업데이트
                     return
                 }
-
-                result.lastLocation?.let { location ->
-                    if (lastSensorVelocity <= THRESHOLD) {
-                        belowThresholdCount++
-                        if (shouldPauseService()) {
-                            pauseRunningService()
-                        }
-                        return@let
-                    }
-                    if (runningServiceState == RunningServiceState.PAUSED) {
-                        resumeRunningService()
-                    }
-                    addGpsDataToRecordData(location)
-                }
+                handleLocationResult(result.lastLocation)
             }
         }
     }
 
-    private fun pauseRunningService() {
-        runningServiceState = RunningServiceState.PAUSED
-        sendBroadcast(
-            Intent(RunningServiceState.PAUSED.name)
-        )
-    }
+    private fun handleLocationResult(location: Location?) {
+        location?.let {
+            if (isUserPaused) { // 사용자가 직접 일시정지 한 경우, 위치 업데이트만 수행하고 리턴
+                Timber.tag("유저").e("사용자 일시정지")
+                lastLocation = it
+                return@let
+            }
 
-    private fun resumeRunningService() {
-        runningServiceState = RunningServiceState.RESUMED
-        belowThresholdCount = 0  // 재시작 시 카운트 초기화
-        sendBroadcast(
-            Intent(RunningServiceState.RESUMED.name)
-        )
+            if (lastSensorVelocity <= THRESHOLD) {
+                belowThresholdCount++
+                if (runningServiceState == RunningServiceState.PAUSED) {
+                    Timber.tag("자동").e("자동 일시정지")
+                    lastLocation = it // 일시정지 상태일 때는 마지막 위치만 업데이트
+                    return@let
+                }
+                if (shouldPauseService()) {
+                    pauseRunningService()
+                }
+                return@let
+            }
+            if (runningServiceState == RunningServiceState.PAUSED) {
+                resumeRunningService()
+            }
+            addGpsDataToRecordData(it)
+        }
     }
 
     override fun addGpsDataToRecordData(location: Location) {
-        if (runningServiceState == RunningServiceState.PAUSED) {
-            lastLocation = location // 일시정지 상태일 때는 마지막 위치만 업데이트
-            return
-        }
-
+        Timber.tag("GPS").e("GPS 데이터 수집")
         val gpsData = GpsData(
             latitude = location.latitude,
             longitude = location.longitude,
@@ -116,11 +128,8 @@ class SingleRunningService : BaseRunningService() {
 
         // 이전 위치가 있으면 거리를 계산
         lastLocation?.let {
-            val distance = it.distanceTo(location)  // 거리를 미터 단위로 계산
-            val roundedDistance = distance.roundToInt()  // 소수점을 반올림
-            totalDistance += roundedDistance // 누적 거리에 더함
+            totalDistance += it.distanceTo(location).roundToInt()
         }
-
         lastLocation = location
 
         // Repository에 GPS 데이터 추가

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/service/SingleRunningService.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/service/SingleRunningService.kt
@@ -9,6 +9,7 @@ import com.google.android.gms.location.LocationResult
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import online.partyrun.partyrunapplication.core.common.Constants
+import online.partyrun.partyrunapplication.core.common.Constants.EXTRA_IS_USER_PAUSED
 import online.partyrun.partyrunapplication.core.data.repository.SingleRepository
 import online.partyrun.partyrunapplication.core.model.running.GpsData
 import online.partyrun.partyrunapplication.feature.running.single.RunningServiceState
@@ -30,10 +31,18 @@ class SingleRunningService : BaseRunningService() {
     private var belowThresholdCount: Int = 0  // 임계값 카운트를 통해 일시정지, 재시작을 구현하기 위함
     private var isUserPaused: Boolean = false // 사용자가 직접 일시정지를 누른 것인지 파악
 
+    companion object {
+        private const val PAUSE_THRESHOLD_COUNT = 3
+    }
+
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        isUserPaused = intent?.getBooleanExtra("isUserPaused", false) ?: false
+        extractUserPauseStatusFromIntent(intent)
         handleIntentAction(intent)
         return START_NOT_STICKY
+    }
+
+    private fun extractUserPauseStatusFromIntent(intent: Intent?) {
+        isUserPaused = intent?.getBooleanExtra(EXTRA_IS_USER_PAUSED, false) ?: false
     }
 
     private fun handleIntentAction(intent: Intent?) {
@@ -45,13 +54,21 @@ class SingleRunningService : BaseRunningService() {
         }
     }
 
-    @SuppressLint("MissingPermission")
-    fun startRunningService() {
-        runningServiceState = RunningServiceState.STARTED
-        belowThresholdCount = 0  // 시작 시 카운트 초기화
+    private fun startRunningService() {
+        initializeRunningServiceState()
         registerSensors()
         setLocationCallback()
         startForeground(Constants.NOTIFICATION_ID, createNotification())
+        requestLocationUpdates()
+    }
+
+    private fun initializeRunningServiceState() {
+        runningServiceState = RunningServiceState.STARTED
+        belowThresholdCount = 0  // 시작 시 카운트 초기화
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun requestLocationUpdates() {
         fusedLocationProviderClient.requestLocationUpdates(
             locationRequest, locationCallback, Looper.getMainLooper()
         )
@@ -59,14 +76,14 @@ class SingleRunningService : BaseRunningService() {
 
     private fun pauseRunningService() {
         runningServiceState = RunningServiceState.PAUSED
-        sendBroadcast(Intent(RunningServiceState.PAUSED.name)) // View로 전달
+        broadcastState(RunningServiceState.PAUSED.name)
     }
 
     private fun resumeRunningService() {
         runningServiceState = RunningServiceState.RESUMED
         isUserPaused = false
         belowThresholdCount = 0  // 재시작 시 카운트 초기화
-        sendBroadcast(Intent(RunningServiceState.RESUMED.name)) // View로 전달
+        broadcastState(RunningServiceState.RESUMED.name)
     }
 
     override fun stopRunningService() {
@@ -77,6 +94,10 @@ class SingleRunningService : BaseRunningService() {
         stopSelf()
     }
 
+    private fun broadcastState(stateName: String) { // View로 전달
+        sendBroadcast(Intent(stateName))
+    }
+
     private fun setLocationCallback() {
         locationCallback = object : LocationCallback() {
             override fun onLocationResult(result: LocationResult) {
@@ -85,46 +106,50 @@ class SingleRunningService : BaseRunningService() {
                     isFirstLocationUpdate = false  // 플래그 업데이트
                     return
                 }
-                handleLocationResult(result.lastLocation)
+                processLocationResult(result.lastLocation)
             }
         }
     }
 
-    private fun handleLocationResult(location: Location?) {
+    private fun processLocationResult(location: Location?) {
         location?.let {
-            if (isUserPaused) { // 사용자가 직접 일시정지 한 경우, 위치 업데이트만 수행하고 리턴
-                Timber.tag("유저").e("사용자 일시정지")
-                lastLocation = it
-                return@let
-            }
-
-            if (lastSensorVelocity <= THRESHOLD) {
-                belowThresholdCount++
-                if (runningServiceState == RunningServiceState.PAUSED) {
-                    Timber.tag("자동").e("자동 일시정지")
-                    lastLocation = it // 일시정지 상태일 때는 마지막 위치만 업데이트
-                    return@let
-                }
-                if (shouldPauseService()) {
-                    pauseRunningService()
-                }
-                return@let
-            }
-            if (runningServiceState == RunningServiceState.PAUSED) {
-                resumeRunningService()
-            }
+            if (handleUserPause(it)) return@let
+            if (handleAutomaticPause(it)) return@let
             addGpsDataToRecordData(it)
         }
     }
 
+    private fun handleAutomaticPause(it: Location): Boolean {
+        if (lastSensorVelocity <= THRESHOLD) {
+            belowThresholdCount++
+            if (runningServiceState == RunningServiceState.PAUSED) {
+                Timber.tag("자동").e("자동 일시정지")
+                lastLocation = it // 일시정지 상태일 때는 마지막 위치만 업데이트
+                return true
+            }
+            if (shouldPauseService()) {
+                pauseRunningService()
+            }
+            return true
+        }
+        if (runningServiceState == RunningServiceState.PAUSED) {
+            resumeRunningService()
+        }
+        return false
+    }
+
+    private fun handleUserPause(location: Location): Boolean {
+        if (isUserPaused) { // 사용자가 직접 일시정지 한 경우, 위치 업데이트만 수행하고 리턴
+            Timber.tag("유저").e("사용자 일시정지")
+            lastLocation = location
+            return true
+        }
+        return false
+    }
+
     override fun addGpsDataToRecordData(location: Location) {
         Timber.tag("GPS").e("GPS 데이터 수집")
-        val gpsData = GpsData(
-            latitude = location.latitude,
-            longitude = location.longitude,
-            altitude = location.altitude,
-            time = LocalDateTime.now()
-        )
+        val gpsData = createGpsData(location)
 
         // 이전 위치가 있으면 거리를 계산
         lastLocation?.let {
@@ -133,6 +158,19 @@ class SingleRunningService : BaseRunningService() {
         lastLocation = location
 
         // Repository에 GPS 데이터 추가
+        storeGpsData(gpsData)
+    }
+
+    private fun createGpsData(location: Location): GpsData {
+        return GpsData(
+            latitude = location.latitude,
+            longitude = location.longitude,
+            altitude = location.altitude,
+            time = LocalDateTime.now()
+        )
+    }
+
+    private fun storeGpsData(gpsData: GpsData) {
         serviceScope.launch {
             singleRepository.setDistance(totalDistance)
             singleRepository.addGpsData(gpsData)
@@ -140,6 +178,6 @@ class SingleRunningService : BaseRunningService() {
     }
 
     private fun shouldPauseService(): Boolean {
-        return belowThresholdCount >= 3 && runningServiceState != RunningServiceState.PAUSED
+        return belowThresholdCount >= PAUSE_THRESHOLD_COUNT && runningServiceState != RunningServiceState.PAUSED
     }
 }

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/service/SingleRunningService.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/service/SingleRunningService.kt
@@ -13,7 +13,6 @@ import online.partyrun.partyrunapplication.core.common.Constants.EXTRA_IS_USER_P
 import online.partyrun.partyrunapplication.core.data.repository.SingleRepository
 import online.partyrun.partyrunapplication.core.model.running.GpsData
 import online.partyrun.partyrunapplication.feature.running.single.RunningServiceState
-import timber.log.Timber
 import java.time.LocalDateTime
 import javax.inject.Inject
 import kotlin.math.roundToInt
@@ -123,7 +122,6 @@ class SingleRunningService : BaseRunningService() {
         if (lastSensorVelocity <= THRESHOLD) {
             belowThresholdCount++
             if (runningServiceState == RunningServiceState.PAUSED) {
-                Timber.tag("자동").e("자동 일시정지")
                 lastLocation = it // 일시정지 상태일 때는 마지막 위치만 업데이트
                 return true
             }
@@ -140,7 +138,6 @@ class SingleRunningService : BaseRunningService() {
 
     private fun handleUserPause(location: Location): Boolean {
         if (isUserPaused) { // 사용자가 직접 일시정지 한 경우, 위치 업데이트만 수행하고 리턴
-            Timber.tag("유저").e("사용자 일시정지")
             lastLocation = location
             return true
         }
@@ -148,7 +145,6 @@ class SingleRunningService : BaseRunningService() {
     }
 
     override fun addGpsDataToRecordData(location: Location) {
-        Timber.tag("GPS").e("GPS 데이터 수집")
         val gpsData = createGpsData(location)
 
         // 이전 위치가 있으면 거리를 계산

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentScreen.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentScreen.kt
@@ -23,6 +23,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.delay
 import online.partyrun.partyrunapplication.core.common.Constants
+import online.partyrun.partyrunapplication.core.common.Constants.EXTRA_IS_USER_PAUSED
 import online.partyrun.partyrunapplication.core.ui.CountdownDialog
 import online.partyrun.partyrunapplication.feature.running.finish.FinishScreen
 import online.partyrun.partyrunapplication.feature.running.ready.SingleReadyScreen
@@ -155,7 +156,7 @@ private fun StartRunningService(
             Constants.ACTION_PAUSE_RUNNING,
             receiver,
             context,
-            singleContentUiState.isUserPaused
+            isUserPaused = singleContentUiState.isUserPaused
         )
 
         RunningServiceState.RESUMED -> ControlRunningService(
@@ -188,7 +189,7 @@ private fun ControlRunningService(
         }
         val intent = createServiceIntent(context, action)
         if (isUserPaused) {
-            intent.putExtra("isUserPaused", true)
+            intent.putExtra(EXTRA_IS_USER_PAUSED, true)
         }
 
         context.startService(intent)

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentUiState.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentUiState.kt
@@ -13,6 +13,8 @@ data class SingleContentUiState(
     val selectedDistance: Int = 0,
     // 사용자가 선택한 목표 시간
     val selectedTime: Int = 0,
+    // 사용자가 직접 일시정지를 누른 것인지를 확인하기 위함
+    val isUserPaused: Boolean = false,
     // 러닝 서비스 상태 추적
     val runningServiceState: RunningServiceState = RunningServiceState.PAUSED,
     // 현재 보여줘야 할 스크린

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentViewModel.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentViewModel.kt
@@ -84,9 +84,12 @@ class SingleContentViewModel @Inject constructor(
         }
     }
 
-    fun pauseSingleRunningService() {
+    fun pauseSingleRunningService(isUserPaused: Boolean) {
         _singleContentUiState.update { state ->
-            state.copy(runningServiceState = RunningServiceState.PAUSED)
+            state.copy(
+                runningServiceState = RunningServiceState.PAUSED,
+                isUserPaused = isUserPaused // 사용자가 일시정지를 직접 누른 것인지 판단
+            )
         }
     }
 
@@ -98,7 +101,10 @@ class SingleContentViewModel @Inject constructor(
 
     fun resumeSingleRunningService() {
         _singleContentUiState.update { state ->
-            state.copy(runningServiceState = RunningServiceState.RESUMED)
+            state.copy(
+                runningServiceState = RunningServiceState.RESUMED,
+                isUserPaused = false // 재시작일 때는 사용자가 직접 누른 것이든, 디바이스 움직임 재시작이든지 상관없이 false로 고정
+            )
         }
     }
 


### PR DESCRIPTION
## Description
사용자가 계속 뛰다가 잠깐 멈춰서 일시정지 된거는 다시 뛰었을 떄 자동으로 재시작되도록 해주는게 맞지만,
사용자가 직접 일시정지를 눌렀을 때는 사용자에게 선택권을 주어야 하기에 자동으로 재시작되도록 해주면 안된다.
따라서, 사용자가 직접 누른 경우와 자동으로 감지하여 일시정지한 경우를 구분할 수 있도록 일부 변경을 수행한다.
->
사용자가 일시정지를 누른 경우는 디바이스의 움직임이 감지되어도 재시작이 되지 않도록 한다.

* 사용자 디바이스의 움직임이 없을 때는 GPS 데이터를 수집하지 않는다. -> 무의미한 데이터라 판단
* 사용자 디바이스의 움직임이 일정 카운트동안 없으면 "자동 일시정지"
* "자동 일시정지" 상태에서 사용자 디바이스의 움직임이 감지되면 "자동 재시작"
* 사용자가 직접 일시정지를 누른 경우 -> "사용자 일시정지"
* "사용자 일시정지" 상태에서는 디바이스 움직임이 감지되어도 "자동 재시작" 되지 않고 사용자가 직접 재시작을 눌러야지만 프로세스 재개

## Implementation

https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/252b9645-0a1b-4fe3-afda-7af6a4f83e9f
1. 사용자 움직임 감지
2. 사용자 움직임이 없을 땐 GPS 데이터 수집 중단
3. 일정 카운트동안 움직임이 없으면 "자동 일시정지"로 전환 (마우스 움직임 == 실제 디바이스 기기의 움직임 표현)
4. 사용자 움직임이 포착되면 "자동 재시작"
5. 사용자가 직접 일시정지를 누를 경우 -> 디바이스 움직임이 감지되어도 일시정지 상태 유지
6. 직접 사용자가 재시작을 눌렀을 때 데이터 수집 재시작
