### PR TITLE
#PAR-375 : 달린 시간의 second의 width를 고정하여 빈번한 텍스트 너비 변화 방지

### DIFF
--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/profile/ProfileViewModel.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/profile/ProfileViewModel.kt
@@ -1,8 +1,13 @@
 package online.partyrun.partyrunapplication.feature.my_page.profile
 
 import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.ImageDecoder
 import android.net.Uri
+import android.os.Build
 import android.provider.MediaStore
+import androidx.annotation.RequiresApi
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -22,6 +27,7 @@ import online.partyrun.partyrunapplication.core.domain.member.SaveUserDataUseCas
 import online.partyrun.partyrunapplication.core.domain.member.UpdateProfileImageUseCase
 import online.partyrun.partyrunapplication.core.domain.member.UpdateUserDataUseCase
 import timber.log.Timber
+import java.io.ByteArrayOutputStream
 import javax.inject.Inject
 
 @HiltViewModel
@@ -31,6 +37,9 @@ class ProfileViewModel @Inject constructor(
     private val getUserDataUseCase: GetUserDataUseCase,
     private val saveUserDataUseCase: SaveUserDataUseCase
 ) : ViewModel() {
+    companion object {
+        const val COMPRESS_BITMAP_QUALITY = 80
+    }
 
     private val _profileUiState = MutableStateFlow(ProfileUiState())
     val profileUiState = _profileUiState.asStateFlow()
@@ -78,7 +87,6 @@ class ProfileViewModel @Inject constructor(
         )
     }
 
