### PR TITLE
feat : m/s로 계산된 평균 페이스를 분/킬로미터 단위로 변환

### DIFF
--- a/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/util/RunningRecordCalculation.kt
+++ b/core/model/src/main/java/online/partyrun/partyrunapplication/core/model/util/RunningRecordCalculation.kt
@@ -32,6 +32,19 @@ fun calculateAveragePace(runnerStatus: RunnerStatus): String {
     return formatPace(pace)
 }
 
+fun calculatePaceInMinPerKm(speedInMetersPerSec: Double): String {
+    if (speedInMetersPerSec == 0.0) {
+        return "0'00''"
+    }
+
+    val paceInMinPerKm = (1 / speedInMetersPerSec) * (1000 / 60)
+    val minutes = paceInMinPerKm.toInt()
+    val seconds = ((paceInMinPerKm - minutes) * 60).roundToInt()
+
+    // %02d는 정수를 두 자리로 표현하는데, 만약 한 자리수면 앞에 0 추가
+    return "${minutes}'${String.format("%02d", seconds)}''"
+}
+
 fun calculateAverageAltitude(runnerStatus: RunnerStatus): Double {
     return if (runnerStatus.records.isNotEmpty()) {
         (runnerStatus.records.sumOf { it.altitude } / runnerStatus.records.size)

--- a/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/ComprehensiveRunRecordResponse.kt
+++ b/core/network/src/main/java/online/partyrun/partyrunapplication/core/network/model/response/ComprehensiveRunRecordResponse.kt
@@ -4,7 +4,7 @@ import com.google.gson.annotations.SerializedName
 import online.partyrun.partyrunapplication.core.model.my_page.ComprehensiveRunRecord
 import online.partyrun.partyrunapplication.core.model.my_page.TotalRunningTime
 import online.partyrun.partyrunapplication.core.model.my_page.toElapsedTimeString
-import online.partyrun.partyrunapplication.core.model.util.formatPace
+import online.partyrun.partyrunapplication.core.model.util.calculatePaceInMinPerKm
 import online.partyrun.partyrunapplication.core.network.model.util.formatDistanceInKm
 
 data class ComprehensiveRunRecordResponse(
@@ -17,7 +17,7 @@ data class ComprehensiveRunRecordResponse(
 )
 
 fun ComprehensiveRunRecordResponse.toDomainModel() = ComprehensiveRunRecord(
-    averagePace = formatPace(this.averagePace ?: 0.0),
+    averagePace = calculatePaceInMinPerKm(this.averagePace ?: 0.0),
     totalDistance = formatDistanceInKm(this.totalDistance?.toInt() ?: 0),
     totalRunningTime = this.totalRunningTime?.toElapsedTimeString() ?: "00:00"
 )


### PR DESCRIPTION
## Description
달리기 앱에서 러닝 기록 평균 페이스는 보통 (분'초'')/킬로미터 단위로 나타낸다.
싱글, 대결모드 결과 조회 시 평균 페이스 계산은 위 공식을 따르지만,
서버로부터 받은 마이페이지 종합기록 중 평균페이스는 m/s로 오기 때문에 분/킬로미터 단위로 변환하는 과정을 거치도록 변환함수를 추가한다.
<img width="539" alt="image" src="https://github.com/SWM-KAWAI-MANS/party-run-application/assets/75293768/d741d25f-148c-4973-a45e-bae2407a6b50">