### PR TITLE
refactor : 인앱 업데이트를 MainActivity에서 수행하도록 변경

### DIFF
--- a/app/src/main/java/online/partyrun/partyrunapplication/AuthActivity.kt
+++ b/app/src/main/java/online/partyrun/partyrunapplication/AuthActivity.kt
@@ -2,26 +2,11 @@ package online.partyrun.partyrunapplication
 
 import android.content.Intent
 import android.os.Bundle
-import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
-import androidx.lifecycle.lifecycleScope
-import com.google.android.play.core.appupdate.AppUpdateManager
-import com.google.android.play.core.appupdate.AppUpdateManagerFactory
-import com.google.android.play.core.appupdate.AppUpdateOptions
-import com.google.android.play.core.install.InstallStateUpdatedListener
-import com.google.android.play.core.install.model.ActivityResult
-import com.google.android.play.core.install.model.AppUpdateType
-import com.google.android.play.core.install.model.InstallStatus
-import com.google.android.play.core.install.model.UpdateAvailability
-import com.google.android.play.core.ktx.isFlexibleUpdateAllowed
-import com.google.android.play.core.ktx.isImmediateUpdateAllowed
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import online.partyrun.partyrunapplication.core.common.extension.setIntentActivity
 import online.partyrun.partyrunapplication.core.designsystem.theme.PartyRunApplicationTheme
 import online.partyrun.partyrunapplication.ui.PartyRunAuth
