### PR TITLE
#PAR-381 : 싱글 모드 단일 조회 API 연동 + Shimmer Effect 적용

### DIFF
--- a/app/src/main/java/online/partyrun/partyrunapplication/navigation/MainNavHost.kt
+++ b/app/src/main/java/online/partyrun/partyrunapplication/navigation/MainNavHost.kt
@@ -109,6 +109,13 @@ fun SetUpMainNavGraph(
             navigateToProfile = {
                 navController.navigate(MainNavRoutes.Profile.route)
             },
+            navigateToSingleResult = {
+                navController.navigate(MainNavRoutes.SingleResult.route) {
+                    popUpTo(MainNavRoutes.MyPage.route) {
+                        inclusive = false
+                    }
+                }
+            },
             onShowSnackbar = onShowSnackbar
         )
 

--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/ResultRepository.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/ResultRepository.kt
@@ -4,10 +4,12 @@ import kotlinx.coroutines.flow.Flow
 import online.partyrun.partyrunapplication.core.model.running_result.battle.BattleResult
 import online.partyrun.partyrunapplication.core.common.result.Result
 import online.partyrun.partyrunapplication.core.model.my_page.ComprehensiveRunRecord
+import online.partyrun.partyrunapplication.core.model.my_page.SingleRunningHistory
 import online.partyrun.partyrunapplication.core.model.running_result.single.SingleResult
 
 interface ResultRepository {
     suspend fun getBattleResults(): Flow<Result<BattleResult>>
     suspend fun getSingleResults(): Flow<Result<SingleResult>>
     suspend fun getComprehensiveRunRecord(): Flow<Result<ComprehensiveRunRecord>>
+    suspend fun getSingleHistory(): Flow<Result<SingleRunningHistory>>
 }

--- a/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/ResultRepositoryImpl.kt
+++ b/core/data/src/main/java/online/partyrun/partyrunapplication/core/data/repository/ResultRepositoryImpl.kt
@@ -11,6 +11,7 @@ import online.partyrun.partyrunapplication.core.common.result.Result
 import online.partyrun.partyrunapplication.core.common.result.mapResultModel
 import online.partyrun.partyrunapplication.core.datastore.datasource.SinglePreferencesDataSource
 import online.partyrun.partyrunapplication.core.model.my_page.ComprehensiveRunRecord
+import online.partyrun.partyrunapplication.core.model.my_page.SingleRunningHistory
 import online.partyrun.partyrunapplication.core.model.running_result.single.SingleResult
 import javax.inject.Inject
 
