### PR TITLE
feat : ProfileBackNavigationHandler 적용

### DIFF
--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/profile/ProfileScreen.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/profile/ProfileScreen.kt
@@ -1,5 +1,7 @@
 package online.partyrun.partyrunapplication.feature.my_page.profile
 
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
@@ -28,8 +30,10 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -38,6 +42,7 @@ import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.SoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
@@ -111,6 +116,10 @@ fun Content(
     val updateProgressState by profileViewModel.updateProgressState.collectAsStateWithLifecycle()
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusManager = LocalFocusManager.current
+
+    ProfileBackNavigationHandler(
+        navigateToMyPage = navigateToMyPage
+    )
 
     LaunchedEffect(profileSnackbarMessage) {
         if (profileSnackbarMessage.isNotEmpty()) {
@@ -404,6 +413,29 @@ private fun NickNameSupportingText(profileUiState: ProfileUiState) {
                 style = MaterialTheme.typography.labelLarge,
                 color = MaterialTheme.colorScheme.error
             )
+        }
+    }
+}
+
+@Composable
+fun ProfileBackNavigationHandler(
+    navigateToMyPage: () -> Unit
+) {
+    val onBackPressedDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val onBackPressedCallback = remember {
+        object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                navigateToMyPage()
+            }
+        }
+    }
+
+    // lifecycleOwner와 backDispatcher가 변경될 때마다 실행
+    DisposableEffect(lifecycleOwner, onBackPressedDispatcher) {
+        onBackPressedDispatcher?.addCallback(lifecycleOwner, onBackPressedCallback)
+        onDispose {
+            onBackPressedCallback.remove()
         }
     }
 }


### PR DESCRIPTION
## Description
인터페이스 상 TopAppBar의 back arrow 클릭 시 의도대로 동작하지만, 디바이스 기기 내 back navigation시 프로필 이미지 변경 사항이 바로 반영되지 않는 현상이 있다.
따라서, BackNavigationHandler를 적용해 마찬가지로 navigateToMyPage() 메소드를 호출할 수 있도록 하여 의도대로 동작하도록 한다.

## Implementation
### 변경 전

https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/e3d35a04-6333-47e0-a262-594c27d93191


### 변경 후

https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/41424faa-4fb5-4df1-8239-7f27aee3e7cb

