### PR TITLE
#PAR-327 : 프로필 사진 수정 기능 추가 / API 연동 

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -41,12 +41,12 @@ jobs:
         BASE_URL: ${{ secrets.BASE_URL }}
         FIREBASE_GOOGLE_CLIENT_ID: ${{ secrets.FIREBASE_GOOGLE_CLIENT_ID }}
         MAPS_API_KEY: ${{ secrets.MAPS_API_KEY }}
-        S3_URL: ${{ secrets.S3_URL }}
+        PARTY_RUN_S3_URL: ${{ secrets.S3_URL }}
       run: |
         echo BASE_URL=\"$BASE_URL\" >> ./local.properties
         echo FIREBASE_GOOGLE_CLIENT_ID=\"$FIREBASE_GOOGLE_CLIENT_ID\" >> ./local.properties
         echo MAPS_API_KEY=\"$MAPS_API_KEY\" >> ./local.properties
-        echo S3_URL=\"S3_URL\" >> ./local.properties
+        echo PARTY_RUN_S3_URL=\"PARTY_RUN_S3_URL\" >> ./local.properties
 
     - name: Create google-services.json
       env:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -41,10 +41,12 @@ jobs:
         BASE_URL: ${{ secrets.BASE_URL }}
         FIREBASE_GOOGLE_CLIENT_ID: ${{ secrets.FIREBASE_GOOGLE_CLIENT_ID }}
         MAPS_API_KEY: ${{ secrets.MAPS_API_KEY }}
+        S3_URL: ${{ secrets.S3_URL }}
       run: |
         echo BASE_URL=\"$BASE_URL\" >> ./local.properties
         echo FIREBASE_GOOGLE_CLIENT_ID=\"$FIREBASE_GOOGLE_CLIENT_ID\" >> ./local.properties
         echo MAPS_API_KEY=\"$MAPS_API_KEY\" >> ./local.properties
+        echo S3_URL=\"S3_URL\" >> ./local.properties
 
     - name: Create google-services.json
       env:

--- a/core/common/src/main/java/online/partyrun/partyrunapplication/core/common/Constants.kt
+++ b/core/common/src/main/java/online/partyrun/partyrunapplication/core/common/Constants.kt
@@ -5,6 +5,7 @@ object Constants {
 
     // App 모듈의 Build.gradle.kts -> BuildType에 따른 BASE_URL 분기 처리
     const val BASE_URL = BuildConfig.BASE_URL
+    const val S3_URL = BuildConfig.PARTY_RUN_S3_URL
 
     const val NOTIFICATION_CHANNEL_ID = "Running_notification_id"
     const val NOTIFICATION_CHANNEL_NAME = "Running_location_updates"

--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/MemberRepository.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/MemberRepository.kt
@@ -1,6 +1,7 @@
 package online.partyrun.partyrunapplication.core.data.repository
 
 import kotlinx.coroutines.flow.Flow
+import okhttp3.RequestBody
 import online.partyrun.partyrunapplication.core.common.result.Result
 import online.partyrun.partyrunapplication.core.model.match.RunnerIds
 import online.partyrun.partyrunapplication.core.model.match.RunnerInfoData
@@ -24,4 +25,6 @@ interface MemberRepository {
     suspend fun setUserId(userId: String)
 
     suspend fun updateUserData(userData: User): Flow<Result<Unit>>
+
+    suspend fun updateProfileImage(requestBody: RequestBody, fileName: String?): Flow<Result<Unit>>
 }

--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/MemberRepositoryImpl.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/MemberRepositoryImpl.kt
@@ -1,6 +1,8 @@
 package online.partyrun.partyrunapplication.core.data.repository
 
 import kotlinx.coroutines.flow.Flow
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
 import online.partyrun.partyrunapplication.core.common.network.apiRequestFlow
 import online.partyrun.partyrunapplication.core.datastore.datasource.UserPreferencesDataSource
 import online.partyrun.partyrunapplication.core.model.match.RunnerIds
@@ -54,4 +56,24 @@ class MemberRepositoryImpl @Inject constructor(
         return apiRequestFlow { memberDataSource.updateUserData(userData.toRequestModel()) }
     }
 
+    override suspend fun updateProfileImage(
+        requestBody: RequestBody,
+        fileName: String?
+    ): Flow<Result<Unit>> {
+        return apiRequestFlow {
+            memberDataSource.updateProfileImage(
+                createMultipartBodyPart(
+                    fileName,
+                    requestBody
+                )
+            )
+        }
+    }
+
+    private fun createMultipartBodyPart(
+        fileName: String?,
+        requestBody: RequestBody
+    ): MultipartBody.Part {
+        return MultipartBody.Part.createFormData("profile", fileName, requestBody)
+    }
 }

