### PR TITLE
fix : 러닝 중 앱 강제종료 시 Service onTaskRemoved() 클린업 Task 수행

### DIFF
--- a/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/service/BaseRunningService.kt
+++ b/feature/running/src/main/java/online/partyrun/partyrunapplication/feature/running/service/BaseRunningService.kt
@@ -171,6 +171,14 @@ abstract class BaseRunningService : Service() {
         stopLocationUpdates()
     }
 
+    override fun onTaskRemoved(rootIntent: Intent) {
+        super.onTaskRemoved(rootIntent)
+        sensorManager.unregisterListener(sensorEventListener) // 센서 해제
+        stopLocationUpdates()
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        stopSelf()
+    }
+
     override fun onBind(intent: Intent?): IBinder? {
         return null
     }


### PR DESCRIPTION
## Description
러닝 중 앱을 강제종료할 시 기존에는 foreground Service 작업이 정상적으로 종료되지 않는 문제 파악
이에,
안드로이드 Service의 onTaskRemoved()를 이용해 클린업 작업을 수행하도록 수정한다.
이 메서드는 사용자가 최근 앱 목록에서 앱을 제거하거나 "Force Stop"을 사용하여 앱을 종료할 때 호출된다.
즉, 이 메서드를 활용하면 앱이 강제 종료될 때 필요한 작업을 수행할 수 있다.

## Implementation

### 변경 전

https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/bbc3dd5f-6b8e-46e9-96e7-90287a10a4fe


### 변경 후

https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/c9fd114e-4665-4878-b833-757be58be8ed

