### PR TITLE
#PAR-384 : GoogleMap isMyLocationEnabled property Exception 처리

### DIFF
--- a/feature/running_result/src/main/java/online/partyrun/partyrunapplication/feature/running_result/battle/BattleResultScreen.kt
+++ b/feature/running_result/src/main/java/online/partyrun/partyrunapplication/feature/running_result/battle/BattleResultScreen.kt
@@ -134,6 +134,7 @@ private fun BattleResultBody(
                     .heightIn(400.dp) // 지도의 높이는 400dp
             ) {
                 MapWidget(
+                    isFromMyPage = isFromMyPage,
                     targetDistanceFormatted = battleResult.targetDistanceFormatted,
                     records = selectedRunner?.records
                 )

--- a/feature/running_result/src/main/java/online/partyrun/partyrunapplication/feature/running_result/component/MapWidget.kt
+++ b/feature/running_result/src/main/java/online/partyrun/partyrunapplication/feature/running_result/component/MapWidget.kt
@@ -43,6 +43,7 @@ import online.partyrun.partyrunapplication.feature.running_result.R
 
 @Composable
 fun MapWidget(
+    isFromMyPage: Boolean = false,
     targetDistanceFormatted: String,
     records: List<RunnerRecordUiModel>?,
 ) {
@@ -61,7 +62,7 @@ fun MapWidget(
             .fillMaxWidth(),
         properties = MapProperties(
             isBuildingEnabled = true,
-            isMyLocationEnabled = true
+            isMyLocationEnabled = !isFromMyPage // 마이페이지로부터 조회하는 경우에는 현재 위치 보여줄 필요 없음
         ),
         uiSettings = MapUiSettings(
             zoomControlsEnabled = false,

--- a/feature/running_result/src/main/java/online/partyrun/partyrunapplication/feature/running_result/single/SingleResultScreen.kt
+++ b/feature/running_result/src/main/java/online/partyrun/partyrunapplication/feature/running_result/single/SingleResultScreen.kt
@@ -114,6 +114,7 @@ private fun SingleResultBody(
                     .heightIn(400.dp) // 지도의 높이는 400dp
             ) {
                 MapWidget(
+                    isFromMyPage = isFromMyPage,
                     targetDistanceFormatted = singleResult.targetDistanceFormatted,
                     records = singleResult.singleRunnerStatus.records
                 )


### PR DESCRIPTION
## Description
마이페이지에서 기록 조회 시, 사용자로부터 ACCESS_FINE_LOCATION or ACCESS_COARSE_LOCATION 권한이 허용되지 않았으면
 java.lang.SecurityException: my location requires permission ACCESS_FINE_LOCATION or ACCESS_COARSE_LOCATION 발생
->
러닝을 위한 모든 기능에 대해서는 권한 체크를 진행해 이러한 Exception이 발생하지 않지만, 마이페이지 같은 경우 권한이 없더라도 기록 조회 자체는 가능하도록 해야 한다.
따라서, 예외를 발생시키는 Property인 isMyLocationEnabled를 마이페이지에서 접근한 경우 false로 설정함으로써 방지한다.


