### PR TITLE
refactor : Single 설정 로직을 domain model의 확장함수에서 처리하도록 변경

### DIFF
--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/single/SingleTargetDetails.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/single/SingleTargetDetails.kt
@@ -1,0 +1,48 @@
+package online.partyrun.partyrunapplication.core.model.single
+
+data class SingleTargetDetails(
+    val distance: Int = INITIAL_DISTANCE,
+    val time: Int = INITIAL_TIME
+) {
+    companion object {
+        const val INITIAL_DISTANCE = 5000 // 'm' 단위
+        const val INITIAL_TIME = 900 // '초' 단위, 900초 = 15분
+        const val DISTANCE_INCREMENT = 250
+        const val TIME_INCREMENT = 300
+        const val SECONDS_IN_HOUR = 3600
+        const val SECONDS_IN_MINUTE = 60
+    }
+}
+
+fun SingleTargetDetails.incrementDistance(): SingleTargetDetails {
+    return copy(distance = this.distance + SingleTargetDetails.DISTANCE_INCREMENT)
+}
+
+fun SingleTargetDetails.decrementDistance(): SingleTargetDetails {
+    if (this.distance > SingleTargetDetails.DISTANCE_INCREMENT) {
+        return copy(distance = this.distance - SingleTargetDetails.DISTANCE_INCREMENT)
+    }
+    return this
+}
+
+fun SingleTargetDetails.incrementTime(): SingleTargetDetails {
+    return copy(time = this.time + SingleTargetDetails.TIME_INCREMENT)
+}
+
+fun SingleTargetDetails.decrementTime(): SingleTargetDetails {
+    if (this.time > SingleTargetDetails.TIME_INCREMENT) {
+        return copy(time = this.time - SingleTargetDetails.TIME_INCREMENT)
+    }
+    return this
+}
+
+fun SingleTargetDetails.getFormattedTime(): String {
+    val hours = this.time / SingleTargetDetails.SECONDS_IN_HOUR
+    val remainingTime = this.time % SingleTargetDetails.SECONDS_IN_HOUR
+    val minutes = remainingTime / SingleTargetDetails.SECONDS_IN_MINUTE
+    return String.format("%02d:%02d", hours, minutes)
+}
+
+fun SingleTargetDetails.getFormattedDistance(): String {
+    return String.format("%04.2f", (this.distance.toFloat() / 1000f) * 100f / 100)
+}

--- a/feature/single/src/main/java/online/partyrun/partyrunapplication/feature/single/SingleScreen.kt
+++ b/feature/single/src/main/java/online/partyrun/partyrunapplication/feature/single/SingleScreen.kt
@@ -34,6 +34,7 @@ import com.google.accompanist.permissions.MultiplePermissionsState
 import online.partyrun.partyrunapplication.core.designsystem.component.PartyRunGradientButton
 import online.partyrun.partyrunapplication.core.designsystem.component.SurfaceRoundedRect
 import online.partyrun.partyrunapplication.core.designsystem.icon.PartyRunIcons
+import online.partyrun.partyrunapplication.core.model.single.SingleTargetDetails
 import online.partyrun.partyrunapplication.core.ui.HeadLine
 import online.partyrun.partyrunapplication.feature.running.permission.HandlePermissionActions
 import online.partyrun.partyrunapplication.feature.running.permission.settingPermissionVariables
