### PR TITLE
#PAR-380 : 종합기록 조회 API 연동 + ShimmerEffect 적용

### DIFF
--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/ResultRepository.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/ResultRepository.kt
@@ -3,9 +3,11 @@ package online.partyrun.partyrunapplication.core.data.repository
 import kotlinx.coroutines.flow.Flow
 import online.partyrun.partyrunapplication.core.model.running_result.battle.BattleResult
 import online.partyrun.partyrunapplication.core.common.result.Result
+import online.partyrun.partyrunapplication.core.model.my_page.ComprehensiveRunRecord
 import online.partyrun.partyrunapplication.core.model.running_result.single.SingleResult
 
 interface ResultRepository {
     suspend fun getBattleResults(): Flow<Result<BattleResult>>
     suspend fun getSingleResults(): Flow<Result<SingleResult>>
+    suspend fun getComprehensiveRunRecord(): Flow<Result<ComprehensiveRunRecord>>
 }

--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/ResultRepositoryImpl.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/ResultRepositoryImpl.kt
@@ -10,6 +10,7 @@ import online.partyrun.partyrunapplication.core.network.model.response.toDomainM
 import online.partyrun.partyrunapplication.core.common.result.Result
 import online.partyrun.partyrunapplication.core.common.result.mapResultModel
 import online.partyrun.partyrunapplication.core.datastore.datasource.SinglePreferencesDataSource
+import online.partyrun.partyrunapplication.core.model.my_page.ComprehensiveRunRecord
 import online.partyrun.partyrunapplication.core.model.running_result.single.SingleResult
 import javax.inject.Inject
 
@@ -30,6 +31,12 @@ class ResultRepositoryImpl @Inject constructor(
         val singleId = singlePreferencesDataSource.getSingleId().first() ?: ""
         return apiRequestFlow {
             resultDataSource.getSingleResults(singleId)
+        }.mapResultModel { it.toDomainModel() }
+    }
+
+    override suspend fun getComprehensiveRunRecord(): Flow<Result<ComprehensiveRunRecord>> {
+        return apiRequestFlow {
+            resultDataSource.getComprehensiveRunRecord()
         }.mapResultModel { it.toDomainModel() }
     }
 

--- a/core/designsystem/src/main/java/online/partyrun/partyrunapplication/core/designsystem/component/ShimmerEffect.kt
+++ b/core/designsystem/src/main/java/online/partyrun/partyrunapplication/core/designsystem/component/ShimmerEffect.kt
@@ -1,0 +1,50 @@
+package online.partyrun.partyrunapplication.core.designsystem.component
+
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.unit.IntSize
+import online.partyrun.partyrunapplication.core.designsystem.theme.Purple50
+import online.partyrun.partyrunapplication.core.designsystem.theme.Purple60
+
+private const val shimmerAnimationDuration = 1000
+
+fun Modifier.shimmerEffect(): Modifier = composed {
+    var size by remember {
+        mutableStateOf(IntSize.Zero)
+    }
+    val transition = rememberInfiniteTransition()
+    val startOffsetX by transition.animateFloat(
+        initialValue = -2 * size.width.toFloat(),
+        targetValue = 2 * size.width.toFloat(),
+        animationSpec = infiniteRepeatable(
+            animation = tween(shimmerAnimationDuration)
+        )
+    )
+
+    background(
+        brush = Brush.linearGradient(
+            colors = listOf(
+                Purple60,
+                Purple50,
+                Purple60,
+            ),
+            start = Offset(startOffsetX, 0f),
+            end = Offset(startOffsetX + size.width.toFloat(), size.height.toFloat())
+        )
+    )
+        .onGloballyPositioned {
+            size = it.size
+        }
+}

