### PR TITLE
#PAR-367 : 파티 멀티 퍼미션 및 디바인스 적용 

### DIFF
--- a/feature/battle/src/main/java/online/partyrun/partyrunapplication/feature/battle/BattleScreen.kt
+++ b/feature/battle/src/main/java/online/partyrun/partyrunapplication/feature/battle/BattleScreen.kt
@@ -1,7 +1,5 @@
 package online.partyrun.partyrunapplication.feature.battle
 
-import android.Manifest
-import android.os.Build
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -19,8 +17,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -30,7 +26,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.MultiplePermissionsState
-import com.google.accompanist.permissions.rememberMultiplePermissionsState
 import online.partyrun.partyrunapplication.core.designsystem.component.BottomHalfOvalGradientShape
 import online.partyrun.partyrunapplication.core.designsystem.component.PartyRunMatchButton
 import online.partyrun.partyrunapplication.core.model.match.RunningDistance
@@ -40,7 +35,8 @@ import online.partyrun.partyrunapplication.core.ui.KmInfoCard
 import online.partyrun.partyrunapplication.feature.match.MatchDialog
 import online.partyrun.partyrunapplication.feature.match.MatchUiState
 import online.partyrun.partyrunapplication.feature.match.MatchViewModel
-import online.partyrun.partyrunapplication.feature.running.permission.CheckMultiplePermissions
+import online.partyrun.partyrunapplication.feature.running.permission.HandlePermissionActions
+import online.partyrun.partyrunapplication.feature.running.permission.settingPermissionVariables
 
 private var lastClickTime = 0L
 private const val DEBOUNCE_DURATION = 100  // 0.1 seconds
@@ -135,13 +131,7 @@ fun BattleMainBody(
     matchViewModel: MatchViewModel,
     matchUiState: MatchUiState
 ) {
-    val showPermissionDialog = remember { mutableStateOf(false) }
-
-    val permissionsList = listOfNotNull(
-        Manifest.permission.ACCESS_FINE_LOCATION,
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) Manifest.permission.POST_NOTIFICATIONS else null
-    )
-    val permissionState = rememberMultiplePermissionsState(permissions = permissionsList)
+    val (showPermissionDialog, permissionState) = settingPermissionVariables()
 
     HandlePermissionActions(
         permissionState = permissionState,
@@ -284,22 +274,6 @@ private fun matchingAction(matchViewModel: MatchViewModel, currentKmState: KmSta
             distance = currentKmState.toDistance()
         )
     )
-}
-
-
-@OptIn(ExperimentalPermissionsApi::class)
-@Composable
-private fun HandlePermissionActions(
-    permissionState: MultiplePermissionsState,
-    showPermissionDialog: MutableState<Boolean>
-) {
-    if (showPermissionDialog.value) {
-        CheckMultiplePermissions(
-            permissionState = permissionState,
-            onPermissionResult = { if (it) showPermissionDialog.value = false },
-            showPermissionDialog = showPermissionDialog
-        )
-    }
 }
 
 fun isDebounced(currentTime: Long): Boolean {

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/permission/HandlePermissionActions.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/permission/HandlePermissionActions.kt
@@ -1,0 +1,21 @@
+package online.partyrun.partyrunapplication.feature.running.permission
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.MultiplePermissionsState
+
+@OptIn(ExperimentalPermissionsApi::class)
+@Composable
+fun HandlePermissionActions(
+    permissionState: MultiplePermissionsState,
+    showPermissionDialog: MutableState<Boolean>
+) {
+    if (showPermissionDialog.value) {
+        CheckMultiplePermissions(
+            permissionState = permissionState,
+            onPermissionResult = { if (it) showPermissionDialog.value = false },
+            showPermissionDialog = showPermissionDialog
+        )
+    }
+}

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/permission/SettingPermissionVariables.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/permission/SettingPermissionVariables.kt
@@ -1,0 +1,24 @@
+package online.partyrun.partyrunapplication.feature.running.permission
+
+import android.Manifest
+import android.os.Build
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.MultiplePermissionsState
+import com.google.accompanist.permissions.rememberMultiplePermissionsState
+
+@Composable
+@OptIn(ExperimentalPermissionsApi::class)
+fun settingPermissionVariables(): Pair<MutableState<Boolean>, MultiplePermissionsState> {
+    val showPermissionDialog = remember { mutableStateOf(false) }
+
+    val permissionsList = listOfNotNull(
+        Manifest.permission.ACCESS_FINE_LOCATION,
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) Manifest.permission.POST_NOTIFICATIONS else null
+    )
+    val permissionState = rememberMultiplePermissionsState(permissions = permissionsList)
+    return Pair(showPermissionDialog, permissionState)
+}

--- a/feature/single/src/main/java/online/partyrun/partyrunapplication/feature/single/SingleScreen.kt
+++ b/feature/single/src/main/java/online/partyrun/partyrunapplication/feature/single/SingleScreen.kt
@@ -1,7 +1,5 @@
 package online.partyrun.partyrunapplication.feature.single
 
-import android.Manifest
-import android.os.Build
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -23,8 +21,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -35,12 +31,12 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.MultiplePermissionsState
-import com.google.accompanist.permissions.rememberMultiplePermissionsState
 import online.partyrun.partyrunapplication.core.designsystem.component.PartyRunGradientButton
 import online.partyrun.partyrunapplication.core.designsystem.component.SurfaceRoundedRect
 import online.partyrun.partyrunapplication.core.designsystem.icon.PartyRunIcons
 import online.partyrun.partyrunapplication.core.ui.HeadLine
-import online.partyrun.partyrunapplication.feature.running.permission.CheckMultiplePermissions
+import online.partyrun.partyrunapplication.feature.running.permission.HandlePermissionActions
+import online.partyrun.partyrunapplication.feature.running.permission.settingPermissionVariables
 
 private var lastClickTime = 0L
 private const val DEBOUNCE_DURATION = 100  // 0.1 seconds
@@ -121,13 +117,7 @@ fun SingleMainBody(
     targetTime: Int,
     navigateToSingleRunningWithDistanceAndTime: (Int, Int) -> Unit
 ) {
-    val showPermissionDialog = remember { mutableStateOf(false) }
-
-    val permissionsList = listOfNotNull(
-        Manifest.permission.ACCESS_FINE_LOCATION,
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) Manifest.permission.POST_NOTIFICATIONS else null
-    )
-    val permissionState = rememberMultiplePermissionsState(permissions = permissionsList)
+    val (showPermissionDialog, permissionState) = settingPermissionVariables()
 
     HandlePermissionActions(
         permissionState = permissionState,
@@ -353,19 +343,4 @@ fun isDebounced(currentTime: Long): Boolean {
         return true
     }
     return false
-}
-
-@OptIn(ExperimentalPermissionsApi::class)
-@Composable
-private fun HandlePermissionActions(
-    permissionState: MultiplePermissionsState,
-    showPermissionDialog: MutableState<Boolean>
-) {
-    if (showPermissionDialog.value) {
-        CheckMultiplePermissions(
-            permissionState = permissionState,
-            onPermissionResult = { if (it) showPermissionDialog.value = false },
-            showPermissionDialog = showPermissionDialog
-        )
-    }
 }


### PR DESCRIPTION
## Description
방 만들기와 방 참여하기 모두 위치 기반과 알림 퍼미션 허용되어야 가능하도록 적용해야 한다.
이를 위해 버튼 클릭 시 다중 퍼미션 획득 여부를 판단하고 없다면 허용하도록 유도한다.
두 버튼 모두 짧은 순간에 연속 클릭이 되는 것을 방지할 수 있도록 디바인스 기법을 적용한다.