@@ -50,15 +51,13 @@ fun SingleScreen(
 ) {
     val singleUiState by singleViewModel.singleUiState.collectAsStateWithLifecycle()
     val singleSnackbarMessage by singleViewModel.snackbarMessage.collectAsStateWithLifecycle()
-    val targetDistance by singleViewModel.targetDistance.collectAsStateWithLifecycle()
-    val targetTime by singleViewModel.targetTime.collectAsStateWithLifecycle()
+    val singleTargetDetails by singleViewModel.singleTargetDetails.collectAsStateWithLifecycle()
 
     Content(
         modifier = modifier,
         singleUiState = singleUiState,
         singleViewModel = singleViewModel,
-        targetDistance = targetDistance,
-        targetTime = targetTime,
+        singleTargetDetails = singleTargetDetails,
         navigateToSingleRunningWithDistanceAndTime = navigateToSingleRunningWithDistanceAndTime,
         singleSnackbarMessage = singleSnackbarMessage,
         onShowSnackbar = onShowSnackbar
@@ -70,8 +69,7 @@ fun Content(
     modifier: Modifier = Modifier,
     singleUiState: SingleUiState,
     singleViewModel: SingleViewModel,
-    targetDistance: Int,
-    targetTime: Int,
+    singleTargetDetails: SingleTargetDetails,
     navigateToSingleRunningWithDistanceAndTime: (Int, Int) -> Unit,
     singleSnackbarMessage: String,
     onShowSnackbar: (String) -> Unit
@@ -88,8 +86,7 @@ fun Content(
             is SingleUiState.Loading -> LoadingBody()
             is SingleUiState.Success -> SingleMainBody(
                 singleViewModel = singleViewModel,
-                targetDistance = targetDistance,
-                targetTime = targetTime,
+                singleTargetDetails = singleTargetDetails,
                 navigateToSingleRunningWithDistanceAndTime = navigateToSingleRunningWithDistanceAndTime
             )
 
@@ -113,8 +110,7 @@ private fun LoadingBody() {
 @Composable
 fun SingleMainBody(
     singleViewModel: SingleViewModel,
-    targetDistance: Int,
-    targetTime: Int,
+    singleTargetDetails: SingleTargetDetails,
     navigateToSingleRunningWithDistanceAndTime: (Int, Int) -> Unit
 ) {
     val (showPermissionDialog, permissionState) = settingPermissionVariables()
@@ -128,8 +124,7 @@ fun SingleMainBody(
         singleViewModel = singleViewModel,
         permissionState = permissionState,
         showPermissionDialog = showPermissionDialog,
-        targetDistance = targetDistance,
-        targetTime = targetTime,
+        singleTargetDetails = singleTargetDetails,
         navigateToSingleRunningWithDistanceAndTime = navigateToSingleRunningWithDistanceAndTime
     )
 }
@@ -140,8 +135,7 @@ private fun SingleContent(
     singleViewModel: SingleViewModel,
     permissionState: MultiplePermissionsState,
     showPermissionDialog: MutableState<Boolean>,
-    targetDistance: Int,
-    targetTime: Int,
+    singleTargetDetails: SingleTargetDetails,
     navigateToSingleRunningWithDistanceAndTime: (Int, Int) -> Unit
 ) {
     Column(
@@ -200,8 +194,7 @@ private fun SingleContent(
                         handleStartButtonClick(
                             permissionState,
                             navigateToSingleRunningWithDistanceAndTime,
-                            targetDistance,
-                            targetTime,
+                            singleTargetDetails,
                             showPermissionDialog
                         )
                     }
@@ -223,14 +216,13 @@ private fun SingleContent(
 private fun handleStartButtonClick(
     permissionState: MultiplePermissionsState,
     navigateToSingleRunningWithDistanceAndTime: (Int, Int) -> Unit,
-    targetDistance: Int,
-    targetTime: Int,
+    singleTargetDetails: SingleTargetDetails,
     showPermissionDialog: MutableState<Boolean>
 ) {
     if (shouldExecuteStartAction(permissionState)) {
         navigateToSingleRunningWithDistanceAndTime(
-            targetDistance,
-            targetTime
+            singleTargetDetails.distance,
+            singleTargetDetails.time
         )
     } else {
         showPermissionDialog.value = true

--- a/feature/single/src/main/java/online/partyrun/partyrunapplication/feature/single/SingleViewModel.kt
+++ b/feature/single/src/main/java/online/partyrun/partyrunapplication/feature/single/SingleViewModel.kt
@@ -4,28 +4,25 @@ import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import online.partyrun.partyrunapplication.core.model.single.SingleTargetDetails
+import online.partyrun.partyrunapplication.core.model.single.decrementDistance
+import online.partyrun.partyrunapplication.core.model.single.decrementTime
+import online.partyrun.partyrunapplication.core.model.single.getFormattedDistance
+import online.partyrun.partyrunapplication.core.model.single.getFormattedTime
+import online.partyrun.partyrunapplication.core.model.single.incrementDistance
+import online.partyrun.partyrunapplication.core.model.single.incrementTime
 import javax.inject.Inject
 
 @HiltViewModel
-class SingleViewModel @Inject constructor() : ViewModel() {
+class SingleViewModel @Inject constructor(
 
-    companion object {
-        const val INITIAL_DISTANCE = 5000 // 'm' 단위
-        const val INITIAL_TIME = 900 // '초' 단위, 900초 = 15분
-        const val DISTANCE_INCREMENT = 250
-        const val TIME_INCREMENT = 300
-        const val SECONDS_IN_HOUR = 3600
-        const val SECONDS_IN_MINUTE = 60
-    }
+) : ViewModel() {
 
     private val _singleUiState = MutableStateFlow<SingleUiState>(SingleUiState.Success)
     val singleUiState: StateFlow<SingleUiState> = _singleUiState
 
-    private val _targetDistance = MutableStateFlow(INITIAL_DISTANCE)
-    val targetDistance: StateFlow<Int> = _targetDistance
-
-    private val _targetTime = MutableStateFlow(INITIAL_TIME)
-    val targetTime: StateFlow<Int> = _targetTime
+    private val _singleTargetDetails = MutableStateFlow(SingleTargetDetails())
+    val singleTargetDetails: StateFlow<SingleTargetDetails> = _singleTargetDetails
 
     private val _snackbarMessage = MutableStateFlow("")
     val snackbarMessage: StateFlow<String> = _snackbarMessage
@@ -35,33 +32,27 @@ class SingleViewModel @Inject constructor() : ViewModel() {
     }
 
     fun incrementTargetDistance() {
-        _targetDistance.value += DISTANCE_INCREMENT
+        _singleTargetDetails.value = _singleTargetDetails.value.incrementDistance()
     }
 
     fun decrementTargetDistance() {
-        if (_targetDistance.value > DISTANCE_INCREMENT) {
-            _targetDistance.value -= DISTANCE_INCREMENT
-        }
+        _singleTargetDetails.value = _singleTargetDetails.value.decrementDistance()
     }
 
     fun incrementTargetTime() {
-        _targetTime.value += TIME_INCREMENT
+        _singleTargetDetails.value = _singleTargetDetails.value.incrementTime()
     }
 
     fun decrementTargetTime() {
-        if (_targetTime.value > TIME_INCREMENT) {
-            _targetTime.value -= TIME_INCREMENT
-        }
+        _singleTargetDetails.value = _singleTargetDetails.value.decrementTime()
     }
 
     fun getFormattedTargetTime(): String {
-        val hours = _targetTime.value / SECONDS_IN_HOUR
-        val remainingTime = _targetTime.value % SECONDS_IN_HOUR
-        val minutes = remainingTime / SECONDS_IN_MINUTE
-        return String.format("%02d:%02d", hours, minutes)
+        return _singleTargetDetails.value.getFormattedTime()
     }
 
     fun getFormattedTargetDistance(): String {
-        return String.format("%04.2f", (_targetDistance.value.toFloat() / 1000f) * 100f / 100)
+        return _singleTargetDetails.value.getFormattedDistance()
     }
+
 }


### PR DESCRIPTION
## Description
싱글모드를 위해 목표 거리와 시간을 설정하는 로직을 ViewModel에서 처리하지 않고, SingleTargetDetails 도메인 모델 내 거리와 시간의 증감 및 표시 방식과 관련된 핵심 규칙을 정의해 처리한다.
이를 통해 뷰모델이 좀 더 간결해지며 UI 상태 관리에 집중할 수 있고, 도메인 모델의 책임과 행동이 명확하게 정의되어 도메인 복잡성 감소, 코드의 가독성과 유지 보수성이 향상되는 이점을 챙길 수 있다.
1. 캡슐화:  SingleTargetDetails는 자신의 상태와 관련된 비즈니스 로직을 자체적으로 포함 -> 객체의 상태와 그 상태를 변경하는 행동이 같은 곳에서 관리되므로 캡슐화 강화
2. 유지 보수성: 도메인 로직이 모델 내에 위치하면, 해당 도메인에 관련된 변경이 필요할 때 모델만 확인하면 됨 -> 유지보수, 리팩토링 수월
3. 재사용성: SingleTargetDetails와 같은 도메인 모델은 여러 뷰모델이나 다른 계층에서도 사용될 수 있기에, 로직이 모델 내에 포함되어 있으면, 재사용 시에도 해당 로직을 함께 가져가게 되므로 중복 코드 감소
4. 테스트 용이성: 도메인 모델에 로직이 포함되어 있으면, 해당 로직에 대한 유닛 테스트를 작성하기 수월. 모델의 상태와 행동을 분리해서 테스트할 수 있으므로, 테스트의 범위와 목적이 명확해짐
5. 가독성: SingleViewModel과 같은 뷰모델은 UI와 관련된 작업에 집중. 로직이 도메인 모델로 이동함으로써 뷰모델이 더 간결하고 명확해지며, 각 계층의 책임이 명확히 구분됨