--- a/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/my_page/GetComprehensiveRunRecordUseCase.kt
+++ b/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/my_page/GetComprehensiveRunRecordUseCase.kt
@@ -1,0 +1,10 @@
+package online.partyrun.partyrunapplication.core.domain.my_page
+
+import online.partyrun.partyrunapplication.core.data.repository.ResultRepository
+import javax.inject.Inject
+
+class GetComprehensiveRunRecordUseCase @Inject constructor(
+    private val resultRepository: ResultRepository
+) {
+    suspend operator fun invoke() = resultRepository.getComprehensiveRunRecord()
+}

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/my_page/ComprehensiveRunRecord.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/my_page/ComprehensiveRunRecord.kt
@@ -2,6 +2,6 @@ package online.partyrun.partyrunapplication.core.model.my_page
 
 data class ComprehensiveRunRecord(
     val averagePace: Double,
-    val totalDistance: Int,
+    val totalDistance: Double,
     val totalRunningTime: TotalRunningTime
 )

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/my_page/ComprehensiveRunRecord.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/my_page/ComprehensiveRunRecord.kt
@@ -1,7 +1,7 @@
 package online.partyrun.partyrunapplication.core.model.my_page
 
 data class ComprehensiveRunRecord(
-    val averagePace: Double,
-    val totalDistance: Double,
-    val totalRunningTime: TotalRunningTime
+    val averagePace: String,
+    val totalDistance: String,
+    val totalRunningTime: String
 )

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/my_page/ComprehensiveRunRecord.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/my_page/ComprehensiveRunRecord.kt
@@ -1,0 +1,7 @@
+package online.partyrun.partyrunapplication.core.model.my_page
+
+data class ComprehensiveRunRecord(
+    val averagePace: Double,
+    val totalDistance: Int,
+    val totalRunningTime: TotalRunningTime
+)

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/my_page/TotalRunningTime.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/my_page/TotalRunningTime.kt
@@ -5,3 +5,7 @@ data class TotalRunningTime(
     val minutes: Int,
     val seconds: Int
 )
+
+fun TotalRunningTime.toElapsedTimeString(): String {
+    return String.format("%02d:%02d:%02d", hours, minutes, seconds)
+}

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/my_page/TotalRunningTime.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/my_page/TotalRunningTime.kt
@@ -7,5 +7,6 @@ data class TotalRunningTime(
 )
 
 fun TotalRunningTime.toElapsedTimeString(): String {
-    return String.format("%02d:%02d:%02d", hours, minutes, seconds)
+    return String.format("%02d:%02d", hours, minutes)
 }
+

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/my_page/TotalRunningTime.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/my_page/TotalRunningTime.kt
@@ -1,0 +1,7 @@
+package online.partyrun.partyrunapplication.core.model.my_page
+
+data class TotalRunningTime(
+    val hours: Int,
+    val minutes: Int,
+    val seconds: Int
+)

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/ResultDataSource.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/ResultDataSource.kt
@@ -2,9 +2,11 @@ package online.partyrun.partyrunapplication.core.network.datasource
 
 import online.partyrun.partyrunapplication.core.common.network.ApiResponse
 import online.partyrun.partyrunapplication.core.network.model.response.BattleResultResponse
+import online.partyrun.partyrunapplication.core.network.model.response.ComprehensiveRunRecordResponse
 import online.partyrun.partyrunapplication.core.network.model.response.SingleResultResponse
 
 interface ResultDataSource {
     suspend fun getBattleResults(battleId: String): ApiResponse<BattleResultResponse>
     suspend fun getSingleResults(singleId: String): ApiResponse<SingleResultResponse>
+    suspend fun getComprehensiveRunRecord(): ApiResponse<ComprehensiveRunRecordResponse>
 }

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/ResultDataSourceImpl.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/ResultDataSourceImpl.kt
@@ -2,6 +2,7 @@ package online.partyrun.partyrunapplication.core.network.datasource
 
 import online.partyrun.partyrunapplication.core.common.network.ApiResponse
 import online.partyrun.partyrunapplication.core.network.model.response.BattleResultResponse
+import online.partyrun.partyrunapplication.core.network.model.response.ComprehensiveRunRecordResponse
 import online.partyrun.partyrunapplication.core.network.model.response.SingleResultResponse
 import online.partyrun.partyrunapplication.core.network.service.ResultApiService
 import javax.inject.Inject
@@ -14,5 +15,8 @@ class ResultDataSourceImpl @Inject constructor(
 
     override suspend fun getSingleResults(singleId: String): ApiResponse<SingleResultResponse> =
         resultApi.getSingleResults(singleId)
+
+    override suspend fun getComprehensiveRunRecord(): ApiResponse<ComprehensiveRunRecordResponse> =
+        resultApi.getComprehensiveRunRecord()
 
 }

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/ComprehensiveRunRecordResponse.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/ComprehensiveRunRecordResponse.kt
@@ -8,13 +8,13 @@ data class ComprehensiveRunRecordResponse(
     @SerializedName("averagePace")
     val averagePace: Double?,
     @SerializedName("totalDistance")
-    val totalDistance: Int?,
+    val totalDistance: Double?,
     @SerializedName("totalRunningTime")
     val totalRunningTime: TotalRunningTime?
 )
 
 fun ComprehensiveRunRecordResponse.toDomainModel() = ComprehensiveRunRecord(
     averagePace = this.averagePace ?: 0.0,
-    totalDistance = this.totalDistance ?: 0,
+    totalDistance = this.totalDistance ?: 0.0,
     totalRunningTime = this.totalRunningTime ?: TotalRunningTime(0, 0, 0)
 )

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/ComprehensiveRunRecordResponse.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/ComprehensiveRunRecordResponse.kt
@@ -3,6 +3,9 @@ package online.partyrun.partyrunapplication.core.network.model.response
 import com.google.gson.annotations.SerializedName
 import online.partyrun.partyrunapplication.core.model.my_page.ComprehensiveRunRecord
 import online.partyrun.partyrunapplication.core.model.my_page.TotalRunningTime