--- a/core/datastore/src/main/java/online/partyrun/partyrunapplication/core/datastore/datasource/UserPreferencesDataSource.kt
+++ b/core/datastore/src/main/java/online/partyrun/partyrunapplication/core/datastore/datasource/UserPreferencesDataSource.kt
@@ -14,8 +14,8 @@ class UserPreferencesDataSource @Inject constructor(
         .map { preferences ->
             User(
                 id = preferences.id,
-                name = preferences.name,
-                profile = preferences.profile
+                nickName = preferences.name,
+                profileImage = preferences.profile
             )
         }
 

--- a/core/designsystem/src/main/java/online/partyrun/partyrunapplication/core/designsystem/icon/PartyRunIcons.kt
+++ b/core/designsystem/src/main/java/online/partyrun/partyrunapplication/core/designsystem/icon/PartyRunIcons.kt
@@ -35,6 +35,7 @@ object PartyRunIcons {
     val Step = R.drawable.ic_outline_step
     val Pace = R.drawable.ic_outline_pace
     val Schedule = R.drawable.ic_outline_schedule
+    val AddCircleFiled = R.drawable.ic_add_circle_filed_24
     val CheckCircleFilled = R.drawable.ic_round_check_circle_24
     val PauseCircleFilled = R.drawable.ic_round_pause_circle_filled_24
     val PlayCircleFilled = R.drawable.ic_round_play_circle_filled_24

--- a/core/designsystem/src/main/res/drawable/ic_add_circle_filed_24.xml
+++ b/core/designsystem/src/main/res/drawable/ic_add_circle_filed_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM17,13h-4v4h-2v-4L7,13v-2h4L11,7h2v4h4v2z"/>
+</vector>

--- a/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/member/SaveUserDataUseCase.kt
+++ b/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/member/SaveUserDataUseCase.kt
@@ -9,7 +9,7 @@ class SaveUserDataUseCase @Inject constructor(
 ) {
     suspend operator fun invoke(userData: User) {
         memberRepository.setUserId(userData.id)
-        memberRepository.setUserName(userData.name)
-        memberRepository.setUserProfile(userData.profile)
+        memberRepository.setUserName(userData.nickName)
+        memberRepository.setUserProfile(userData.profileImage)
     }
 }

--- a/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/member/UpdateProfileImageUseCase.kt
+++ b/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/member/UpdateProfileImageUseCase.kt
@@ -1,0 +1,16 @@
+package online.partyrun.partyrunapplication.core.domain.member
+
+import kotlinx.coroutines.flow.Flow
+import okhttp3.RequestBody
+import online.partyrun.partyrunapplication.core.common.result.Result
+import online.partyrun.partyrunapplication.core.data.repository.MemberRepository
+import javax.inject.Inject
+
+class UpdateProfileImageUseCase @Inject constructor(
+    private val memberRepository: MemberRepository
+) {
+    suspend operator fun invoke(requestBody: RequestBody, fileName: String?): Flow<Result<Unit>> {
+        return memberRepository.updateProfileImage(requestBody, fileName)
+    }
+
+}

--- a/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/member/UpdateUserDataUseCase.kt
+++ b/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/member/UpdateUserDataUseCase.kt
@@ -10,15 +10,16 @@ import javax.inject.Inject
 class UpdateUserDataUseCase @Inject constructor(
     private val memberRepository: MemberRepository
 ) {
-    suspend operator fun invoke(name: String): Flow<Result<Unit>> {
+    suspend operator fun invoke(nickName: String): Flow<Result<Unit>> {
         val currentUserData = memberRepository.userData.first()
 
         return memberRepository.updateUserData(
             User(
                 id = currentUserData.id,
-                name = name,
-                profile = currentUserData.profile
+                nickName = nickName,
+                profileImage = currentUserData.profileImage
             )
         )
     }
+
 }

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/user/User.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/user/User.kt
@@ -2,6 +2,6 @@ package online.partyrun.partyrunapplication.core.model.user
 
 data class User(
     val id: String,
-    val name: String,
-    val profile: String
+    val nickName: String,
+    val profileImage: String
 )

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/MemberDataSource.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/MemberDataSource.kt
@@ -1,5 +1,6 @@
 package online.partyrun.partyrunapplication.core.network.datasource
 
+import okhttp3.MultipartBody
 import online.partyrun.partyrunapplication.core.common.network.ApiResponse
 import online.partyrun.partyrunapplication.core.network.model.request.UserDataRequest
 import online.partyrun.partyrunapplication.core.network.model.response.BattleMembersInfoResponse
@@ -11,5 +12,5 @@ interface MemberDataSource {
     suspend fun getRunnersInfo(runnerIds: List<String>): ApiResponse<BattleMembersInfoResponse>
     suspend fun deleteAccount(): ApiResponse<DeleteAccountResponse>
     suspend fun updateUserData(userData: UserDataRequest): ApiResponse<Unit>
+    suspend fun updateProfileImage(image: MultipartBody.Part): ApiResponse<Unit>
 }
-

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/MemberDataSourceImpl.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/MemberDataSourceImpl.kt
@@ -1,5 +1,6 @@
 package online.partyrun.partyrunapplication.core.network.datasource
 
+import okhttp3.MultipartBody
 import online.partyrun.partyrunapplication.core.common.network.ApiResponse
 import online.partyrun.partyrunapplication.core.network.model.request.UserDataRequest
 import online.partyrun.partyrunapplication.core.network.model.response.BattleMembersInfoResponse
@@ -22,5 +23,8 @@ class MemberDataSourceImpl @Inject constructor(
 
     override suspend fun updateUserData(userData: UserDataRequest): ApiResponse<Unit> =
         memberApi.updateUserData(userData)
+
+    override suspend fun updateProfileImage(image: MultipartBody.Part): ApiResponse<Unit> =
+        memberApi.updateProfileImage(image)
 
 }

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/request/UserDataRequest.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/request/UserDataRequest.kt
@@ -8,6 +8,6 @@ data class UserDataRequest(
 
 fun User.toRequestModel(): UserDataRequest {
     return UserDataRequest(
-        name = this.name
+        name = this.nickName
     )
 }

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/UserResponse.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/UserResponse.kt
@@ -1,6 +1,7 @@
 package online.partyrun.partyrunapplication.core.network.model.response
 
 import com.google.gson.annotations.SerializedName
+import online.partyrun.partyrunapplication.core.common.Constants.S3_URL
 import online.partyrun.partyrunapplication.core.model.user.User
 
 data class UserResponse(
@@ -15,5 +16,5 @@ data class UserResponse(
 fun UserResponse.toDomainModel() = User(
     id = this.userId ?: "",
     name = this.userName ?: "",
-    profile = this.userProfile ?: ""
+    profile = S3_URL.plus(this.userProfile)
 )

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/UserResponse.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/UserResponse.kt
@@ -8,13 +8,13 @@ data class UserResponse(
     @SerializedName("id")
     val userId: String?,
     @SerializedName("name")
-    val userName: String?,
+    val nickName: String?,
     @SerializedName("profile")
-    val userProfile: String?,
+    val profileImage: String?,
 )
 
 fun UserResponse.toDomainModel() = User(
     id = this.userId ?: "",
-    name = this.userName ?: "",
-    profile = S3_URL.plus(this.userProfile)
+    nickName = this.nickName ?: "",
+    profileImage = S3_URL.plus(this.profileImage)
 )

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/service/MemberApiService.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/service/MemberApiService.kt
@@ -1,5 +1,6 @@
 package online.partyrun.partyrunapplication.core.network.service
 
+import okhttp3.MultipartBody
 import online.partyrun.partyrunapplication.core.common.network.ApiResponse
 import online.partyrun.partyrunapplication.core.network.model.request.UserDataRequest
 import online.partyrun.partyrunapplication.core.network.model.response.BattleMembersInfoResponse
@@ -8,7 +9,9 @@ import online.partyrun.partyrunapplication.core.network.model.response.UserRespo
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.Multipart
 import retrofit2.http.PATCH
+import retrofit2.http.Part
 import retrofit2.http.Query
 
 interface MemberApiService {
@@ -23,4 +26,11 @@ interface MemberApiService {
 
     @PATCH("/api/members/name")
     suspend fun updateUserData(@Body userData: UserDataRequest): ApiResponse<Unit>
+
+    @Multipart
+    @PATCH("/api/members/profile")
+    suspend fun updateProfileImage(
+        @Part image: MultipartBody.Part
+    ): ApiResponse<Unit>
+
 }

--- a/core/testing/src/main/java/online/partyrun/partyrunapplication/core/testing/repository/TestMemberRepository.kt
+++ b/core/testing/src/main/java/online/partyrun/partyrunapplication/core/testing/repository/TestMemberRepository.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flowOf
+import okhttp3.RequestBody
 import online.partyrun.partyrunapplication.core.common.result.Result
 import online.partyrun.partyrunapplication.core.data.repository.MemberRepository
 import online.partyrun.partyrunapplication.core.model.match.RunnerIds
@@ -19,7 +20,7 @@ class TestMemberRepository : MemberRepository {
     private var userProfile: String? = null
 
     override val userData: Flow<User>
-        get() = flowOf(User(id = userId ?: "", name = userName ?: "", profile = userProfile ?: ""))
+        get() = flowOf(User(id = userId ?: "", nickName = userName ?: "", profileImage = userProfile ?: ""))
 
     override suspend fun getRunnersInfo(runnerIds: RunnerIds): Flow<Result<RunnerInfoData>> {
         TODO("Not yet implemented")
@@ -45,4 +46,12 @@ class TestMemberRepository : MemberRepository {
     override suspend fun updateUserData(userData: User): Flow<Result<Unit>> {
         TODO("Not yet implemented")
     }
+
+    override suspend fun updateProfileImage(
+        requestBody: RequestBody,
+        fileName: String?
+    ): Flow<Result<Unit>> {
+        TODO("Not yet implemented")
+    }
+
 }

--- a/feature/my_page/build.gradle.kts
+++ b/feature/my_page/build.gradle.kts
@@ -11,6 +11,8 @@ android {
 
 dependencies {
     // Timber
-    implementation (libs.timber)
+    implementation(libs.timber)
 
+    //For PickVisualMedia contract
+    implementation(libs.androidx.activity.ktx)
 }

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageScreen.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageScreen.kt
@@ -180,8 +180,8 @@ private fun MyPageBody(
         ) {
             ProfileContent(
                 navigateToProfile = navigateToProfile,
-                userName = userData.name,
-                userProfile = userData.profile
+                userName = userData.nickName,
+                userProfile = userData.profileImage
             )
         }
 

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageScreen.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageScreen.kt
@@ -1,5 +1,6 @@
 package online.partyrun.partyrunapplication.feature.my_page
 
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -264,9 +265,11 @@ private fun ProfileImage(
             .size(80.dp)
             .aspectRatio(1f, matchHeightConstraintsFirst = true)
             .clip(CircleShape)
+            .border(3.dp, MaterialTheme.colorScheme.onPrimary, CircleShape)
             .zIndex(1f)
     ) {
         RenderAsyncUrlImage(
+            modifier = Modifier.fillMaxSize(),
             imageUrl = userProfile,
             contentDescription = null
         )

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageUiState.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageUiState.kt
@@ -8,8 +8,8 @@ sealed class MyPageUiState {
     data class Success(
         val user: User = User(
             id = "",
-            name = "",
-            profile = ""
+            nickName = "",
+            profileImage = ""
         )
     ) : MyPageUiState()
 

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/profile/ProfileScreen.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/profile/ProfileScreen.kt
@@ -61,7 +61,6 @@ import online.partyrun.partyrunapplication.feature.my_page.MyPageUiState
 import online.partyrun.partyrunapplication.feature.my_page.MyPageViewModel
 import online.partyrun.partyrunapplication.feature.my_page.R
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun ProfileScreen(
     myPageViewModel: MyPageViewModel = hiltViewModel(),
@@ -72,8 +71,6 @@ fun ProfileScreen(
     val context = LocalContext.current
     val myPageUiState by myPageViewModel.myPageUiState.collectAsStateWithLifecycle()
     val profileUiState by profileViewModel.profileUiState.collectAsStateWithLifecycle()
-    val keyboardController = LocalSoftwareKeyboardController.current
-    val focusManager = LocalFocusManager.current
     val profileSnackbarMessage by profileViewModel.snackbarMessage.collectAsStateWithLifecycle()
     val photoPickerLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
@@ -84,7 +81,6 @@ fun ProfileScreen(
         profileViewModel = profileViewModel,
         myPageUiState = myPageUiState,
         profileUiState = profileUiState,
-        keyboardController = keyboardController,
         photoPicker = {
             photoPickerLauncher.launch(
                 PickVisualMediaRequest(
@@ -92,7 +88,6 @@ fun ProfileScreen(
                 )
             )
         },
-        focusManager = focusManager,
         navigateToMyPage = navigateToMyPage,
         onShowSnackbar = onShowSnackbar,
         profileSnackbarMessage = profileSnackbarMessage
@@ -106,13 +101,14 @@ fun Content(
     profileViewModel: ProfileViewModel,
     myPageUiState: MyPageUiState,
     profileUiState: ProfileUiState,
-    keyboardController: SoftwareKeyboardController? = null,
     photoPicker: () -> Unit,
-    focusManager: FocusManager,
     navigateToMyPage: () -> Unit,
     onShowSnackbar: (String) -> Unit,
     profileSnackbarMessage: String
 ) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+    val focusManager = LocalFocusManager.current
+
     LaunchedEffect(profileSnackbarMessage) {
         if (profileSnackbarMessage.isNotEmpty()) {
             onShowSnackbar(profileSnackbarMessage)

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/profile/ProfileUiState.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/profile/ProfileUiState.kt
@@ -2,6 +2,8 @@ package online.partyrun.partyrunapplication.feature.my_page.profile
 
 data class ProfileUiState(
     val nickName: String = "",
+    val profileImage: String = "",
+    val newNickName: String = "",
     val nickNameError: Boolean = false,
     val nickNameSupportingText: String = "",
     val isProfileUpdateSuccess: Boolean = false

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentViewModel.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentViewModel.kt
@@ -156,8 +156,8 @@ class SingleContentViewModel @Inject constructor(
         viewModelScope.launch {
             val userData = getMyPageDataUseCase()
             val userStatus = SingleRunnerDisplayStatus(
-                runnerName = userData.name,
-                runnerProfile = ProfileImageSource.Url(userData.profile) // 서버에서 관리하는 사용자 프로필 이미지 URL
+                runnerName = userData.nickName,
+                runnerProfile = ProfileImageSource.Url(userData.profileImage) // 서버에서 관리하는 사용자 프로필 이미지 URL
             )
             val robotStatus = SingleRunnerDisplayStatus(
                 runnerName = "파티런 봇",
@@ -166,7 +166,7 @@ class SingleContentViewModel @Inject constructor(
 
             _singleContentUiState.update { state ->
                 state.copy(
-                    userName = userData.name,
+                    userName = userData.nickName,
                     userStatus = userStatus,
                     robotStatus = robotStatus
                 )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,6 +69,7 @@ androidx-compose-foundation = { group = "androidx.compose.foundation", name = "f
 androidx-compose-foundation-layout = { group = "androidx.compose.foundation", name = "foundation-layout" }
 androidx-compose-runtime = { group = "androidx.compose.runtime", name = "runtime" }
 android-desugarJdkLibs = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "androidDesugarJdkLibs" }
+androidx-activity-ktx = { group = "androidx.activity", name = "activity-ktx", version.ref = "androidxActivity" }
 
 # compose
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidxActivity" }


### PR DESCRIPTION
## Description
사용자 프로필 이미지 수정 기능을 추가한다.
Multipart를 통해 이미지를 업로드한다.

1. Multipart 형식은 여러 종류의 데이터를 함께 전송할 수 있는 유연한 방법 제공
2. 효율적인 파일 업로드: 이미지 파일과 같은 이진 데이터를 효율적으로 전송. Multipart 요청은 파일 데이터를 분할하여 전송하므로 대용량 파일의 업로드 관리 이점
3. 서버 호환성: 대부분의 서버 및 백엔드 API는 Multipart 형식 지원. 이미지 업로드에 대한 서버 호환성 확보
4. 메타 데이터
5. 보안, 서버 처리 용이성

## Implementation