@@ -29,21 +14,9 @@ import online.partyrun.partyrunapplication.ui.PartyRunAuth
 @AndroidEntryPoint
 class AuthActivity : ComponentActivity() {
 
-    private lateinit var appUpdateManager: AppUpdateManager
-
-    // 업데이트 타입 변경 가능 -> 현재 FLEXIBLE
-    private val updateType = AppUpdateType.FLEXIBLE
-
     override fun onCreate(savedInstanceState: Bundle?) {
         // Splash Screen API
         installSplashScreen()
-
-        // 최신 업데이트 정보 확인
-        appUpdateManager = AppUpdateManagerFactory.create(applicationContext)
-        if (updateType == AppUpdateType.FLEXIBLE) {
-            appUpdateManager.registerListener(installStateUpdatedListener)
-        }
-        checkForAppUpdates()
 
         super.onCreate(savedInstanceState)
         setContent {
@@ -68,83 +41,6 @@ class AuthActivity : ComponentActivity() {
         )
         overridePendingTransition(R.anim.slide_in_right, R.anim.slide_out_left) // 화면 전환 애니메이션
         finish()
-    }
-
-    private val activityResultLauncher =
-        registerForActivityResult(ActivityResultContracts.StartIntentSenderForResult()) { result ->
-            when (result.resultCode) {
-                ActivityResult.RESULT_IN_APP_UPDATE_FAILED ->
-                    Toast.makeText(
-                        applicationContext,
-                        applicationContext.getString(R.string.result_in_app_update_failed),
-                        Toast.LENGTH_SHORT
-                    ).show()
-            }
-        }
-
-    private fun checkForAppUpdates() {
-        val appUpdateInfoTask = appUpdateManager.appUpdateInfo
-
-        appUpdateInfoTask.addOnSuccessListener { info ->
-            val isUpdateAvailable = info.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE
-            val isUpdateAllowed = when (updateType) {
-                AppUpdateType.IMMEDIATE -> info.isImmediateUpdateAllowed
-                AppUpdateType.FLEXIBLE -> info.isFlexibleUpdateAllowed
-                else -> false
-            }
-            if (isUpdateAvailable && isUpdateAllowed) {
-                appUpdateManager.startUpdateFlowForResult(
-                    info,
-                    activityResultLauncher,
-                    AppUpdateOptions.newBuilder(AppUpdateType.FLEXIBLE)
-                        .setAllowAssetPackDeletion(true)
-                        .build()
-                )
-            }
-        }
-    }
-
-    private val installStateUpdatedListener = InstallStateUpdatedListener { state ->
-        if (state.installStatus() == InstallStatus.DOWNLOADED) {
-            val msg = applicationContext.getString(R.string.update_download_success)
-            Toast.makeText(
-                applicationContext,
-                msg,
-                Toast.LENGTH_LONG
-            ).show()
-            lifecycleScope.launch {
-                delay(3000)
-                appUpdateManager.completeUpdate()
-            }
-        }
-    }
-
-    override fun onResume() {
-        super.onResume()
-        if (updateType == AppUpdateType.IMMEDIATE) {
-            val appUpdateInfoTask = appUpdateManager.appUpdateInfo
-
-            appUpdateInfoTask.addOnSuccessListener { info ->
-                val isUpdateAvailable =
-                    info.updateAvailability() == UpdateAvailability.DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS
-                if (isUpdateAvailable) {
-                    appUpdateManager.startUpdateFlowForResult(
-                        info,
-                        activityResultLauncher,
-                        AppUpdateOptions.newBuilder(AppUpdateType.IMMEDIATE)
-                            .setAllowAssetPackDeletion(true)
-                            .build()
-                    )
-                }
-            }
-        }
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        if (updateType == AppUpdateType.FLEXIBLE) {
-            appUpdateManager.unregisterListener(installStateUpdatedListener)
-        }
     }
 
 }

--- a/app/src/main/java/online/partyrun/partyrunapplication/MainActivity.kt
+++ b/app/src/main/java/online/partyrun/partyrunapplication/MainActivity.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
@@ -12,7 +13,18 @@ import androidx.annotation.RequiresApi
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
+import com.google.android.play.core.appupdate.AppUpdateManager
+import com.google.android.play.core.appupdate.AppUpdateManagerFactory
+import com.google.android.play.core.appupdate.AppUpdateOptions
+import com.google.android.play.core.install.InstallStateUpdatedListener
+import com.google.android.play.core.install.model.ActivityResult
+import com.google.android.play.core.install.model.AppUpdateType
+import com.google.android.play.core.install.model.InstallStatus
+import com.google.android.play.core.install.model.UpdateAvailability
+import com.google.android.play.core.ktx.isFlexibleUpdateAllowed
+import com.google.android.play.core.ktx.isImmediateUpdateAllowed
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import online.partyrun.partyrunapplication.ui.PartyRunMain
 import online.partyrun.partyrunapplication.core.common.extension.setIntentActivity
@@ -24,6 +36,11 @@ import timber.log.Timber
 class MainActivity : ComponentActivity() {
 
     private val battleViewModel: BattleViewModel by viewModels()
+
+    private lateinit var appUpdateManager: AppUpdateManager
+
+    // 업데이트 타입 변경 가능 -> 현재 IMMEDIATE
+    private val updateType = AppUpdateType.IMMEDIATE
 
     /**
      * 사용자로부터 권한을 요청하고 그 결과를 받아 처리하기 위한 코드
@@ -68,6 +85,13 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        // 최신 업데이트 정보 확인
+        appUpdateManager = AppUpdateManagerFactory.create(applicationContext)
+        if (updateType == AppUpdateType.FLEXIBLE) {
+            appUpdateManager.registerListener(installStateUpdatedListener)
+        }
+        checkForAppUpdates()
+
         battleViewModel.terminateOngoingBattle() // 앱이 처음 시작될 때 진행 중인 배틀이 있다면 종료 요청
         askPermissions() // 권한 확인 및 요청
 
@@ -88,9 +112,84 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    private val activityResultLauncher =
+        registerForActivityResult(ActivityResultContracts.StartIntentSenderForResult()) { result ->
+            when (result.resultCode) {
+                ActivityResult.RESULT_IN_APP_UPDATE_FAILED ->
+                    Toast.makeText(
+                        applicationContext,
+                        applicationContext.getString(R.string.result_in_app_update_failed),
+                        Toast.LENGTH_SHORT
+                    ).show()
+            }
+        }
+
+    private fun checkForAppUpdates() {
+        val appUpdateInfoTask = appUpdateManager.appUpdateInfo
+
+        appUpdateInfoTask.addOnSuccessListener { info ->
+            val isUpdateAvailable = info.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE
+            val isUpdateAllowed = when (updateType) {
+                AppUpdateType.IMMEDIATE -> info.isImmediateUpdateAllowed
+                AppUpdateType.FLEXIBLE -> info.isFlexibleUpdateAllowed
+                else -> false
+            }
+            if (isUpdateAvailable && isUpdateAllowed) {
+                appUpdateManager.startUpdateFlowForResult(
+                    info,
+                    activityResultLauncher,
+                    AppUpdateOptions.newBuilder(updateType)
+                        .build()
+                )
+            }
+        }
+    }
+
+    private val installStateUpdatedListener = InstallStateUpdatedListener { state ->
+        if (state.installStatus() == InstallStatus.DOWNLOADED) {
+            val msg = applicationContext.getString(R.string.update_download_success)
+            Toast.makeText(
+                applicationContext,
+                msg,
+                Toast.LENGTH_LONG
+            ).show()
+            lifecycleScope.launch {
+                delay(3000)
+                appUpdateManager.completeUpdate()
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (updateType == AppUpdateType.IMMEDIATE) {
+            val appUpdateInfoTask = appUpdateManager.appUpdateInfo
+
+            appUpdateInfoTask.addOnSuccessListener { info ->
+                val isUpdateAvailable =
+                    info.updateAvailability() == UpdateAvailability.DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS
+                if (isUpdateAvailable) {
+                    appUpdateManager.startUpdateFlowForResult(
+                        info,
+                        activityResultLauncher,
+                        AppUpdateOptions.newBuilder(AppUpdateType.IMMEDIATE)
+                            .build()
+                    )
+                }
+            }
+        }
+    }
+
     private fun performSignOutProcess() {
         setIntentActivity(AuthActivity::class.java)
         overridePendingTransition(0, 0) // 전환 애니메이션 생략
         finish()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        if (updateType == AppUpdateType.FLEXIBLE) {
+            appUpdateManager.unregisterListener(installStateUpdatedListener)
+        }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,6 +2,6 @@
     <string name="app_name">파티런</string>
 
     <string name="navigation_bar_launch_status">준비중</string>
-    <string name="update_download_success">다운로드 성공! 3초 뒤 앱이 재시작 됩니다."></string>
+    <string name="update_download_success">다운로드 성공! 3초 뒤 앱이 재시작 됩니다."</string>
     <string name="result_in_app_update_failed">RESULT_IN_APP_UPDATE_FAILED</string>
 </resources>


### PR DESCRIPTION
## Description
기존 In-App-Update를 AuthActivity에서 수행하도록 했는데, 이 경우 화면 전환이 많은 PartyRun AuthActivity 특성 상 업데이트 창이 오래 지속되지 못한다.
따라서, 인앱 업데이트 프로세스를 MainActivity에서 수행하도록 변경한다.
또한, AppUpdateType을 FLEXIBLE에서 IMMEDIATE로 변경