### PR TITLE
#PAR-371 : 프로필 이미지 전처리

### DIFF
--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/profile/ProfileScreen.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/profile/ProfileScreen.kt
@@ -1,8 +1,10 @@
 package online.partyrun.partyrunapplication.feature.my_page.profile
 
+import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -64,6 +66,7 @@ import online.partyrun.partyrunapplication.feature.my_page.MyPageUiState
 import online.partyrun.partyrunapplication.feature.my_page.MyPageViewModel
 import online.partyrun.partyrunapplication.feature.my_page.R
 
+@RequiresApi(Build.VERSION_CODES.P)
 @Composable
 fun ProfileScreen(
     myPageViewModel: MyPageViewModel = hiltViewModel(),

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/profile/ProfileScreen.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/profile/ProfileScreen.kt
@@ -1,10 +1,8 @@
 package online.partyrun.partyrunapplication.feature.my_page.profile
 
-import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.annotation.RequiresApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -66,7 +64,6 @@ import online.partyrun.partyrunapplication.feature.my_page.MyPageUiState
 import online.partyrun.partyrunapplication.feature.my_page.MyPageViewModel
 import online.partyrun.partyrunapplication.feature.my_page.R
 
-@RequiresApi(Build.VERSION_CODES.P)
 @Composable
 fun ProfileScreen(
     myPageViewModel: MyPageViewModel = hiltViewModel(),

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/profile/ProfileViewModel.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/profile/ProfileViewModel.kt
@@ -105,7 +105,7 @@ class ProfileViewModel @Inject constructor(
     fun handlePickedImage(context: Context, uri: Uri) {
         _updateProgressState.value = true
 
-        val bitmap = getBitmapFromUriUsingImageDecoder(context, uri)
+        val bitmap = getBitmapFromUriUsingImageDecoder(context, uri, 500, 500)
         val compressedBitmap = compressBitmap(bitmap)
         val byteArray = bitmapToByteArray(compressedBitmap)
 
@@ -116,9 +116,11 @@ class ProfileViewModel @Inject constructor(
     }
 
     @RequiresApi(Build.VERSION_CODES.P)
-    fun getBitmapFromUriUsingImageDecoder(context: Context, uri: Uri): Bitmap {
+    fun getBitmapFromUriUsingImageDecoder(context: Context, uri: Uri, width: Int, height: Int): Bitmap {
         val source = ImageDecoder.createSource(context.contentResolver, uri)
-        return ImageDecoder.decodeBitmap(source)
+        return ImageDecoder.decodeBitmap(source) { decoder, _, _ ->
+            decoder.setTargetSize(width, height)
+        }
     }
 
 


### PR DESCRIPTION
## Description
카메라로 찍은 사진 같은 경우 MB가 나오게 된다. 이 경우 아래와 같은 문제가 예상되기에 KB로 압축하는 과정이 들어가야 된다.
1. 전송 시간: 큰 파일 전송 -> 시간 더 많이 소요 -> 사용자가 더 긴 대기 시간을 느낌
2. 서버 저장 비용: 이미지를 서버에 저장하는 경우, 큰 이미지는 더 많은 저장 공간 차지 -> 스토리지 비용 증가
3. 메모리 이슈: 고해상도 이미지를 로드하고 처리할 때 앱의 메모리 사용량 증가

## Implementation
<img width="227" alt="스크린샷 2023-09-28 오후 8 36 32" src="https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/d3632e58-8a10-4063-9386-a6a4bff5cb46">