+import online.partyrun.partyrunapplication.core.model.my_page.toElapsedTimeString
+import online.partyrun.partyrunapplication.core.model.util.formatPace
+import online.partyrun.partyrunapplication.core.network.model.util.formatDistanceInKm
 
 data class ComprehensiveRunRecordResponse(
     @SerializedName("averagePace")
@@ -14,7 +17,7 @@ data class ComprehensiveRunRecordResponse(
 )
 
 fun ComprehensiveRunRecordResponse.toDomainModel() = ComprehensiveRunRecord(
-    averagePace = this.averagePace ?: 0.0,
-    totalDistance = this.totalDistance ?: 0.0,
-    totalRunningTime = this.totalRunningTime ?: TotalRunningTime(0, 0, 0)
+    averagePace = formatPace(this.averagePace ?: 0.0),
+    totalDistance = formatDistanceInKm(this.totalDistance?.toInt() ?: 0),
+    totalRunningTime = this.totalRunningTime?.toElapsedTimeString() ?: "00:00:00"
 )

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/ComprehensiveRunRecordResponse.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/ComprehensiveRunRecordResponse.kt
@@ -1,0 +1,20 @@
+package online.partyrun.partyrunapplication.core.network.model.response
+
+import com.google.gson.annotations.SerializedName
+import online.partyrun.partyrunapplication.core.model.my_page.ComprehensiveRunRecord
+import online.partyrun.partyrunapplication.core.model.my_page.TotalRunningTime
+
+data class ComprehensiveRunRecordResponse(
+    @SerializedName("averagePace")
+    val averagePace: Double?,
+    @SerializedName("totalDistance")
+    val totalDistance: Int?,
+    @SerializedName("totalRunningTime")
+    val totalRunningTime: TotalRunningTime?
+)
+
+fun ComprehensiveRunRecordResponse.toDomainModel() = ComprehensiveRunRecord(
+    averagePace = this.averagePace ?: 0.0,
+    totalDistance = this.totalDistance ?: 0,
+    totalRunningTime = this.totalRunningTime ?: TotalRunningTime(0, 0, 0)
+)

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/ComprehensiveRunRecordResponse.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/ComprehensiveRunRecordResponse.kt
@@ -19,5 +19,5 @@ data class ComprehensiveRunRecordResponse(
 fun ComprehensiveRunRecordResponse.toDomainModel() = ComprehensiveRunRecord(
     averagePace = formatPace(this.averagePace ?: 0.0),
     totalDistance = formatDistanceInKm(this.totalDistance?.toInt() ?: 0),
-    totalRunningTime = this.totalRunningTime?.toElapsedTimeString() ?: "00:00:00"
+    totalRunningTime = this.totalRunningTime?.toElapsedTimeString() ?: "00:00"
 )

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/TotalRunningTimeResponse.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/TotalRunningTimeResponse.kt
@@ -1,0 +1,19 @@
+package online.partyrun.partyrunapplication.core.network.model.response
+
+import com.google.gson.annotations.SerializedName
+import online.partyrun.partyrunapplication.core.model.my_page.TotalRunningTime
+
+data class TotalRunningTimeResponse(
+    @SerializedName("hours")
+    val hours: Int?,
+    @SerializedName("minutes")
+    val minutes: Int?,
+    @SerializedName("seconds")
+    val seconds: Int?
+)
+
+fun TotalRunningTimeResponse.toDomainModel() = TotalRunningTime(
+    hours = this.hours ?: 0,
+    minutes = this.minutes ?: 0,
+    seconds = this.seconds ?: 0
+)

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/service/ResultApiService.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/service/ResultApiService.kt
@@ -2,6 +2,7 @@ package online.partyrun.partyrunapplication.core.network.service
 
 import online.partyrun.partyrunapplication.core.common.network.ApiResponse
 import online.partyrun.partyrunapplication.core.network.model.response.BattleResultResponse
+import online.partyrun.partyrunapplication.core.network.model.response.ComprehensiveRunRecordResponse
 import online.partyrun.partyrunapplication.core.network.model.response.SingleResultResponse
 import retrofit2.http.GET
 import retrofit2.http.Path
@@ -18,4 +19,6 @@ interface ResultApiService {
         @Path("singleId") singleId: String
     ): ApiResponse<SingleResultResponse>
 
+    @GET("/api/mypage/total")
+    suspend fun getComprehensiveRunRecord(): ApiResponse<ComprehensiveRunRecordResponse>
 }

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageScreen.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageScreen.kt
@@ -1,27 +1,17 @@
 package online.partyrun.partyrunapplication.feature.my_page
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
@@ -44,16 +34,17 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.max
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import online.partyrun.partyrunapplication.core.designsystem.component.LottieImage
 import online.partyrun.partyrunapplication.core.designsystem.component.PartyRunGradientRoundedRect
 import online.partyrun.partyrunapplication.core.designsystem.component.PartyRunTopAppBar
-import online.partyrun.partyrunapplication.core.designsystem.component.RenderAsyncUrlImage
 import online.partyrun.partyrunapplication.core.designsystem.icon.PartyRunIcons
 import online.partyrun.partyrunapplication.core.model.user.User
 import online.partyrun.partyrunapplication.core.ui.ProfileSection
+import online.partyrun.partyrunapplication.feature.my_page.component.EmptyRunningHistory
+import online.partyrun.partyrunapplication.feature.my_page.component.ProfileContent
+import online.partyrun.partyrunapplication.feature.my_page.component.RunningHistory
+import online.partyrun.partyrunapplication.feature.my_page.component.StatusElement
 
 data class RunningData(
     val date: String,  // "월-일" 형태
@@ -248,7 +239,7 @@ private fun MyPageBody(
             Spacer(modifier = Modifier.height(30.dp))
 
             if (mockList.isEmpty()) {
-                EmptyRunningData()
+                EmptyRunningHistory()
             } else {
                 RunningHistory(
                     data = mockList,
@@ -272,7 +263,7 @@ private fun MyPageBody(
             Spacer(modifier = Modifier.height(30.dp))
 
             if (mockList.isEmpty()) {
-                EmptyRunningData()
+                EmptyRunningHistory()
             } else {
                 RunningHistory(
                     data = mockList,
@@ -286,207 +277,3 @@ private fun MyPageBody(
     }
 }
 
-@Composable
-private fun ProfileContent(
-    navigateToProfile: () -> Unit,
-    userName: String,
-    userProfile: String,
-) {
-    Column(
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        ProfileHeader(
-            navigateToProfile = navigateToProfile,
-            userName = userName
-        )
-        ProfileImage(
-            userProfile = userProfile
-        )
-    }
-}
-
-@Composable
-private fun ProfileHeader(
-    navigateToProfile: () -> Unit,
-    userName: String
-) {
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(top = 20.dp, bottom = 10.dp),
-        contentAlignment = Alignment.Center
-    ) {
-        Text(
-            text = userName,
-            style = MaterialTheme.typography.titleLarge,
-            color = MaterialTheme.colorScheme.onPrimary,
-            modifier = Modifier
-                .align(Alignment.Center)
-                .zIndex(1f) // 이미지와 동일한 Z-축 위치에 배치
-        )
-
-        IconButton(
-            onClick = {
-                navigateToProfile()
-            },
-            modifier = Modifier
-                .size(45.dp)
-                .padding(end = 10.dp)
-                .align(Alignment.CenterEnd)
-        ) {
-            Icon(
-                painter = painterResource(id = PartyRunIcons.edit),
-                tint = MaterialTheme.colorScheme.onPrimary,
-                contentDescription = stringResource(id = R.string.edit_desc)
-            )
-        }
-    }
-}
-
-@Composable
-private fun ProfileImage(
-    userProfile: String
-) {
-    Box(
-        contentAlignment = Alignment.Center,
-        modifier = Modifier
-            .size(80.dp)
-            .aspectRatio(1f, matchHeightConstraintsFirst = true)
-            .clip(CircleShape)
-            .border(3.dp, MaterialTheme.colorScheme.onPrimary, CircleShape)
-            .zIndex(1f)
-    ) {
-        RenderAsyncUrlImage(
-            modifier = Modifier.fillMaxSize(),
-            imageUrl = userProfile,
-            contentDescription = null
-        )
-    }
-}
-
-@Composable
-private fun StatusElement(
-    value: String,
-    title: String,
-    statusElementImage: @Composable () -> Unit
-) {
-    Column(
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        statusElementImage()
-        Spacer(modifier = Modifier.height(5.dp))
-        Text(
-            text = value,
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onPrimary,
-        )
-        Text(
-            text = title,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onPrimary,
-        )
-    }
-}
-
-@Composable
-private fun RunningHistory(
-    data: List<RunningData>,
-    onClick: () -> Unit,
-    isSingleData: Boolean
-) {
-    LazyRow(
-        horizontalArrangement = Arrangement.spacedBy(20.dp)
-    ) {
-        items(data) { data ->
-            RunningDataCard(
-                data = data,
-                isSingleData = isSingleData,
-                onClick = onClick,
-            )
-        }
-    }
-}
-
-@Composable
-private fun RunningDataCard(
-    data: RunningData,
-    isSingleData: Boolean,
-    onClick: () -> Unit
-) {
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick)
-    ) {
-        Row(
-            modifier = Modifier
-                .clip(RoundedCornerShape(15.dp))
-                .background(MaterialTheme.colorScheme.surface)
-                .padding(start = 25.dp, end = 5.dp, top = 20.dp, bottom = 15.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween
-        ) {
-            Column(
-                verticalArrangement = Arrangement.SpaceAround,
-                horizontalAlignment = Alignment.Start
-            ) {
-                Text(
-                    text = data.date,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurface
-                )
-                Text(
-                    text = data.runningTime,
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onPrimary
-                )
-                Text(
-                    text = data.distance,
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.onPrimary
-                )
-            }
-            Spacer(modifier = Modifier.width(32.dp))
-            Icon(
-                modifier = Modifier.size(18.dp),
-                painter = painterResource(id = PartyRunIcons.ArrowForwardIos),
-                tint = MaterialTheme.colorScheme.onPrimary,
-                contentDescription = null
-            )
-        }
-        Box(
-            modifier = Modifier
-                .size(32.dp)
-                .offset(x = 10.dp, y = (-15).dp)
-        ) {
-            val icon =
-                if (isSingleData) PartyRunIcons.SingleResultIcon else PartyRunIcons.BattleResultIcon
-
-            Image(
-                painter = painterResource(id = icon),
-                contentDescription = null
-            )
-        }
-    }
-}
-
-@Composable
-private fun EmptyRunningData() {
-    Column(
-        modifier = Modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        LottieImage(
-            modifier = Modifier.size(120.dp),
-            rawAnimation = R.raw.empty_list
-        )
-        Text(
-            text = stringResource(id = R.string.empty_list_item),
-            style = MaterialTheme.typography.titleSmall,
-            color = MaterialTheme.colorScheme.onPrimary,
-        )
-    }
-}

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageUiState.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageUiState.kt
@@ -1,9 +1,10 @@
 package online.partyrun.partyrunapplication.feature.my_page
 
+import online.partyrun.partyrunapplication.core.model.my_page.ComprehensiveRunRecord
 import online.partyrun.partyrunapplication.core.model.user.User
 
-sealed class MyPageUiState {
-    object Loading : MyPageUiState()
+sealed class MyPageProfileState {
+    object Loading : MyPageProfileState()
 
     data class Success(
         val user: User = User(
@@ -11,7 +12,21 @@ sealed class MyPageUiState {
             nickName = "",
             profileImage = ""
         )
-    ) : MyPageUiState()
+    ) : MyPageProfileState()
 
-    object LoadFailed : MyPageUiState()
+    object LoadFailed : MyPageProfileState()
+}
+
+sealed class MyPageComprehensiveRunRecordState {
+    object Loading : MyPageComprehensiveRunRecordState()
+
+    data class Success(
+        val comprehensiveRunRecord: ComprehensiveRunRecord = ComprehensiveRunRecord(
+            averagePace = "0'00''",
+            totalDistance = "0km",
+            totalRunningTime = "00:00"
+        )
+    ) : MyPageComprehensiveRunRecordState()
+
+    object LoadFailed : MyPageComprehensiveRunRecordState()
 }

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageViewModel.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageViewModel.kt
@@ -7,17 +7,27 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import online.partyrun.partyrunapplication.core.common.result.onFailure
+import online.partyrun.partyrunapplication.core.common.result.onSuccess
+import online.partyrun.partyrunapplication.core.domain.my_page.GetComprehensiveRunRecordUseCase
 import online.partyrun.partyrunapplication.core.domain.my_page.GetMyPageDataUseCase
 import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
 class MyPageViewModel @Inject constructor(
-    private val getMyPageDataUseCase: GetMyPageDataUseCase
+    private val getMyPageDataUseCase: GetMyPageDataUseCase,
+    private val getComprehensiveRunRecordUseCase: GetComprehensiveRunRecordUseCase
 ) : ViewModel() {
 
-    private val _myPageUiState = MutableStateFlow<MyPageUiState>(MyPageUiState.Loading)
-    val myPageUiState = _myPageUiState.asStateFlow()
+    private val _myPageProfileState =
+        MutableStateFlow<MyPageProfileState>(MyPageProfileState.Loading)
+    val myPageProfileState = _myPageProfileState.asStateFlow()
+
+    private val _myPageComprehensiveRunRecordState =
+        MutableStateFlow<MyPageComprehensiveRunRecordState>(MyPageComprehensiveRunRecordState.Loading)
+    val myPageComprehensiveRunRecordState = _myPageComprehensiveRunRecordState.asStateFlow()
+
 
     private val _snackbarMessage = MutableStateFlow("")
     val snackbarMessage: StateFlow<String> = _snackbarMessage
@@ -30,9 +40,28 @@ class MyPageViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 val user = getMyPageDataUseCase()
-                _myPageUiState.value = MyPageUiState.Success(user = user)
+                _myPageProfileState.value = MyPageProfileState.Success(user = user)
             } catch (e: Exception) {
                 Timber.e(e)
+            }
+        }
+    }
+
+    fun getComprehensiveRunRecord() = viewModelScope.launch {
+        _myPageComprehensiveRunRecordState.value =
+            MyPageComprehensiveRunRecordState.Loading
+
+        getComprehensiveRunRecordUseCase().collect { result ->
+            result.onSuccess {
+                _myPageComprehensiveRunRecordState.value =
+                    MyPageComprehensiveRunRecordState.Success(
+                        comprehensiveRunRecord = it
+                    )
+            }.onFailure { errorMessage, code ->
+                Timber.e(errorMessage, code)
+                _snackbarMessage.value = "종합기록을 불러오는데 실패했습니다."
+                _myPageComprehensiveRunRecordState.value =
+                    MyPageComprehensiveRunRecordState.LoadFailed
             }
         }
     }
@@ -41,4 +70,3 @@ class MyPageViewModel @Inject constructor(
         _snackbarMessage.value = ""
     }
 }
-

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageViewModel.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageViewModel.kt
@@ -23,10 +23,10 @@ class MyPageViewModel @Inject constructor(
     val snackbarMessage: StateFlow<String> = _snackbarMessage
 
     init {
-        getMyPageData()
+        getMyPageUserData()
     }
 
-    private fun getMyPageData() {
+    private fun getMyPageUserData() {
         viewModelScope.launch {
             try {
                 val user = getMyPageDataUseCase()

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/component/MyPageProfile.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/component/MyPageProfile.kt
@@ -1,0 +1,106 @@
+package online.partyrun.partyrunapplication.feature.my_page.component
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
+import online.partyrun.partyrunapplication.core.designsystem.component.RenderAsyncUrlImage
+import online.partyrun.partyrunapplication.core.designsystem.icon.PartyRunIcons
+import online.partyrun.partyrunapplication.feature.my_page.R
+
+@Composable
+fun ProfileContent(
+    navigateToProfile: () -> Unit,
+    userName: String,
+    userProfile: String,
+) {
+    Column(
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        ProfileHeader(
+            navigateToProfile = navigateToProfile,
+            userName = userName
+        )
+        ProfileImage(
+            userProfile = userProfile
+        )
+    }
+}
+
+@Composable
+private fun ProfileHeader(
+    navigateToProfile: () -> Unit,
+    userName: String
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 20.dp, bottom = 10.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = userName,
+            style = MaterialTheme.typography.titleLarge,
+            color = MaterialTheme.colorScheme.onPrimary,
+            modifier = Modifier
+                .align(Alignment.Center)
+                .zIndex(1f) // 이미지와 동일한 Z-축 위치에 배치
+        )
+
+        IconButton(
+            onClick = {
+                navigateToProfile()
+            },
+            modifier = Modifier
+                .size(45.dp)
+                .padding(end = 10.dp)
+                .align(Alignment.CenterEnd)
+        ) {
+            Icon(
+                painter = painterResource(id = PartyRunIcons.edit),
+                tint = MaterialTheme.colorScheme.onPrimary,
+                contentDescription = stringResource(id = R.string.edit_desc)
+            )
+        }
+    }
+}
+
+@Composable
+private fun ProfileImage(
+    userProfile: String
+) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .size(80.dp)
+            .aspectRatio(1f, matchHeightConstraintsFirst = true)
+            .clip(CircleShape)
+            .border(3.dp, MaterialTheme.colorScheme.onPrimary, CircleShape)
+            .zIndex(1f)
+    ) {
+        RenderAsyncUrlImage(
+            modifier = Modifier.fillMaxSize(),
+            imageUrl = userProfile,
+            contentDescription = null
+        )
+    }
+}

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/component/RunningHistory.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/component/RunningHistory.kt
@@ -1,0 +1,133 @@
+package online.partyrun.partyrunapplication.feature.my_page.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import online.partyrun.partyrunapplication.core.designsystem.component.LottieImage
+import online.partyrun.partyrunapplication.core.designsystem.icon.PartyRunIcons
+import online.partyrun.partyrunapplication.feature.my_page.R
+import online.partyrun.partyrunapplication.feature.my_page.RunningData
+
+@Composable
+fun RunningHistory(
+    data: List<RunningData>,
+    onClick: () -> Unit,
+    isSingleData: Boolean
+) {
+    LazyRow(
+        horizontalArrangement = Arrangement.spacedBy(20.dp)
+    ) {
+        items(data) { data ->
+            RunningDataCard(
+                data = data,
+                isSingleData = isSingleData,
+                onClick = onClick,
+            )
+        }
+    }
+}
+
+@Composable
+private fun RunningDataCard(
+    data: RunningData,
+    isSingleData: Boolean,
+    onClick: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+    ) {
+        Row(
+            modifier = Modifier
+                .clip(RoundedCornerShape(15.dp))
+                .background(MaterialTheme.colorScheme.surface)
+                .padding(start = 25.dp, end = 5.dp, top = 20.dp, bottom = 15.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Column(
+                verticalArrangement = Arrangement.SpaceAround,
+                horizontalAlignment = Alignment.Start
+            ) {
+                Text(
+                    text = data.date,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Text(
+                    text = data.runningTime,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onPrimary
+                )
+                Text(
+                    text = data.distance,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onPrimary
+                )
+            }
+            Spacer(modifier = Modifier.width(32.dp))
+            Icon(
+                modifier = Modifier.size(18.dp),
+                painter = painterResource(id = PartyRunIcons.ArrowForwardIos),
+                tint = MaterialTheme.colorScheme.onPrimary,
+                contentDescription = null
+            )
+        }
+        Box(
+            modifier = Modifier
+                .size(32.dp)
+                .offset(x = 10.dp, y = (-15).dp)
+        ) {
+            val icon =
+                if (isSingleData) PartyRunIcons.SingleResultIcon else PartyRunIcons.BattleResultIcon
+
+            Image(
+                painter = painterResource(id = icon),
+                contentDescription = null
+            )
+        }
+    }
+}
+
+@Composable
+fun EmptyRunningHistory() {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        LottieImage(
+            modifier = Modifier.size(120.dp),
+            rawAnimation = R.raw.empty_list
+        )
+        Text(
+            text = stringResource(id = R.string.empty_list_item),
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onPrimary,
+        )
+    }
+}

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/component/StatusElement.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/component/StatusElement.kt
@@ -1,0 +1,77 @@
+package online.partyrun.partyrunapplication.feature.my_page.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import online.partyrun.partyrunapplication.core.designsystem.component.shimmerEffect
+
+@Composable
+fun StatusElement(
+    value: String,
+    title: String,
+    statusElementImage: @Composable () -> Unit
+) {
+    Column(
+        modifier = Modifier.height(80.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        statusElementImage()
+        Spacer(modifier = Modifier.height(5.dp))
+        Text(
+            text = value,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onPrimary,
+        )
+        Text(
+            text = title,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onPrimary,
+        )
+    }
+}
+
+@Composable
+fun ShimmerStatusElement() {
+    Column(
+        modifier = Modifier.height(80.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Box(
+            modifier = Modifier
+                .size(32.dp)
+                .clip(CircleShape)
+                .shimmerEffect(),
+        )
+        Spacer(
+            modifier = Modifier
+                .height(5.dp)
+                .shimmerEffect()
+        )
+        Box(
+            modifier = Modifier
+                .width(50.dp)
+                .height(24.dp)
+                .shimmerEffect(),
+        )
+        Box(
+            modifier = Modifier
+                .width(80.dp)
+                .height(20.dp)
+                .shimmerEffect(),
+        )
+    }
+}

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/profile/ProfileScreen.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/profile/ProfileScreen.kt
@@ -64,7 +64,7 @@ import online.partyrun.partyrunapplication.core.designsystem.component.RenderAsy
 import online.partyrun.partyrunapplication.core.designsystem.icon.PartyRunIcons
 import online.partyrun.partyrunapplication.core.model.user.User
 import online.partyrun.partyrunapplication.core.ui.ProfileSection
-import online.partyrun.partyrunapplication.feature.my_page.MyPageUiState
+import online.partyrun.partyrunapplication.feature.my_page.MyPageProfileState
 import online.partyrun.partyrunapplication.feature.my_page.MyPageViewModel
 import online.partyrun.partyrunapplication.feature.my_page.R
 
@@ -76,7 +76,7 @@ fun ProfileScreen(
     onShowSnackbar: (String) -> Unit
 ) {
     val context = LocalContext.current
-    val myPageUiState by myPageViewModel.myPageUiState.collectAsStateWithLifecycle()
+    val myPageProfileState by myPageViewModel.myPageProfileState.collectAsStateWithLifecycle()
     val profileUiState by profileViewModel.profileUiState.collectAsStateWithLifecycle()
     val profileSnackbarMessage by profileViewModel.snackbarMessage.collectAsStateWithLifecycle()
     val photoPickerLauncher =
@@ -86,7 +86,7 @@ fun ProfileScreen(
 
     Content(
         profileViewModel = profileViewModel,
-        myPageUiState = myPageUiState,
+        myPageProfileState = myPageProfileState,
         profileUiState = profileUiState,
         photoPicker = {
             photoPickerLauncher.launch(
@@ -106,7 +106,7 @@ fun ProfileScreen(
 fun Content(
     modifier: Modifier = Modifier,
     profileViewModel: ProfileViewModel,
-    myPageUiState: MyPageUiState,
+    myPageProfileState: MyPageProfileState,
     profileUiState: ProfileUiState,
     photoPicker: () -> Unit,
     navigateToMyPage: () -> Unit,
@@ -150,10 +150,10 @@ fun Content(
                 .fillMaxSize()
                 .padding(paddingValues)
         ) {
-            if (myPageUiState is MyPageUiState.Success && keyboardController != null) {
+            if (myPageProfileState is MyPageProfileState.Success && keyboardController != null) {
                 ProfileBody(
                     profileViewModel = profileViewModel,
-                    userData = myPageUiState.user,
+                    userData = myPageProfileState.user,
                     photoPicker = photoPicker,
                     profileUiState = profileUiState,
                     keyboardController = keyboardController,


### PR DESCRIPTION
## Description
마이페이지 유저 정보 박스 아래에 총 달린 거리, 평균 페이스, 총 누적 거리를 보여줄 수 있는 스테이터스 바에 API 연동 결과를 보여준다.
**특히, 마이페이지 같은 경우 정보를 가져오는 API가 많기에 ShimmerEffect를 적용하여 다음과 같은 이점을 얻는다.**
1. 보다 나은 사용자 경험(UX): 데이터 로딩 시간 동안 사용자에게 빈 화면을 보여주는 것보다 무언가 로딩되고 있다는 것을 시각적으로 표현하는 것이 더 나은 UX 제공
2. 콘텐츠의 예상 형태 표현: 로딩되는 콘텐츠의 기본 형태와 구조를 나타내어 사용자로 하여금 콘텐츠가 로드되는 동안 어떤 형태의 정보가 제공될지 미리 예상할 수 있게 함
3. 응답성 향상: 실제 콘텐츠가 준비되기 전에 UI를 빠르게 표시함으로써 앱의 반응성 향상
4. 로딩 지연의 인식 감소: 사용자의 주의를 분산시키고, 실제로 데이터 로딩에 걸리는 시간 즉, 지루함을 느끼는 것을 줄임.

## Implementation
* ShimmerEffect를 보여주기 위해 의도적으로 delay를 추가한 상태에서 촬영

https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/56d1510f-a5b9-4147-8099-2cc18021ff6c