@@ -37,6 +38,12 @@ class ResultRepositoryImpl @Inject constructor(
     override suspend fun getComprehensiveRunRecord(): Flow<Result<ComprehensiveRunRecord>> {
         return apiRequestFlow {
             resultDataSource.getComprehensiveRunRecord()
+        }.mapResultModel { it.toDomainModel() }
+    }
+
+    override suspend fun getSingleHistory(): Flow<Result<SingleRunningHistory>> {
+        return apiRequestFlow {
+            resultDataSource.getSingleHistory()
         }.mapResultModel { it.toDomainModel() }
     }
 

--- a/core/designsystem/src/main/java/online/partyrun/partyrunapplication/core/designsystem/component/ShimmerEffect.kt
+++ b/core/designsystem/src/main/java/online/partyrun/partyrunapplication/core/designsystem/component/ShimmerEffect.kt
@@ -1,65 +1,41 @@
 package online.partyrun.partyrunapplication.core.designsystem.component
 
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.*
 import androidx.compose.foundation.background
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.unit.IntSize
-import online.partyrun.partyrunapplication.core.designsystem.theme.Gray10
-import online.partyrun.partyrunapplication.core.designsystem.theme.Gray20
-import online.partyrun.partyrunapplication.core.designsystem.theme.Purple50
-import online.partyrun.partyrunapplication.core.designsystem.theme.Purple60
+import online.partyrun.partyrunapplication.core.designsystem.theme.*
 
-private const val shimmerAnimationDuration = 1000
+private const val SHIMMER_ANIMATION_DURATION = 1000
 
-fun Modifier.shimmerEffect(
-    isDarkTheme: Boolean
-): Modifier = composed {
-    val brushColorList =
-        if (isDarkTheme) {
-            listOf(
-                Gray20,
-                Gray10,
-                Gray20
-            )
-        } else {
-            listOf(
-                Purple60,
-                Purple50,
-                Purple60
-            )
-        }
+private val DarkThemeColors = listOf(Gray20, Gray10, Gray20)
+private val PartyRunThemeColors = listOf(Purple60, Purple50, Purple60)
 
-    var size by remember {
-        mutableStateOf(IntSize.Zero)
-    }
+fun Modifier.shimmerEffect(isDarkTheme: Boolean): Modifier = composed {
+    val colors = if (isDarkTheme) DarkThemeColors else PartyRunThemeColors
+
+    var size by remember { mutableStateOf(IntSize.Zero) }
     val transition = rememberInfiniteTransition()
     val startOffsetX by transition.animateFloat(
         initialValue = -2 * size.width.toFloat(),
         targetValue = 2 * size.width.toFloat(),
         animationSpec = infiniteRepeatable(
-            animation = tween(shimmerAnimationDuration)
+            animation = tween(SHIMMER_ANIMATION_DURATION)
         )
     )
 
     background(
         brush = Brush.linearGradient(
-            colors = brushColorList,
+            colors = colors,
             start = Offset(startOffsetX, 0f),
             end = Offset(startOffsetX + size.width.toFloat(), size.height.toFloat())
         )
-    )
-        .onGloballyPositioned {
-            size = it.size
-        }
+    ).onGloballyPositioned {
+        size = it.size
+    }
 }

--- a/core/designsystem/src/main/java/online/partyrun/partyrunapplication/core/designsystem/component/ShimmerEffect.kt
+++ b/core/designsystem/src/main/java/online/partyrun/partyrunapplication/core/designsystem/component/ShimmerEffect.kt
@@ -15,12 +15,31 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.unit.IntSize
+import online.partyrun.partyrunapplication.core.designsystem.theme.Gray10
+import online.partyrun.partyrunapplication.core.designsystem.theme.Gray20
 import online.partyrun.partyrunapplication.core.designsystem.theme.Purple50
 import online.partyrun.partyrunapplication.core.designsystem.theme.Purple60
 
 private const val shimmerAnimationDuration = 1000
 
-fun Modifier.shimmerEffect(): Modifier = composed {
+fun Modifier.shimmerEffect(
+    isDarkTheme: Boolean
+): Modifier = composed {
+    val brushColorList =
+        if (isDarkTheme) {
+            listOf(
+                Gray20,
+                Gray10,
+                Gray20
+            )
+        } else {
+            listOf(
+                Purple60,
+                Purple50,
+                Purple60
+            )
+        }
+
     var size by remember {
         mutableStateOf(IntSize.Zero)
     }
@@ -35,11 +54,7 @@ fun Modifier.shimmerEffect(): Modifier = composed {
 
     background(
         brush = Brush.linearGradient(
-            colors = listOf(
-                Purple60,
-                Purple50,
-                Purple60,
-            ),
+            colors = brushColorList,
             start = Offset(startOffsetX, 0f),
             end = Offset(startOffsetX + size.width.toFloat(), size.height.toFloat())
         )

--- a/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/my_page/GetSingleHistoryUseCase.kt
+++ b/core/domain/src/main/java/online/partyrun/partyrunapplication/core/domain/my_page/GetSingleHistoryUseCase.kt
@@ -1,0 +1,11 @@
+package online.partyrun.partyrunapplication.core.domain.my_page
+
+import online.partyrun.partyrunapplication.core.data.repository.ResultRepository
+import javax.inject.Inject
+
+class GetSingleHistoryUseCase @Inject constructor(
+    private val resultRepository: ResultRepository
+) {
+    suspend operator fun invoke() = resultRepository.getSingleHistory()
+
+}

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/my_page/RunningHistoryDetail.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/my_page/RunningHistoryDetail.kt
@@ -4,5 +4,5 @@ data class RunningHistoryDetail(
     val id: String,
     val date: String,
     val runningTime: String,
-    val DistanceFormatted: String
+    val distanceFormatted: String
 )

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/my_page/RunningHistoryDetail.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/my_page/RunningHistoryDetail.kt
@@ -1,0 +1,8 @@
+package online.partyrun.partyrunapplication.core.model.my_page
+
+data class RunningHistoryDetail(
+    val id: String,
+    val date: String,
+    val runningTime: String,
+    val DistanceFormatted: String
+)

--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/my_page/SingleRunningHistory.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/my_page/SingleRunningHistory.kt
@@ -1,0 +1,5 @@
+package online.partyrun.partyrunapplication.core.model.my_page
+
+data class SingleRunningHistory(
+    val history: List<RunningHistoryDetail>
+)

--- a/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/my_page/MyPageNavigation.kt
+++ b/core/navigation/src/main/java/online/partyrun/partyrunapplication/core/navigation/my_page/MyPageNavigation.kt
@@ -10,12 +10,14 @@ fun NavGraphBuilder.myPageRoute(
     navigateToSettings: () -> Unit,
     navigateToMyPage: () -> Unit,
     navigateToProfile: () -> Unit,
+    navigateToSingleResult: () -> Unit,
     onShowSnackbar: (String) -> Unit
 ) {
     composable(route = MainNavRoutes.MyPage.route) {
         MyPageScreen(
             navigateToSettings = navigateToSettings,
             navigateToProfile = navigateToProfile,
+            navigateToSingleResult = navigateToSingleResult,
             onShowSnackbar = onShowSnackbar
         )
     }

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/ResultDataSource.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/ResultDataSource.kt
@@ -3,10 +3,12 @@ package online.partyrun.partyrunapplication.core.network.datasource
 import online.partyrun.partyrunapplication.core.common.network.ApiResponse
 import online.partyrun.partyrunapplication.core.network.model.response.BattleResultResponse
 import online.partyrun.partyrunapplication.core.network.model.response.ComprehensiveRunRecordResponse
+import online.partyrun.partyrunapplication.core.network.model.response.SingleHistoryResponse
 import online.partyrun.partyrunapplication.core.network.model.response.SingleResultResponse
 
 interface ResultDataSource {
     suspend fun getBattleResults(battleId: String): ApiResponse<BattleResultResponse>
     suspend fun getSingleResults(singleId: String): ApiResponse<SingleResultResponse>
     suspend fun getComprehensiveRunRecord(): ApiResponse<ComprehensiveRunRecordResponse>
+    suspend fun getSingleHistory(): ApiResponse<SingleHistoryResponse>
 }

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/ResultDataSourceImpl.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/datasource/ResultDataSourceImpl.kt
@@ -3,6 +3,7 @@ package online.partyrun.partyrunapplication.core.network.datasource
 import online.partyrun.partyrunapplication.core.common.network.ApiResponse
 import online.partyrun.partyrunapplication.core.network.model.response.BattleResultResponse
 import online.partyrun.partyrunapplication.core.network.model.response.ComprehensiveRunRecordResponse
+import online.partyrun.partyrunapplication.core.network.model.response.SingleHistoryResponse
 import online.partyrun.partyrunapplication.core.network.model.response.SingleResultResponse
 import online.partyrun.partyrunapplication.core.network.service.ResultApiService
 import javax.inject.Inject
@@ -18,5 +19,8 @@ class ResultDataSourceImpl @Inject constructor(
 
     override suspend fun getComprehensiveRunRecord(): ApiResponse<ComprehensiveRunRecordResponse> =
         resultApi.getComprehensiveRunRecord()
+
+    override suspend fun getSingleHistory(): ApiResponse<SingleHistoryResponse> =
+        resultApi.getSingleHistory()
 
 }

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/SingleHistoryDetailResponse.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/SingleHistoryDetailResponse.kt
@@ -32,6 +32,6 @@ fun SingleHistoryDetailResponse.toDomainModel(): RunningHistoryDetail {
         id = this.id ?: "",
         date = parsedDate?.let { formatDate(it) } ?: "",
         runningTime = this.runningTime?.toElapsedTimeString() ?: "00:00:00",
-        DistanceFormatted = formatDistanceWithComma(this.distance?.toInt() ?: 0)
+        distanceFormatted = formatDistanceWithComma(this.distance?.toInt() ?: 0)
     )
 }

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/SingleHistoryDetailResponse.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/SingleHistoryDetailResponse.kt
@@ -1,0 +1,37 @@
+package online.partyrun.partyrunapplication.core.network.model.response
+
+import com.google.gson.annotations.SerializedName
+import online.partyrun.partyrunapplication.core.model.my_page.RunningHistoryDetail
+import online.partyrun.partyrunapplication.core.model.running.RunningTime
+import online.partyrun.partyrunapplication.core.model.running.toElapsedTimeString
+import online.partyrun.partyrunapplication.core.model.util.DateTimeUtils
+import online.partyrun.partyrunapplication.core.network.model.util.formatDate
+import online.partyrun.partyrunapplication.core.network.model.util.formatDistanceWithComma
+import java.time.LocalDateTime
+
+data class SingleHistoryDetailResponse(
+    @SerializedName("id")
+    val id: String?,
+    @SerializedName("startTime")
+    val startTime: String?,
+    @SerializedName("runningTime")
+    val runningTime: RunningTime?,
+    @SerializedName("distance")
+    val distance: Double?
+)
+
+fun SingleHistoryDetailResponse.toDomainModel(): RunningHistoryDetail {
+    val parsedDate = startTime?.let {
+        LocalDateTime.parse(
+            it,
+            DateTimeUtils.localDateTimeFormatter
+        )
+    }
+
+    return RunningHistoryDetail(
+        id = this.id ?: "",
+        date = parsedDate?.let { formatDate(it) } ?: "",
+        runningTime = this.runningTime?.toElapsedTimeString() ?: "00:00:00",
+        DistanceFormatted = formatDistanceWithComma(this.distance?.toInt() ?: 0)
+    )
+}

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/SingleHistoryResponse.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/SingleHistoryResponse.kt
@@ -1,0 +1,14 @@
+package online.partyrun.partyrunapplication.core.network.model.response
+
+import com.google.gson.annotations.SerializedName
+import online.partyrun.partyrunapplication.core.model.my_page.SingleRunningHistory
+
+data class SingleHistoryResponse(
+    @SerializedName("history")
+    val history: List<SingleHistoryDetailResponse>?
+)
+
+fun SingleHistoryResponse.toDomainModel(): SingleRunningHistory {
+    val transformedHistory = history?.map { it.toDomainModel() }?.reversed() ?: emptyList()
+    return SingleRunningHistory(history = transformedHistory)
+}

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/service/ResultApiService.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/service/ResultApiService.kt
@@ -3,6 +3,7 @@ package online.partyrun.partyrunapplication.core.network.service
 import online.partyrun.partyrunapplication.core.common.network.ApiResponse
 import online.partyrun.partyrunapplication.core.network.model.response.BattleResultResponse
 import online.partyrun.partyrunapplication.core.network.model.response.ComprehensiveRunRecordResponse
+import online.partyrun.partyrunapplication.core.network.model.response.SingleHistoryResponse
 import online.partyrun.partyrunapplication.core.network.model.response.SingleResultResponse
 import retrofit2.http.GET
 import retrofit2.http.Path
@@ -21,4 +22,8 @@ interface ResultApiService {
 
     @GET("/api/mypage/total")
     suspend fun getComprehensiveRunRecord(): ApiResponse<ComprehensiveRunRecordResponse>
+
+    @GET("/api/mypage/singles")
+    suspend fun getSingleHistory(): ApiResponse<SingleHistoryResponse>
+
 }

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageScreen.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageScreen.kt
@@ -172,7 +172,9 @@ private fun MyPageBody(
         myPageViewModel.saveIdCompleteEvent.collect { modeType ->
             when (modeType) {
                 ModeType.SINGLE -> navigateToSingleResult()
-                else -> {}
+                else -> {
+                    // Battle 
+                }
             }
         }
     }

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageScreen.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageScreen.kt
@@ -187,7 +187,7 @@ private fun MyPageBody(
         }
         Spacer(modifier = Modifier.height(30.dp))
 
-        ComprehensiveRunRecord(
+        ComprehensiveRunRecordRect(
             myPageComprehensiveRunRecordState = myPageComprehensiveRunRecordState
         )
 
@@ -266,23 +266,23 @@ private fun SingleRunningHistoryBody(
 }
 
 @Composable
-private fun ComprehensiveRunRecord(
+private fun ComprehensiveRunRecordRect(
     myPageComprehensiveRunRecordState: MyPageComprehensiveRunRecordState
 ) {
     when (myPageComprehensiveRunRecordState) {
-        is MyPageComprehensiveRunRecordState.Loading -> ComprehensiveRunRecordShimmerEffect()
-        is MyPageComprehensiveRunRecordState.Success -> ComprehensiveRunRecordBody(
+        is MyPageComprehensiveRunRecordState.Loading -> ShimmerComprehensiveRunRecordRect()
+        is MyPageComprehensiveRunRecordState.Success -> ComprehensiveRunRecordRectBody(
             averagePace = myPageComprehensiveRunRecordState.comprehensiveRunRecord.averagePace,
             totalDistance = myPageComprehensiveRunRecordState.comprehensiveRunRecord.totalDistance,
             totalRunningTime = myPageComprehensiveRunRecordState.comprehensiveRunRecord.totalRunningTime
         )
 
-        MyPageComprehensiveRunRecordState.LoadFailed -> ComprehensiveRunRecordShimmerEffect()
+        MyPageComprehensiveRunRecordState.LoadFailed -> ShimmerComprehensiveRunRecordRect()
     }
 }
 
 @Composable
-private fun ComprehensiveRunRecordShimmerEffect() {
+private fun ShimmerComprehensiveRunRecordRect() {
     PartyRunGradientRoundedRect(
         modifier = Modifier
             .fillMaxWidth()
@@ -304,7 +304,7 @@ private fun ComprehensiveRunRecordShimmerEffect() {
 }
 
 @Composable
-private fun ComprehensiveRunRecordBody(
+private fun ComprehensiveRunRecordRectBody(
     averagePace: String,
     totalDistance: String,
     totalRunningTime: String

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageUiState.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageUiState.kt
@@ -1,6 +1,7 @@
 package online.partyrun.partyrunapplication.feature.my_page
 
 import online.partyrun.partyrunapplication.core.model.my_page.ComprehensiveRunRecord
+import online.partyrun.partyrunapplication.core.model.my_page.SingleRunningHistory
 import online.partyrun.partyrunapplication.core.model.user.User
 
 sealed class MyPageProfileState {
@@ -29,4 +30,14 @@ sealed class MyPageComprehensiveRunRecordState {
     ) : MyPageComprehensiveRunRecordState()
 
     object LoadFailed : MyPageComprehensiveRunRecordState()
+}
+
+sealed class RunningHistoryState {
+    object Loading : RunningHistoryState()
+
+    data class Success(
+        val singleRunningHistory: SingleRunningHistory = SingleRunningHistory(emptyList())
+    ) : RunningHistoryState()
+
+    object LoadFailed : RunningHistoryState()
 }

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageUiState.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageUiState.kt
@@ -4,6 +4,10 @@ import online.partyrun.partyrunapplication.core.model.my_page.ComprehensiveRunRe
 import online.partyrun.partyrunapplication.core.model.my_page.SingleRunningHistory
 import online.partyrun.partyrunapplication.core.model.user.User
 
+enum class ModeType {
+    SINGLE, BATTLE
+}
+
 sealed class MyPageProfileState {
     object Loading : MyPageProfileState()
 

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageViewModel.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageViewModel.kt
@@ -3,6 +3,7 @@ package online.partyrun.partyrunapplication.feature.my_page
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -11,13 +12,15 @@ import online.partyrun.partyrunapplication.core.common.result.onFailure
 import online.partyrun.partyrunapplication.core.common.result.onSuccess
 import online.partyrun.partyrunapplication.core.domain.my_page.GetComprehensiveRunRecordUseCase
 import online.partyrun.partyrunapplication.core.domain.my_page.GetMyPageDataUseCase
+import online.partyrun.partyrunapplication.core.domain.my_page.GetSingleHistoryUseCase
 import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
 class MyPageViewModel @Inject constructor(
     private val getMyPageDataUseCase: GetMyPageDataUseCase,
-    private val getComprehensiveRunRecordUseCase: GetComprehensiveRunRecordUseCase
+    private val getComprehensiveRunRecordUseCase: GetComprehensiveRunRecordUseCase,
+    private val getSingleHistoryUseCase: GetSingleHistoryUseCase
 ) : ViewModel() {
 
     private val _myPageProfileState =
@@ -28,6 +31,9 @@ class MyPageViewModel @Inject constructor(
         MutableStateFlow<MyPageComprehensiveRunRecordState>(MyPageComprehensiveRunRecordState.Loading)
     val myPageComprehensiveRunRecordState = _myPageComprehensiveRunRecordState.asStateFlow()
 
+    private val _runningHistoryState =
+        MutableStateFlow<RunningHistoryState>(RunningHistoryState.Loading)
+    val runningHistoryState = _runningHistoryState.asStateFlow()
 
     private val _snackbarMessage = MutableStateFlow("")
     val snackbarMessage: StateFlow<String> = _snackbarMessage
@@ -53,6 +59,7 @@ class MyPageViewModel @Inject constructor(
 
         getComprehensiveRunRecordUseCase().collect { result ->
             result.onSuccess {
+                delay(1000L)
                 _myPageComprehensiveRunRecordState.value =
                     MyPageComprehensiveRunRecordState.Success(
                         comprehensiveRunRecord = it
@@ -66,7 +73,26 @@ class MyPageViewModel @Inject constructor(
         }
     }
 
+
+    fun getSingleRunningHistory() = viewModelScope.launch {
+        _runningHistoryState.value = RunningHistoryState.Loading
+
+        getSingleHistoryUseCase().collect { result ->
+            result.onSuccess {
+                _runningHistoryState.value = RunningHistoryState.Success(
+                    singleRunningHistory = it
+                )
+            }.onFailure { errorMessage, code ->
+                Timber.e(errorMessage, code)
+                _snackbarMessage.value = "싱글 기록을 불러오는데\n실패했습니다."
+                _runningHistoryState.value =
+                    RunningHistoryState.LoadFailed
+            }
+        }
+    }
+
     fun clearSnackbarMessage() {
         _snackbarMessage.value = ""
     }
+
 }

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageViewModel.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageViewModel.kt
@@ -3,7 +3,7 @@ package online.partyrun.partyrunapplication.feature.my_page
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -13,6 +13,7 @@ import online.partyrun.partyrunapplication.core.common.result.onSuccess
 import online.partyrun.partyrunapplication.core.domain.my_page.GetComprehensiveRunRecordUseCase
 import online.partyrun.partyrunapplication.core.domain.my_page.GetMyPageDataUseCase
 import online.partyrun.partyrunapplication.core.domain.my_page.GetSingleHistoryUseCase
+import online.partyrun.partyrunapplication.core.domain.running.single.SaveSingleIdUseCase
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -20,9 +21,9 @@ import javax.inject.Inject
 class MyPageViewModel @Inject constructor(
     private val getMyPageDataUseCase: GetMyPageDataUseCase,
     private val getComprehensiveRunRecordUseCase: GetComprehensiveRunRecordUseCase,
-    private val getSingleHistoryUseCase: GetSingleHistoryUseCase
+    private val getSingleHistoryUseCase: GetSingleHistoryUseCase,
+    private val saveSingleIdUseCase: SaveSingleIdUseCase
 ) : ViewModel() {
-
     private val _myPageProfileState =
         MutableStateFlow<MyPageProfileState>(MyPageProfileState.Loading)
     val myPageProfileState = _myPageProfileState.asStateFlow()
@@ -34,6 +35,8 @@ class MyPageViewModel @Inject constructor(
     private val _runningHistoryState =
         MutableStateFlow<RunningHistoryState>(RunningHistoryState.Loading)
     val runningHistoryState = _runningHistoryState.asStateFlow()
+
+    val saveIdCompleteEvent = MutableSharedFlow<ModeType>(replay = 0)
 
     private val _snackbarMessage = MutableStateFlow("")
     val snackbarMessage: StateFlow<String> = _snackbarMessage
@@ -88,6 +91,11 @@ class MyPageViewModel @Inject constructor(
                     RunningHistoryState.LoadFailed
             }
         }
+    }
+
+    fun saveSingleId(singleId: String) = viewModelScope.launch {
+        saveSingleIdUseCase(singleId)
+        saveIdCompleteEvent.emit(ModeType.SINGLE)
     }
 
     fun clearSnackbarMessage() {

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageViewModel.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/MyPageViewModel.kt
@@ -59,7 +59,6 @@ class MyPageViewModel @Inject constructor(
 
         getComprehensiveRunRecordUseCase().collect { result ->
             result.onSuccess {
-                delay(1000L)
                 _myPageComprehensiveRunRecordState.value =
                     MyPageComprehensiveRunRecordState.Success(
                         comprehensiveRunRecord = it

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/component/RunningHistory.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/component/RunningHistory.kt
@@ -67,7 +67,7 @@ fun RunningDataCard(
                     color = MaterialTheme.colorScheme.onPrimary
                 )
                 Text(
-                    text = runningHistoryDetail.DistanceFormatted,
+                    text = runningHistoryDetail.distanceFormatted,
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.onPrimary
                 )

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/component/RunningHistory.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/component/RunningHistory.kt
@@ -9,12 +9,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -27,32 +28,14 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import online.partyrun.partyrunapplication.core.designsystem.component.LottieImage
+import online.partyrun.partyrunapplication.core.designsystem.component.shimmerEffect
 import online.partyrun.partyrunapplication.core.designsystem.icon.PartyRunIcons
+import online.partyrun.partyrunapplication.core.model.my_page.RunningHistoryDetail
 import online.partyrun.partyrunapplication.feature.my_page.R
-import online.partyrun.partyrunapplication.feature.my_page.RunningData
 
 @Composable
-fun RunningHistory(
-    data: List<RunningData>,
-    onClick: () -> Unit,
-    isSingleData: Boolean
-) {
-    LazyRow(
-        horizontalArrangement = Arrangement.spacedBy(20.dp)
-    ) {
-        items(data) { data ->
-            RunningDataCard(
-                data = data,
-                isSingleData = isSingleData,
-                onClick = onClick,
-            )
-        }
-    }
-}
-
-@Composable
-private fun RunningDataCard(
-    data: RunningData,
+fun RunningDataCard(
+    runningHistoryDetail: RunningHistoryDetail,
     isSingleData: Boolean,
     onClick: () -> Unit
 ) {
@@ -74,17 +57,17 @@ private fun RunningDataCard(
                 horizontalAlignment = Alignment.Start
             ) {
                 Text(
-                    text = data.date,
+                    text = runningHistoryDetail.date,
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurface
                 )
                 Text(
-                    text = data.runningTime,
+                    text = runningHistoryDetail.runningTime,
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.onPrimary
                 )
                 Text(
-                    text = data.distance,
+                    text = runningHistoryDetail.DistanceFormatted,
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.onPrimary
                 )

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/component/RunningHistory.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/component/RunningHistory.kt
@@ -114,3 +114,90 @@ fun EmptyRunningHistory() {
         )
     }
 }
+
+@Composable
+fun ShimmerRunningHistory(
+    isSingleData: Boolean
+) {
+    val title =
+        if (isSingleData) stringResource(id = R.string.single_title) else stringResource(id = R.string.battle_title)
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 20.dp)
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onPrimary,
+        )
+        Spacer(modifier = Modifier.height(30.dp))
+
+        LazyRow(
+            horizontalArrangement = Arrangement.spacedBy(20.dp)
+        ) {
+            items(5) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(15.dp))
+                            .background(MaterialTheme.colorScheme.surface)
+                            .padding(start = 25.dp, end = 5.dp, top = 20.dp, bottom = 15.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Column(
+                            verticalArrangement = Arrangement.SpaceAround,
+                            horizontalAlignment = Alignment.Start
+                        ) {
+                            Spacer(modifier = Modifier.height(3.dp))
+                            Box(
+                                modifier = Modifier
+                                    .width(50.dp)
+                                    .height(16.dp)
+                                    .shimmerEffect(isDarkTheme = true)
+                            )
+                            Spacer(modifier = Modifier.height(3.dp))
+                            Box(
+                                modifier = Modifier
+                                    .width(70.dp)
+                                    .height(18.dp)
+                                    .shimmerEffect(isDarkTheme = true)
+                            )
+                            Spacer(modifier = Modifier.height(3.dp))
+                            Box(
+                                modifier = Modifier
+                                    .width(60.dp)
+                                    .height(20.dp)
+                                    .shimmerEffect(isDarkTheme = true)
+                            )
+                            Spacer(modifier = Modifier.height(3.dp))
+                        }
+                        Spacer(modifier = Modifier.width(30.dp))
+                        Box(
+                            modifier = Modifier
+                                .size(18.dp)
+                                .shimmerEffect(isDarkTheme = true)
+                        )
+                    }
+                    Box(
+                        modifier = Modifier
+                            .size(32.dp)
+                            .offset(x = 10.dp, y = (-15).dp)
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .size(32.dp)
+                                .clip(CircleShape)
+                                .shimmerEffect(isDarkTheme = true)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/component/StatusElement.kt
+++ b/feature/my_page/src/main/java/online/partyrun/partyrunapplication/feature/my_page/component/StatusElement.kt
@@ -54,24 +54,24 @@ fun ShimmerStatusElement() {
             modifier = Modifier
                 .size(32.dp)
                 .clip(CircleShape)
-                .shimmerEffect(),
+                .shimmerEffect(isDarkTheme = false)
         )
         Spacer(
             modifier = Modifier
                 .height(5.dp)
-                .shimmerEffect()
+                .shimmerEffect(isDarkTheme = false)
         )
         Box(
             modifier = Modifier
                 .width(50.dp)
                 .height(24.dp)
-                .shimmerEffect(),
+                .shimmerEffect(isDarkTheme = false)
         )
         Box(
             modifier = Modifier
                 .width(80.dp)
                 .height(20.dp)
-                .shimmerEffect(),
+                .shimmerEffect(isDarkTheme = false)
         )
     }
 }


### PR DESCRIPTION
## Description
마이페이지에서 싱글 모드 단일 조회 API를 연동하고 결과를 보여준다.
원하는 기록을 클릭할 시 러닝 결과를 볼 수 있게 ResultScreen으로 전환

**특히, 마이페이지 같은 경우 정보를 가져오는 API가 많기에 ShimmerEffect를 적용하여 다음과 같은 이점을 얻는다.**
1. 보다 나은 사용자 경험(UX): 데이터 로딩 시간 동안 사용자에게 빈 화면을 보여주는 것보다 무언가 로딩되고 있다는 것을 시각적으로 표현하는 것이 더 나은 UX 제공
2. 콘텐츠의 예상 형태 표현: 로딩되는 콘텐츠의 기본 형태와 구조를 나타내어 사용자로 하여금 콘텐츠가 로드되는 동안 어떤 형태의 정보가 제공될지 미리 예상할 수 있게 함
3. 응답성 향상: 실제 콘텐츠가 준비되기 전에 UI를 빠르게 표시함으로써 앱의 반응성 향상
4. 로딩 지연의 인식 감소: 사용자의 주의를 분산시키고, 실제로 데이터 로딩에 걸리는 시간 즉, 지루함을 느끼는 것을 줄임.

## Implementation
* ShimmerEffect를 보여주기 위해 의도적으로 delay를 추가한 상태에서 촬영

https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/812ba7b3-9889-4163-b701-84a6e54cc262

