### PR TITLE
refactor : startSingleRunningService 수행 카운트다운 변경

### DIFF
--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentViewModel.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentViewModel.kt
@@ -70,7 +70,7 @@ class SingleContentViewModel @Inject constructor(
     }
 
     private fun updateCountdownState(timeRemaining: Int) {
-        if (timeRemaining == 3) { // 3초가 남았을 때 러닝 서비스 시작
+        if (timeRemaining == 5) { // 카운트다운 시작 시 러닝 서비스 활성화
             startSingleRunningService()
         }
         _singleContentUiState.update { state ->


### PR DESCRIPTION
## Description
기존 SingleRunningService는 카운트다운이 3초가 될 때 활성화되었다. (최초 1회 GPS 데이터만 무시하기 위해)
그러나, 지금은 2번째 GPS Data를 LastLocation으로 넣는 로직이 추가로 들어가기에 유의미한 거리비교가 수행되기 위해서는 더 빠른 시간에 RunningService가 활성화 되어야 한다.

최초 1회 GPS data는 이전에 찍힌 가장 최신 GPS data가 찍히므로 무시 (멀리 찍힌 데이터가 찍힐 수도 있음)
최초 1회 GPS data가 찍힌 이후 약 3초 후에 현재 위치가 반영이 보장된 유효한 GPS data가 찍힘
2번째 GPS data는 LastLocation을 업데이트하므로 사실상 카운트다운 시작 시에 RunningService를 활성화시키면
카운트다운이 끝나자마자 유의미한 거리비교가 가능
