### PR TITLE
refactor : match dialoag Colon 간격 수정

### DIFF
--- a/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/ui/MatchResultDialog.kt
+++ b/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/ui/MatchResultDialog.kt
@@ -148,7 +148,7 @@ private fun MatchAcceptanceInfo() {
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
             Text(
-                text = stringResource(id = R.string.time_remaining_acceptance),
+                text = stringResource(id = R.string.time_remaining_acceptance) + ":  ",
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.onPrimary
             )

--- a/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/ui/MatchWaitingDialog.kt
+++ b/feature/match/src/main/java/online/partyrun/partyrunapplication/feature/match/ui/MatchWaitingDialog.kt
@@ -62,7 +62,7 @@ fun MatchWaitingDialog(
                 modifier = Modifier.padding(1.dp)
             ) {
                 Text(
-                    text = stringResource(id = R.string.elapsed_time),
+                    text = stringResource(id = R.string.elapsed_time) + ":  ",
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.primary
                 )

--- a/feature/match/src/main/res/values/strings.xml
+++ b/feature/match/src/main/res/values/strings.xml
@@ -4,7 +4,7 @@
     <string name="cancel_button_title">취소</string>
 
    <!-- MatchWaitingDialog -->
-    <string name="elapsed_time">소요 대기 시간 : </string>
+    <string name="elapsed_time">소요 대기 시간</string>
     <string name="waiting_match_title">매칭 찾는 중</string>
     <string name="close_button_desc">취소</string>
 
@@ -22,7 +22,7 @@
     <string name="else_status">알 수 없는 상태</string>
     <string name="Determining_acceptance">수락 여부 파악 중...</string>
     <string name="completed_match">매칭 완료!</string>
-    <string name="time_remaining_acceptance">남은 수락 대기 시간 : </string>
+    <string name="time_remaining_acceptance">남은 수락 대기 시간</string>
 
 
     <!-- MatchCancelDialog -->


### PR DESCRIPTION
## Description
MatchWaitingDialog와 MatchResultDialog Colon 띄어쓰기 수정

## Implementation
### 변경 전
<img width="371" alt="image" src="https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/dd2110bc-130a-4794-a5ba-5a5b9960d724">


### 변경 후
<img width="380" alt="스크린샷 2023-10-09 오후 12 02 21" src="https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/600bcb43-b0fe-4e95-9a82-56fa0abdc048">
