### PR TITLE
#PAR-346 : 싱글모드 종료 시 일정 거리 이상 달리지 않았으면 결과 조회를 하지 않는다.

### DIFF
--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentScreen.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentScreen.kt
@@ -25,11 +25,14 @@ import kotlinx.coroutines.delay
 import online.partyrun.partyrunapplication.core.common.Constants
 import online.partyrun.partyrunapplication.core.common.Constants.EXTRA_IS_USER_PAUSED
 import online.partyrun.partyrunapplication.core.ui.CountdownDialog
+import online.partyrun.partyrunapplication.feature.running.R
 import online.partyrun.partyrunapplication.feature.running.finish.FinishScreen
 import online.partyrun.partyrunapplication.feature.running.ready.SingleReadyScreen
 import online.partyrun.partyrunapplication.feature.running.running.SingleRunningScreen
 import online.partyrun.partyrunapplication.feature.running.running.component.RunningExitConfirmationDialog
 import online.partyrun.partyrunapplication.feature.running.service.SingleRunningService
+
+const val MINIMUM_FINISH_DISTANCE = 100
 
 @Composable
 fun SingleContentScreen(
@@ -93,6 +96,7 @@ fun Content(
     RunningBackNavigationHandler(
         activity = activity,
         singleContentViewModel = singleContentViewModel,
+        singleContentUiState = singleContentUiState,
         openRunningExitDialog = openRunningExitDialog
     )
 
@@ -250,6 +254,7 @@ private fun unregisterReceiverAndStopService(
 fun RunningBackNavigationHandler(
     activity: Activity?,
     singleContentViewModel: SingleContentViewModel,
+    singleContentUiState: SingleContentUiState,
     openRunningExitDialog: MutableState<Boolean>
 ) {
     val onBackPressedDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
@@ -273,7 +278,35 @@ fun RunningBackNavigationHandler(
     RunningExitConfirmationDialog(
         openRunningExitDialog = openRunningExitDialog,
     ) {
+        handleRunningExit(
+            activity = activity,
+            distanceInMeter = singleContentUiState.distanceInMeter,
+            singleContentViewModel = singleContentViewModel,
+            minimumFinishDistance = MINIMUM_FINISH_DISTANCE
+        )
+    }
+}
+
+fun handleRunningExit(
+    activity: Activity?,
+    distanceInMeter: Int,
+    singleContentViewModel: SingleContentViewModel,
+    minimumFinishDistance: Int
+) {
+    if (distanceInMeter < minimumFinishDistance) { // 일정 거리를 못넘기면 저장하지 않는 GPS 데이터
         singleContentViewModel.stopSingleRunningService()
-        singleContentViewModel.stopRunningProcess()
+        restartActivity(activity)
+    } else {
+        singleContentViewModel.finishRunningProcess()
+    }
+}
+
+fun restartActivity(activity: Activity?) {
+    activity?.let {
+        val intent = it.intent
+        it.startActivity(intent)
+        it.overridePendingTransition(R.anim.slide_in_right, R.anim.slide_out_left)
+        it.finish()
+        it.overridePendingTransition(R.anim.slide_in_left, R.anim.slide_out_right)
     }
 }

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentUiState.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentUiState.kt
@@ -22,6 +22,7 @@ data class SingleContentUiState(
     // 유저 이름
     val userName: String = "",
     // 이동 거리
+    val distanceInMeter: Int = 0,
     val distanceInKm: String = "0.00",
     // 경과 시간
     val elapsedSecondsTime: Int = 0,

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentViewModel.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentViewModel.kt
@@ -117,7 +117,7 @@ class SingleContentViewModel @Inject constructor(
         }
     }
 
-    fun stopRunningProcess() {
+    fun finishRunningProcess() {
         stopSingleRunningService()
         stopRunningState()
     }
@@ -185,6 +185,7 @@ class SingleContentViewModel @Inject constructor(
                 _singleContentUiState.update { state ->
                     state.copy(
                         userStatus = updatedUser,
+                        distanceInMeter = totalDistance,
                         distanceInKm = formattedDistance
                     )
                 }


### PR DESCRIPTION
## Description
기존 유사 러닝앱은 10미터 이상만 달리면 데이터를 저장하고 있다.
그러나, 10미터와 같은 적은 거리의 데이터를 저장할 필요성을 못느끼기에,
최소 100미터 이상 달린 데이터들만 저장하고 결과 조회를 할 수 있도록 기능을 추가한다.