### PR TITLE
 #PAR-355 : 회원탈퇴 시 약관동의부터 다시 받도록 보장

### DIFF
--- a/feature/settings/src/main/java/online/partyrun/partyrunapplication/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/online/partyrun/partyrunapplication/feature/settings/SettingsViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import online.partyrun.partyrunapplication.core.common.result.onFailure
 import online.partyrun.partyrunapplication.core.common.result.onSuccess
+import online.partyrun.partyrunapplication.core.domain.agreement.SaveAgreementStateUseCase
 import online.partyrun.partyrunapplication.core.domain.auth.GoogleSignOutUseCase
 import online.partyrun.partyrunapplication.core.domain.member.DeleteAccountUseCase
 import timber.log.Timber
@@ -17,8 +18,8 @@ import javax.inject.Inject
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
     private val deleteAccountUseCase: DeleteAccountUseCase,
-    private val googleSignOutUseCase: GoogleSignOutUseCase
-
+    private val googleSignOutUseCase: GoogleSignOutUseCase,
+    private val saveAgreementStateUseCase: SaveAgreementStateUseCase
 ) : ViewModel() {
     private val _settingsUiState = MutableStateFlow(SettingsUiState())
     val settingsUiState: StateFlow<SettingsUiState> = _settingsUiState
@@ -33,16 +34,20 @@ class SettingsViewModel @Inject constructor(
     fun deleteAccount() = viewModelScope.launch {
         deleteAccountUseCase().collect { result ->
             result.onSuccess {
+                googleSignOutUseCase()
                 _settingsUiState.update { state ->
                     state.copy(
                         isAccountDeletionSuccess = true,
                     )
                 }
-                googleSignOutUseCase()
             }.onFailure { errorMessage, code ->
                 Timber.e("$code $errorMessage")
             }
         }
+    }
+
+    fun saveAgreementState(isChecked: Boolean) = viewModelScope.launch {
+        saveAgreementStateUseCase(isChecked)
     }
 
 }

--- a/feature/settings/src/main/java/online/partyrun/partyrunapplication/feature/settings/UnsubscribeScreen.kt
+++ b/feature/settings/src/main/java/online/partyrun/partyrunapplication/feature/settings/UnsubscribeScreen.kt
@@ -155,6 +155,7 @@ private fun ConfirmButton(
 ) {
     PartyRunGradientButton(
         onClick = {
+            settingsViewModel.saveAgreementState(isChecked = false)
             settingsViewModel.deleteAccount()
         },
         modifier = Modifier


### PR DESCRIPTION
## Description
회원탈퇴를 진행할 때 딜레이 문제가 발생할 경우,
회원탈퇴 Confirm이 됐음에도 약관동의 스크린부터 시작한 로그인 프로세스를 진행하지 않고
앱 메인 스크린에서 다시 시작되는 문제 발생
->
약관동의 Boolean 값 처리를 위한 UseCase를 SettingViewModel에서 함께 처리할 수 있도록 수정