### PR TITLE
chore : Security Hotspots Reviewed

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     tools:ignore="LockedOrientationActivity">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
@@ -15,6 +16,7 @@
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
+        android:usesCleartextTraffic="false"
         android:icon="@mipmap/ic_partyrun"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_partyrun_round"


### PR DESCRIPTION
## Description
1. "usesCleartextTraffic" is implicitly enabled for older Android versions. Make sure allowing clear-text traffic is safe here.
Using clear-text protocols is security-sensitive[xml:S5332](https://sonarcloud.io/organizations/swm-kawai-mans/rules?open=xml%3AS5332&rule_key=xml%3AS5332)

For versions older than Android 9 (API level 28) android:usesCleartextTraffic is implicitely set to true.
*  **Compliant Solution**
    android:usesCleartextTraffic="false"

2. 