-    // 조건을 만족하면 true, 아니면 false 반환
     private fun getResultOfNickNameCondition(condition: Boolean, errorState: String): Boolean {
         _profileUiState.update {
             it.copy(
@@ -93,16 +101,39 @@ class ProfileViewModel @Inject constructor(
         return !isNickNameEmpty() && !isInvalidNickNameLength()
     }
 
+    @RequiresApi(Build.VERSION_CODES.P)
     fun handlePickedImage(context: Context, uri: Uri) {
         _updateProgressState.value = true
-        val requestBody = context.contentResolver.openInputStream(uri)?.use { inputStream ->
-            inputStream.readBytes().toRequestBody("image/*".toMediaTypeOrNull())
-        }
+
+        val bitmap = getBitmapFromUriUsingImageDecoder(context, uri)
+        val compressedBitmap = compressBitmap(bitmap)
+        val byteArray = bitmapToByteArray(compressedBitmap)
+
+        val requestBody = byteArray.toRequestBody("image/*".toMediaTypeOrNull())
         val fileName = getFileName(context, uri)
-        requestBody?.let {
-            updateProfileImage(requestBody, fileName)
-        }
+
+        updateProfileImage(requestBody, fileName)
     }
+
+    @RequiresApi(Build.VERSION_CODES.P)
+    fun getBitmapFromUriUsingImageDecoder(context: Context, uri: Uri): Bitmap {
+        val source = ImageDecoder.createSource(context.contentResolver, uri)
+        return ImageDecoder.decodeBitmap(source)
+    }
+
+    private fun compressBitmap(bitmap: Bitmap): Bitmap {
+        val stream = ByteArrayOutputStream()
+        bitmap.compress(Bitmap.CompressFormat.JPEG, COMPRESS_BITMAP_QUALITY, stream)
+        val byteArray = stream.toByteArray()
+        return BitmapFactory.decodeByteArray(byteArray, 0, byteArray.size)
+    }
+
+    private fun bitmapToByteArray(bitmap: Bitmap): ByteArray {
+        val stream = ByteArrayOutputStream()
+        bitmap.compress(Bitmap.CompressFormat.JPEG, 100, stream)
+        return stream.toByteArray()
+    }
+
 
     private fun getFileName(context: Context, uri: Uri): String? {
         return context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/profile/ProfileViewModel.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/profile/ProfileViewModel.kt
@@ -105,7 +105,7 @@ class ProfileViewModel @Inject constructor(
     fun handlePickedImage(context: Context, uri: Uri) {
         _updateProgressState.value = true
 
-        val bitmap = getBitmapFromUriUsingImageDecoder(context, uri)
+        val bitmap = getBitmapFromUriUsingImageDecoder(context, uri, 500, 500)
         val compressedBitmap = compressBitmap(bitmap)
         val byteArray = bitmapToByteArray(compressedBitmap)
 
@@ -116,10 +116,13 @@ class ProfileViewModel @Inject constructor(
     }
 
     @RequiresApi(Build.VERSION_CODES.P)
-    fun getBitmapFromUriUsingImageDecoder(context: Context, uri: Uri): Bitmap {
+    fun getBitmapFromUriUsingImageDecoder(context: Context, uri: Uri, width: Int, height: Int): Bitmap {
         val source = ImageDecoder.createSource(context.contentResolver, uri)
-        return ImageDecoder.decodeBitmap(source)
+        return ImageDecoder.decodeBitmap(source) { decoder, _, _ ->
+            decoder.setTargetSize(width, height)
+        }
     }
+
 
     private fun compressBitmap(bitmap: Bitmap): Bitmap {
         val stream = ByteArrayOutputStream()

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/running/SingleRunningScreen.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/running/SingleRunningScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -47,6 +48,7 @@ import online.partyrun.partyrunapplication.feature.running.running.component.tra
 import online.partyrun.partyrunapplication.feature.running.single.RunningServiceState
 import online.partyrun.partyrunapplication.feature.running.single.SingleContentUiState
 import online.partyrun.partyrunapplication.feature.running.single.SingleContentViewModel
+import online.partyrun.partyrunapplication.feature.running.single.getTimeComponents
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -138,11 +140,8 @@ fun SingleRunningScreen(
                 RunningMetricsPanel(
                     title = stringResource(id = R.string.progress_time)
                 ) {
-                    Text(
-                        text = singleContentUiState.elapsedFormattedTime,
-                        style = MaterialTheme.typography.displayLarge,
-                        color = MaterialTheme.colorScheme.onPrimary
-                    )
+                    val (hours, minutes, seconds) = singleContentUiState.getTimeComponents()
+                    FixedWidthTimeText(hours, minutes, seconds)
                 }
                 Spacer(modifier = Modifier.size(5.dp))
                 RunControlPanel(
@@ -203,7 +202,6 @@ private fun RunningMetricsPanel(
     record: @Composable () -> Unit
 ) {
     Column(
-        modifier = Modifier,
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
@@ -306,4 +304,25 @@ fun PartyRunImageButton(
             onClick()
         }
     )
+}
+
+@Composable
+fun FixedWidthTimeText(hour: String, minute: String, second: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = "$hour:$minute:",
+            style = MaterialTheme.typography.displayLarge,
+            color = MaterialTheme.colorScheme.onPrimary
+        )
+        Text(
+            modifier = Modifier.width(75.dp),
+            text = second,
+            style = MaterialTheme.typography.displayLarge,
+            color = MaterialTheme.colorScheme.onPrimary
+        )
+    }
 }

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentUiState.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentUiState.kt
@@ -62,10 +62,22 @@ fun SingleContentUiState.incrementElapsedSeconds(): Int {
     return this.elapsedSecondsTime + 1
 }
 
-fun SingleContentUiState.formatTime(seconds: Int): String {
-    val hours = seconds / 3600
-    val minutes = (seconds % 3600) / 60
-    val remainingSeconds = seconds % 60
+fun SingleContentUiState.formatTime(): String {
+    val hours = this.elapsedSecondsTime / 3600
+    val minutes = (this.elapsedSecondsTime % 3600) / 60
+    val remainingSeconds = this.elapsedSecondsTime % 60
 
     return String.format("%02d:%02d:%02d", hours, minutes, remainingSeconds)
+}
+
+fun SingleContentUiState.getTimeComponents(): Triple<String, String, String> {
+    val hours = this.elapsedSecondsTime / 3600
+    val minutes = (this.elapsedSecondsTime % 3600) / 60
+    val remainingSeconds = this.elapsedSecondsTime % 60
+
+    return Triple(
+        String.format("%02d", hours),
+        String.format("%02d", minutes),
+        String.format("%02d", remainingSeconds)
+    )
 }

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentViewModel.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentViewModel.kt
@@ -155,7 +155,7 @@ class SingleContentViewModel @Inject constructor(
         _singleContentUiState.update { state ->
             state.copy(
                 elapsedSecondsTime = state.incrementElapsedSeconds(),
-                elapsedFormattedTime = state.formatTime(state.elapsedSecondsTime)
+                elapsedFormattedTime = state.formatTime()
             )
         }
     }


### PR DESCRIPTION
## Description
 Text Composable의 너비가 달린시간에 따라 달라질 때 이를 고정하는 작업을 수행하고자 했다.
러닝 시간을 표현할 때 1의 너비가 다른 숫자들의 너비와 다르기에 상위 컴포저블에서 Center로 Alignment를 고정했을 때 텍스트가 조금씩 움직이는 문제가 있었다.
즉, 00:00:00 포맷의 너비와 00:00:01 포맷의 너비가 다르기에 Center 정렬로 디바이스의 중앙에 러닝시간을 표현할 때 시간 변화에 따라 움직이는 문제
**1. 달린시간 width 고정**
 달린 시간은 Center 정렬하여 표현되어야 하기에 00:00:00 포맷으로 width를 맞춰나도 00:01:00 혹은 00:00:10 처럼 1이 들어가면 너비가 달라지기에 Center에 정확히 시간이 위치하지 못하게 된다.
**2. '1'의 갯수에 따라 width를 동적으로 반영**
 그러나, 이 방법은 근본적인 원인 해결이 아니라 현상태와 동일하므로 패스.
**3. Monospace**
 각 텍스트의 하나하나마다 width를 고정한다.
이 경우 00:01:00과 같은 포맷이 될 경우 1 양 옆에 공백이 있어 적절하지 못했다.
그렇다고 각 텍스트마다 space를 동일하게 주면 0 0 : 0 0 : 0 0 이런 식의 포맷이 되는데, 이는 적절하지 않았다.
 **최종. second에만 width 고정** 
 변화가 가장 많은 seconds에만 width를 고정해 시간 변화에 따른 텍스트 너비의 변화를 최소화하고자 한다.
hour와 minute의 변화는 second에 비해 비교적 적으므로 어느정도의 움직임은 감안한다.
**다 하고 나서 알게 되었는데, 다른 러닝앱들은 아래 "변경 전"처럼 시간 변화에 따라 텍스트가 계속 움직이도록 그냥 놔뒀다.**

## Implementation
### 변경 전

https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/17024d65-e5e0-4d65-a0e3-fc1c5be32722

### 변경 후

https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/ffd7db8d-04b3-4650-b61b-320abf79744b

