### PR TITLE
 #PAR-368 : 방장 혼자 있을 때는 파티 시작을 못하도록 제한

### DIFF
--- a/feature/party/src/main/java/online/partyrun/partyrunapplication/feature/party/room/PartyRoomViewModel.kt
+++ b/feature/party/src/main/java/online/partyrun/partyrunapplication/feature/party/room/PartyRoomViewModel.kt
@@ -170,6 +170,11 @@ class PartyRoomViewModel @Inject constructor(
     }
 
     fun startPartyBattle(partyCode: String) {
+        if (!isEligibleToStartBattle()) {
+            _snackbarMessage.value = "파티 인원이 2명 이상 필요해요."
+            return
+        }
+
         viewModelScope.launch {
             startPartyBattleUseCase(partyCode).collect { result ->
                 result.onEmpty {
@@ -180,6 +185,14 @@ class PartyRoomViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    private fun isEligibleToStartBattle(): Boolean {
+        val currentState = _partyRoomUiState.value
+        if (currentState is PartyRoomUiState.Success && currentState.partyRoomState.participants.size < 2) {
+            return false
+        }
+        return true
     }
 
     fun quitPartyRoom(partyCode: String) {


### PR DESCRIPTION
## Description
방장 혼자 있을 때는 대결를 시작하지 못하도록 제한하는 기능을 추가한다.
파티 러닝은 반드시 2인 이상이 가능하도록 제한

## Implementation

https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/aa9e8bec-ebd2-4e1b-b055-3a12e3a634c5

1. 1인일 경우 제한 메세지
2. 타인 참여
3. 2인부터 시작 시 Running 기능 수행
