### PR TITLE
refactor : 마이페이지에 불필요한 navigateToBack 기능 제거

### DIFF
--- a/app/src/main/java/online/partyrun/partyrunapplication/navigation/MainNavHost.kt
+++ b/app/src/main/java/online/partyrun/partyrunapplication/navigation/MainNavHost.kt
@@ -100,9 +100,6 @@ fun SetUpMainNavGraph(
             navigateToSettings = {
                 navController.navigate(MainNavRoutes.Settings.route)
             },
-            navigateBack = {
-                navController.popBackStack()
-            },
             navigateToMyPage = {
                 navController.navigate(MainNavRoutes.MyPage.route) {
                     popUpTo(MainNavRoutes.MyPage.route) {

--- a/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/my_page/MyPageNavigation.kt
+++ b/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/my_page/MyPageNavigation.kt
@@ -9,7 +9,6 @@ import online.partyrun.partyrunapplication.feature.my_page.profile.ProfileScreen
 fun NavGraphBuilder.myPageRoute(
     onSignOut: () -> Unit,
     navigateToSettings: () -> Unit,
-    navigateBack: () -> Unit,
     navigateToMyPage: () -> Unit,
     navigateToProfile: () -> Unit,
     onShowSnackbar: (String) -> Unit
@@ -18,7 +17,6 @@ fun NavGraphBuilder.myPageRoute(
         MyPageScreen(
             onSignOut = onSignOut,
             navigateToSettings = navigateToSettings,
-            navigateBack = navigateBack,
             navigateToProfile = navigateToProfile,
             onShowSnackbar = onShowSnackbar
         )

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageScreen.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageScreen.kt
@@ -46,7 +46,6 @@ fun MyPageScreen(
     myPageViewModel: MyPageViewModel = hiltViewModel(),
     onSignOut: () -> Unit = {},
     navigateToSettings: () -> Unit = {},
-    navigateBack: () -> Unit = {},
     navigateToProfile: () -> Unit = {},
     onShowSnackbar: (String) -> Unit
 ) {
@@ -58,7 +57,6 @@ fun MyPageScreen(
         myPageUiState = myPageUiState,
         onSignOut = onSignOut,
         navigateToSettings = navigateToSettings,
-        navigateBack = navigateBack,
         navigateToProfile = navigateToProfile,
         onShowSnackbar = onShowSnackbar,
         myPageSnackbarMessage = myPageSnackbarMessage
@@ -73,7 +71,6 @@ fun Content(
     myPageUiState: MyPageUiState,
     onSignOut: () -> Unit,
     navigateToSettings: () -> Unit,
-    navigateBack: () -> Unit,
     navigateToProfile: () -> Unit,
     onShowSnackbar: (String) -> Unit,
     myPageSnackbarMessage: String
@@ -90,7 +87,6 @@ fun Content(
         topBar = {
             MyPageTopAppBar(
                 modifier = modifier,
-                navigateBack = navigateBack,
                 navigateToSettings = navigateToSettings
             )
         }
@@ -119,19 +115,10 @@ fun Content(
 @Composable
 private fun MyPageTopAppBar(
     modifier: Modifier,
-    navigateBack: () -> Unit,
     navigateToSettings: () -> Unit
 ) {
     PartyRunTopAppBar(
         modifier = modifier,
-        navigateToContent = {
-            IconButton(onClick = { navigateBack() }) {
-                Icon(
-                    painterResource(id = PartyRunIcons.ArrowBackIos),
-                    contentDescription = stringResource(id = R.string.arrow_back_desc)
-                )
-            }
-        },
         titleContent = {
             Text(
                 text = stringResource(id = R.string.my_page_title)


### PR DESCRIPTION
## Description
마이페이지는 바텀 네비게이션을 통해 이동하는 findStartDestination이다.
따라서 기존에 있던 필요없는 뒤로가기 기능을 제거한다.

## Implementation
<img width="377" alt="image" src="https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/8b6f2027-116a-4870-b526-b1b1e4402f72">
