### PR TITLE
refactor : 싱글, 배틀 디테일 수정

### DIFF
--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/running/RecordDataWithDistance.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/running/RecordDataWithDistance.kt
@@ -7,20 +7,17 @@ data class RecordDataWithDistance(
     val records: List<GpsDataWithDistance>
 )
 
-fun RecordDataWithDistance.calculateInstantPace(): String {
-    val (currentGpsData, lastGpsData) = getLastTwoGpsData() ?: return "0'00''"
+fun RecordDataWithDistance.calculateInstantPace(): String? {
+    val (currentGpsData, lastGpsData) = getLastTwoGpsData() ?: return null
 
     val distanceCoveredInKm = calculateDistanceInKm(currentGpsData, lastGpsData)
     val timeElapsedInSeconds = calculateDurationInSeconds(currentGpsData, lastGpsData)
 
-    if (isInvalidData(distanceCoveredInKm, timeElapsedInSeconds)) return "0'00''"
+    if (isTimeOrDistanceZero(distanceCoveredInKm, timeElapsedInSeconds)) return "0'00''"
+    if (isDistanceTooSmall(distanceCoveredInKm)) return null
 
     return formatPace(timeElapsedInSeconds / distanceCoveredInKm)
 }
-
-private fun isInvalidData(distance: Double, time: Double) =
-    isDistanceTooSmall(distance) || isTimeOrDistanceZero(time, distance)
-
 
 private fun RecordDataWithDistance.getLastTwoGpsData(): Pair<GpsDataWithDistance, GpsDataWithDistance>? {
     val currentGpsData = records.lastOrNull() ?: return null
@@ -36,10 +33,10 @@ private fun calculateDistanceInKm(
 }
 
 private fun isDistanceTooSmall(distance: Double): Boolean {
-    return distance < 0.0003 // 0.3m
+    return distance < 0.0008 // 0.8m
 }
 
-private fun isTimeOrDistanceZero(time: Double, distance: Double): Boolean {
+private fun isTimeOrDistanceZero(distance: Double, time: Double): Boolean {
     return time == 0.0 || distance == 0.0
 }
 

--- a/feature/party/src/main/java/online/partyrun/partyrunapplication/feature/party/room/PartyRoomViewModel.kt
+++ b/feature/party/src/main/java/online/partyrun/partyrunapplication/feature/party/room/PartyRoomViewModel.kt
@@ -116,7 +116,9 @@ class PartyRoomViewModel @Inject constructor(
         viewModelScope.launch {
             saveRunnersInfoUseCase(runnerInfoData)
         }
-        canceledEventProcess(eventData)
+        updatedPartyRoomState = updatePartyRoomState(runnerInfoData, eventData)
+        _partyRoomUiState.value =
+            _partyRoomUiState.value.updateState(updatedPartyRoomState)
     }
 
     private fun canceledEventProcess(eventData: PartyEvent) {

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentScreen.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/battle/BattleContentScreen.kt
@@ -7,6 +7,8 @@ import androidx.activity.OnBackPressedCallback
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -17,6 +19,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.delay
@@ -219,6 +222,13 @@ fun RunningBackNavigationHandler(
 
     RunningExitConfirmationDialog(
         openRunningExitDialog = openRunningExitDialog,
+        exitMessage = {
+            Text(
+                text = stringResource(id = R.string.exit_dialog_battle_subtitle),
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onPrimary
+            )
+        }
     ) {
         battleContentViewModel.disposeSocketResources()
         // 액티비티 재시작

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/running/component/RunningExitConfirmationDialog.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/running/component/RunningExitConfirmationDialog.kt
@@ -22,6 +22,7 @@ import online.partyrun.partyrunapplication.feature.running.R
 @Composable
 fun RunningExitConfirmationDialog(
     openRunningExitDialog: MutableState<Boolean>,
+    exitMessage: @Composable () -> Unit,
     confirmExit: () -> Unit
 ) {
     if (openRunningExitDialog.value) {
@@ -38,11 +39,7 @@ fun RunningExitConfirmationDialog(
                         style = MaterialTheme.typography.titleLarge,
                         color = MaterialTheme.colorScheme.onPrimary
                     )
-                    Text(
-                        text = stringResource(id = R.string.exit_dialog_subtitle),
-                        style = MaterialTheme.typography.titleMedium,
-                        color = MaterialTheme.colorScheme.onPrimary
-                    )
+                    exitMessage()
                 }
             },
             confirmButton = {

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/service/BaseRunningService.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/service/BaseRunningService.kt
@@ -32,7 +32,7 @@ abstract class BaseRunningService : Service() {
 
     companion object {
         const val LOCATION_UPDATE_INTERVAL_SECONDS = 1L
-        const val THRESHOLD = -1
+        const val THRESHOLD = 0.08
     }
 
     @Inject

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/service/SingleRunningService.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/service/SingleRunningService.kt
@@ -199,7 +199,6 @@ class SingleRunningService : BaseRunningService() {
         storeGpsData(gpsData)
     }
 
-
     private fun createGpsData(location: Location, distance: Double): GpsDataWithDistance {
         return GpsDataWithDistance(
             latitude = location.latitude,

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentScreen.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentScreen.kt
@@ -9,6 +9,8 @@ import androidx.activity.OnBackPressedCallback
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -19,6 +21,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.delay
@@ -264,6 +267,13 @@ fun RunningBackNavigationHandler(
 
     RunningExitConfirmationDialog(
         openRunningExitDialog = openRunningExitDialog,
+        exitMessage = {
+            Text(
+                text = stringResource(id = R.string.exit_dialog_single_subtitle),
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onPrimary
+            )
+        }
     ) {
         handleRunningExit(
             activity = activity,
@@ -284,8 +294,8 @@ fun handleRunningExit(
         singleContentViewModel.stopSingleRunningService()
         restartActivity(activity)
     } else {
-        singleContentViewModel.finishRunningProcess()
         singleContentViewModel.sendRecordDataWithDistance()
+        singleContentViewModel.finishRunningProcess()
     }
 }
 

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentScreen.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentScreen.kt
@@ -36,7 +36,7 @@ import online.partyrun.partyrunapplication.feature.running.running.component.Run
 import online.partyrun.partyrunapplication.feature.running.service.SingleRunningService
 import online.partyrun.partyrunapplication.feature.running.util.RunningConstants.RESULT_SCREEN_TRANSITION_DELAY
 
-const val MINIMUM_FINISH_DISTANCE = 100
+const val MINIMUM_FINISH_DISTANCE = 50
 
 @Composable
 fun SingleContentScreen(

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentUiState.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentUiState.kt
@@ -28,7 +28,7 @@ data class SingleContentUiState(
     val elapsedSecondsTime: Int = 0,
     val elapsedFormattedTime: String = "00:00:00",
     // 현재 페이스
-    val instantPace: String = "",
+    val instantPace: String = "0'00''",
     // 대결에 참여 중인 자신과 로봇의 현재 상태 정보
     val userStatus: SingleRunnerDisplayStatus = SingleRunnerDisplayStatus(),
     val robotStatus: SingleRunnerDisplayStatus = SingleRunnerDisplayStatus(),

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentViewModel.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentViewModel.kt
@@ -195,13 +195,15 @@ class SingleContentViewModel @Inject constructor(
                 checkTargetDistanceReached(currentDistance)
                 val (updatedUser, formattedDistance) =
                     _singleContentUiState.value.getUpdatedMovementData(currentDistance)
+                val instantPace =
+                    record.calculateInstantPace() ?: _singleContentUiState.value.instantPace
 
                 _singleContentUiState.update { state ->
                     state.copy(
                         userStatus = updatedUser,
                         distanceInMeter = currentDistance,
                         distanceInKm = formattedDistance,
-                        instantPace = record.calculateInstantPace()
+                        instantPace = instantPace
                     )
                 }
             }

--- a/feature/running/src/main/res/values/strings.xml
+++ b/feature/running/src/main/res/values/strings.xml
@@ -24,7 +24,8 @@
     <string name="finish_comment">대결이 종료됐습니다.</string>
 
     <string name="exit_dialog_title">대결을 종료하시겠습니까?</string>
-    <string name="exit_dialog_subtitle">종료 시 현재 대결을 이어 달릴 수 없습니다.</string>
+    <string name="exit_dialog_battle_subtitle">종료 시 현재 대결을 이어 달릴 수 없습니다.</string>
+    <string name="exit_dialog_single_subtitle">달리기 결과를 분석하려면\n최소 30미터 이상 달려야 해요.</string>
     <string name="exit_dialog_confirm">예</string>
     <string name="exit_dialog_cancel">아니오</string>
 

--- a/feature/running_result/src/main/java/online/partyrun/partyrunapplication/feature/running_result/single/SingleResultScreen.kt
+++ b/feature/running_result/src/main/java/online/partyrun/partyrunapplication/feature/running_result/single/SingleResultScreen.kt
@@ -187,7 +187,7 @@ private fun SingleTitleAndDateDisplay(singleResult: SingleResultUiModel) {
         Text(text = singleResult.singleDate)
         Spacer(modifier = Modifier.height(5.dp))
         Text(
-            text = "${stringResource(id = R.string.single_title)} ${singleResult.targetDistanceInKm}",
+            text = "${stringResource(id = R.string.single_title)} ${singleResult.targetDistanceFormatted}",
             style = MaterialTheme.typography.titleMedium,
             color = MaterialTheme.colorScheme.onPrimary
         )


### PR DESCRIPTION
## Description
1. 기존 100m였던 Single MINIMUM_FINISH_DISTANCE를 50으로 변경
2. Single, Battle 종료 달리기에 대한 안내 멘트 별도 처리
3. completedEventProcess에서는 SnackbarMessage를 출력하지 않도록 변경
4. Single은 자체적으로 거리 조정이 가능하므로 'km'로 고정하던 Battle과는 달리 'm' 포맷으로 출력