### PR TITLE
#PAR-376 : 달린 시간의 second의 width를 고정하여 시간 변화에 따른 너비 변화 방지

### DIFF
--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/running/SingleRunningScreen.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/running/SingleRunningScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import kotlinx.coroutines.delay
@@ -314,13 +315,21 @@ fun FixedWidthTimeText(hour: String, minute: String, second: String) {
         horizontalArrangement = Arrangement.Center
     ) {
         Text(
-            text = "$hour:$minute:",
+            modifier = Modifier.width(100.dp),
+            text = hour,
+            textAlign = TextAlign.End,
             style = MaterialTheme.typography.displayLarge,
             color = MaterialTheme.colorScheme.onPrimary
         )
         Text(
-            modifier = Modifier.width(75.dp),
+            text = ":$minute:",
+            style = MaterialTheme.typography.displayLarge,
+            color = MaterialTheme.colorScheme.onPrimary
+        )
+        Text(
+            modifier = Modifier.width(100.dp),
             text = second,
+            textAlign = TextAlign.Start,
             style = MaterialTheme.typography.displayLarge,
             color = MaterialTheme.colorScheme.onPrimary
         )

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/running/SingleRunningScreen.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/running/SingleRunningScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -47,6 +48,7 @@ import online.partyrun.partyrunapplication.feature.running.running.component.tra
 import online.partyrun.partyrunapplication.feature.running.single.RunningServiceState
 import online.partyrun.partyrunapplication.feature.running.single.SingleContentUiState
 import online.partyrun.partyrunapplication.feature.running.single.SingleContentViewModel
+import online.partyrun.partyrunapplication.feature.running.single.getTimeComponents
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -138,11 +140,8 @@ fun SingleRunningScreen(
                 RunningMetricsPanel(
                     title = stringResource(id = R.string.progress_time)
                 ) {
-                    Text(
-                        text = singleContentUiState.elapsedFormattedTime,
-                        style = MaterialTheme.typography.displayLarge,
-                        color = MaterialTheme.colorScheme.onPrimary
-                    )
+                    val (hours, minutes, seconds) = singleContentUiState.getTimeComponents()
+                    FixedWidthTimeText(hours, minutes, seconds)
                 }
                 Spacer(modifier = Modifier.size(5.dp))
                 RunControlPanel(
@@ -203,7 +202,6 @@ private fun RunningMetricsPanel(
     record: @Composable () -> Unit
 ) {
     Column(
-        modifier = Modifier,
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
@@ -306,4 +304,25 @@ fun PartyRunImageButton(
             onClick()
         }
     )
+}
+
+@Composable
+fun FixedWidthTimeText(hour: String, minute: String, second: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = "$hour:$minute:",
+            style = MaterialTheme.typography.displayLarge,
+            color = MaterialTheme.colorScheme.onPrimary
+        )
+        Text(
+            modifier = Modifier.width(75.dp),
+            text = second,
+            style = MaterialTheme.typography.displayLarge,
+            color = MaterialTheme.colorScheme.onPrimary
+        )
+    }
 }

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentUiState.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentUiState.kt
@@ -62,10 +62,22 @@ fun SingleContentUiState.incrementElapsedSeconds(): Int {
     return this.elapsedSecondsTime + 1
 }
 
-fun SingleContentUiState.formatTime(seconds: Int): String {
-    val hours = seconds / 3600
-    val minutes = (seconds % 3600) / 60
-    val remainingSeconds = seconds % 60
+fun SingleContentUiState.formatTime(): String {
+    val hours = this.elapsedSecondsTime / 3600
+    val minutes = (this.elapsedSecondsTime % 3600) / 60
+    val remainingSeconds = this.elapsedSecondsTime % 60
 
     return String.format("%02d:%02d:%02d", hours, minutes, remainingSeconds)
+}
+
+fun SingleContentUiState.getTimeComponents(): Triple<String, String, String> {
+    val hours = this.elapsedSecondsTime / 3600
+    val minutes = (this.elapsedSecondsTime % 3600) / 60
+    val remainingSeconds = this.elapsedSecondsTime % 60
+
+    return Triple(
+        String.format("%02d", hours),
+        String.format("%02d", minutes),
+        String.format("%02d", remainingSeconds)
+    )
 }

--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentViewModel.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/single/SingleContentViewModel.kt
@@ -155,7 +155,7 @@ class SingleContentViewModel @Inject constructor(
         _singleContentUiState.update { state ->
             state.copy(
                 elapsedSecondsTime = state.incrementElapsedSeconds(),
-                elapsedFormattedTime = state.formatTime(state.elapsedSecondsTime)
+                elapsedFormattedTime = state.formatTime()
             )
         }
     }


### PR DESCRIPTION
## Description
 Text Composable의 너비가 달린시간의 변화에 따라 동적으로 달라질 때 이를 고정하는 작업을 수행하고자 했다.
러닝 시간을 표현할 때 1의 너비가 다른 숫자들의 너비와 다르기에 상위 컴포저블에서 Center로 Alignment를 고정했을 때 텍스트가 조금씩 움직이는 문제가 있었다.
즉, 00:00:00 포맷의 너비와 00:00:01 포맷의 너비가 다르기에 Center 정렬로 디바이스의 중앙에 러닝시간을 표현할 때 시간 변화에 따라 움직이는 문제
**1. 달린시간 width 고정**
 달린 시간은 Center 정렬하여 표현되어야 하기에 00:00:00 포맷으로 width를 맞춰나도 00:01:00 혹은 00:00:10 처럼 1이 들어가면 너비가 달라지기에 Center에 정확히 시간이 위치하지 못하게 된다.
**2. '1'의 갯수에 따라 width를 동적으로 반영**
 그러나, 이 방법은 근본적인 원인 해결이 아니라 현상태와 동일하므로 패스.
**3. Monospace**
파티런은 Pretendard폰트를 사용하기에 기본 FontFamily의 monospace를 활용할 수 없었다.
이에 직접 각 텍스트의 하나하나마다 width를 고정하려고 했으나, 00:01:00과 같은 포맷이 될 경우 1 양 옆에 space가 생겨 적절하지 못했다.
그렇다고 각 텍스트마다 space를 동일하게 주면 0 0 : 0 0 : 0 0 이런 식의 포맷이 되는데, 이는 적절하지 않았다.
 **4. second에만 width 고정** 
 변화가 가장 많은 seconds에만 width를 고정해 시간 변화에 따른 텍스트 너비의 변화를 최소화하고자 했지만
디바이스별 화면 크기와 해상도에 따라 font표현이 다르기에 어느 기기에서는 짤릴 수 있을 것 같다고 판단 
 **5. 최종** 
hour와 second에 넉넉한 width값을 주고 hours는 end 정렬, seconds는 start 정렬을 하여 
모든 기기에 대응할 수 있도록 함.
다만, 이 최종도 minute값이 바뀔 때 움직임이 있지만, 분 단위 변경은 크리티컬 하지 않을거라 판단하고 마무리

**다 하고 나서 알게 되었는데, 다른 러닝앱들은 아래 "변경 전"처럼 시간 변화에 따라 텍스트가 계속 움직이도록 그냥 놔뒀다.**

## Implementation
### 변경 전

https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/17024d65-e5e0-4d65-a0e3-fc1c5be32722

### 변경 후

https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/820e567d-84a3-46b8-9a3e-8bcfc7bd5a25


